### PR TITLE
issue_891 fix bug

### DIFF
--- a/sqle/api/cloudbeaver_wrapper/app.go
+++ b/sqle/api/cloudbeaver_wrapper/app.go
@@ -182,7 +182,7 @@ func TriggerLogin() echo.MiddlewareFunc {
 
 			_, isLogin, _ := service.GetCurrentCloudBeaverUserID(c)
 			if isLogin {
-				return nil
+				return respFunc()
 			}
 
 			cookies, err := service.Login(user.Name, user.Password)

--- a/sqle/api/cloudbeaver_wrapper/app.go
+++ b/sqle/api/cloudbeaver_wrapper/app.go
@@ -177,7 +177,7 @@ func TriggerLogin() echo.MiddlewareFunc {
 			user, _, err := s.GetUserByName(userName)
 			if err != nil {
 				l.Errorf("get user info err: %v", err)
-				return nil
+				return respFunc()
 			}
 
 			_, isLogin, _ := service.GetCurrentCloudBeaverUserID(c)
@@ -188,7 +188,7 @@ func TriggerLogin() echo.MiddlewareFunc {
 			cookies, err := service.Login(user.Name, user.Password)
 			if err != nil {
 				l.Errorf("login to cloudbeaver failed: %v", err)
-				return nil
+				return respFunc()
 			}
 			for _, cookie := range cookies {
 				c.SetCookie(cookie)

--- a/sqle/api/cloudbeaver_wrapper/service/base.go
+++ b/sqle/api/cloudbeaver_wrapper/service/base.go
@@ -27,8 +27,8 @@ const (
 	CBUserRole = "user"
 )
 
-func GetGQLClientWithCurrentUser(ctx echo.Context) (*gqlClient.Client, error) {
-	return gqlClient.NewClient(GetGqlServerURI(), gqlClient.WithCookie(ctx.Cookies())), nil
+func GetSQLEGQLClientWithCurrentUser(ctx echo.Context) (*gqlClient.Client, error) {
+	return gqlClient.NewClient(GetSQLEGqlServerURI(), gqlClient.WithCookie(ctx.Cookies())), nil
 }
 
 func GetGQLClientWithRootUser() (*gqlClient.Client, error) {

--- a/sqle/api/cloudbeaver_wrapper/service/user.go
+++ b/sqle/api/cloudbeaver_wrapper/service/user.go
@@ -236,7 +236,7 @@ query authLogin(
 `
 
 func GetCurrentCloudBeaverUserID(ctx echo.Context) (string, bool, error) {
-	client, err := GetGQLClientWithCurrentUser(ctx)
+	client, err := GetSQLEGQLClientWithCurrentUser(ctx)
 	if err != nil {
 		return "", false, err
 	}


### PR DESCRIPTION
#891 修复用户登录成功后续操作失败会报错, 修复SQLE拿到的CB是否登录有误
1. 如果用户登录成功了, 后续TriggerLogin()中间件无论出什么错都应该把登录接口的响应抛回前侧
2. 只有从SQLE处登录, SQLE的cookie转换中间件才会生效, cookie得转换后才能拿到正确的用户状态(当前是否登录)