### PR TITLE
fix pr #392

### DIFF
--- a/sqle/api/app.go
+++ b/sqle/api/app.go
@@ -66,9 +66,9 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config config.SqleConfi
 	e.GET("/v1/basic_info", v1.GetSQLEInfo)
 
 	v1Router := e.Group(apiV1)
-	v1Router.Use(sqleMiddleware.JWTTokenAdapter(), middleware.JWT(utils.SecretKey), sqleMiddleware.VerifyUserIsDisabled(), sqleMiddleware.LicenseAdapter())
+	v1Router.Use(sqleMiddleware.JWTTokenAdapter(), middleware.JWT(utils.JWTSecretKey), sqleMiddleware.VerifyUserIsDisabled(), sqleMiddleware.LicenseAdapter())
 	v2Router := e.Group(apiV2)
-	v2Router.Use(sqleMiddleware.JWTTokenAdapter(), middleware.JWT(utils.SecretKey), sqleMiddleware.VerifyUserIsDisabled(), sqleMiddleware.LicenseAdapter())
+	v2Router.Use(sqleMiddleware.JWTTokenAdapter(), middleware.JWT(utils.JWTSecretKey), sqleMiddleware.VerifyUserIsDisabled(), sqleMiddleware.LicenseAdapter())
 
 	// v1 admin api, just admin user can access.
 	{

--- a/sqle/api/controller/v1/audit_plan.go
+++ b/sqle/api/controller/v1/audit_plan.go
@@ -230,7 +230,7 @@ func CreateAuditPlan(c echo.Context) error {
 		return controller.JSONBaseErrorReq(c, errors.New(errors.DataConflict, err))
 	}
 
-	j := utils.NewJWT(utils.SecretKey)
+	j := utils.NewJWT(utils.JWTSecretKey)
 	t, err := j.CreateToken(currentUserName, time.Now().Add(tokenExpire).Unix(),
 		utils.WithAuditPlanName(req.Name))
 	if err != nil {

--- a/sqle/api/controller/v1/auth.go
+++ b/sqle/api/controller/v1/auth.go
@@ -51,7 +51,7 @@ func Login(c echo.Context) error {
 		return controller.JSONBaseErrorReq(c, errors.New(errors.LoginAuthFail, err))
 	}
 
-	j := utils.NewJWT(utils.SecretKey)
+	j := utils.NewJWT(utils.JWTSecretKey)
 	t, err := j.CreateToken(req.UserName, time.Now().Add(time.Hour*24).Unix())
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)

--- a/sqle/api/middleware/jwt_test.go
+++ b/sqle/api/middleware/jwt_test.go
@@ -21,7 +21,7 @@ import (
 func TestScannerVerifier(t *testing.T) {
 	e := echo.New()
 
-	jwt := utils.NewJWT(utils.SecretKey)
+	jwt := utils.NewJWT(utils.JWTSecretKey)
 	apName := "test_audit_plan"
 	testUser := "test_user"
 

--- a/sqle/utils/aes.go
+++ b/sqle/utils/aes.go
@@ -11,7 +11,16 @@ import (
 
 var SecretKey = []byte("471F77D078C5994BD06B65B8B5B1935B")
 
-func SetSecretKey(key []byte) (err error) {
+func SetSecretKey(key []byte) error {
+	err := setAesSecretKey(key)
+	if err != nil {
+		return err
+	}
+	setJWTSecretKey(key)
+	return nil
+}
+
+func setAesSecretKey(key []byte) (err error) {
 	origKey := SecretKey
 	SecretKey = key
 	origData := "test"

--- a/sqle/utils/jwt.go
+++ b/sqle/utils/jwt.go
@@ -4,8 +4,11 @@ import (
 	"github.com/golang-jwt/jwt"
 )
 
-// TODO: Using configuration to set jwt secret
-const JWTSecret = "secret"
+var JWTSecretKey = []byte("secret")
+
+func setJWTSecretKey(key []byte) {
+	JWTSecretKey = key
+}
 
 type JWT struct {
 	key []byte
@@ -61,7 +64,7 @@ func WithAuditPlanName(name string) CustomClaimOption {
 // ParseAuditPlanName used by echo middleware which only verify api request to audit plan related.
 func ParseAuditPlanName(tokenString string) (string, error) {
 	keyFunc := func(t *jwt.Token) (interface{}, error) {
-		return SecretKey, nil
+		return JWTSecretKey, nil
 	}
 	token, err := jwt.Parse(tokenString, keyFunc)
 	if err != nil {


### PR DESCRIPTION
fix pr #392, the original jwt key is "secret" who has been changed when we set it is same as aes secret key, so the audit token cannot be used after upgrading SQLE from 1.2202.0 to 1.2203.0