### PR TITLE
修复表名为关键字时审核任务无法正常展示的问题

### DIFF
--- a/sqle/driver/mysql/executor/executor.go
+++ b/sqle/driver/mysql/executor/executor.go
@@ -211,7 +211,7 @@ func Ping(entry *logrus.Entry, instance *mdriver.DSN) error {
 }
 
 func (c *Executor) ShowCreateTable(tableName string) (string, error) {
-	result, err := c.Db.Query(fmt.Sprintf("show create table %s", tableName))
+	result, err := c.Db.Query(fmt.Sprintf("show create table `%s`", tableName))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
#499
创建审核任务时，如果表名中存在以关键字（比如group）明明的表，审核任务可以正常创建，页面可以正常打开，但是SQL语句池是空的，查看日志时发现是SQL执行异常

time="2022-05-05T10:24:52+08:00" level=error msg="query sql failed; host: 10.0.11
.123, port: 3306, user: root, query: show create table group, error: Error 1064::
 You have an error in your SQL syntax; check the manual that corresponds to yourr
 MySQL server version for the right syntax to use near 'group' at line 1\n" namee
=meta_iastdb thread_id=J90 type=audit_plan