### PR TITLE
feat: support ldaps protocol 

### DIFF
--- a/sqle/api/controller/v1/auth.go
+++ b/sqle/api/controller/v1/auth.go
@@ -3,6 +3,7 @@ package v1
 import (
 	_errors "errors"
 	"fmt"
+	"crypto/tls"
 	"net/http"
 	"time"
 
@@ -190,8 +191,8 @@ func (l *ldapLoginV3) loginToLdap(password string) (err error) {
 	if err != nil {
 		return err
 	}
-	url := fmt.Sprintf("ldap://%s:%s", ldapC.Host, ldapC.Port)
-	conn, err := ldap.DialURL(url)
+	url := fmt.Sprintf("%s:%s", ldapC.Host, ldapC.Port)
+	conn, err := ldap.DialURL(url, ldap.DialWithTLSConfig(&tls.Config{InsecureSkipVerify: true}))
 	if err != nil {
 		return fmt.Errorf("get ldap server connect failed: %v", err)
 	}


### PR DESCRIPTION
The system setting support ldaps protocol, and skip ldaps verify. User can input ldap or ldaps protocol in the LDAP host input box.