### PR TITLE
issue_960 debug fix bug

### DIFF
--- a/sqle/model/rule.go
+++ b/sqle/model/rule.go
@@ -101,7 +101,7 @@ func (s *Storage) GetRuleTemplatesByInstanceNameAndProjectId(name string, projec
 	err := s.db.Joins("JOIN `instance_rule_template` ON `rule_templates`.`id` = `instance_rule_template`.`rule_template_id`").
 		Joins("JOIN `instances` ON `instance_rule_template`.`instance_id` = `instances`.`id`").
 		Where("`instances`.`name` = ?", name).
-		Where("`rule_templates`.`project_id` = ?", projectId).Find(t).Error
+		Where("`instances`.`project_id` = ?", projectId).Find(t).Error
 	if err == gorm.ErrRecordNotFound {
 		return t, false, nil
 	}
@@ -300,6 +300,15 @@ func (s *Storage) IsRuleTemplateBeingUsed(ruleTemplateName string, projectId uin
 		Where("audit_plans.deleted_at is null").
 		Where("audit_plans.rule_template_name = ?", ruleTemplateName).
 		Where("rule_templates.project_id = ?", projectId).
+		Count(&count).Error
+	return count > 0, errors.New(errors.ConnectStorageError, err)
+}
+
+func (s *Storage) IsRuleTemplateBeingUsedFromAnyProject(ruleTemplateName string) (bool, error) {
+	var count int
+	err := s.db.Table("audit_plans").
+		Where("audit_plans.rule_template_name = ?", ruleTemplateName).
+		Where("audit_plans.deleted_at is null").
 		Count(&count).Error
 	return count > 0, errors.New(errors.ConnectStorageError, err)
 }

--- a/sqle/model/utils.go
+++ b/sqle/model/utils.go
@@ -210,6 +210,7 @@ func (s *Storage) CreateRulesIfNotExist(rules map[string][]*driver.Rule) error {
 	}
 	return nil
 }
+
 func (s *Storage) CreateDefaultRole() error {
 	roles, err := s.GetAllRoleTip()
 	if err != nil {
@@ -242,7 +243,7 @@ func (s *Storage) CreateDefaultRole() error {
 func (s *Storage) CreateDefaultTemplate(rules map[string][]*driver.Rule) error {
 	for dbType, r := range rules {
 		templateName := s.GetDefaultRuleTemplateName(dbType)
-		_, exist, err := s.GetGlobalAndProjectRuleTemplateByNameAndProjectId(templateName, ProjectIdForGlobalRuleTemplate)
+		exist, err := s.IsRuleTemplateExistFromAnyProject(templateName)
 		if err != nil {
 			return xerrors.Wrap(err, "get rule template failed")
 		}


### PR DESCRIPTION
#960

* sql工作台的审核 
* * 规则模板应该从项目和全局里找sqle/api/cloudbeaver_wrapper/service/audit.go:47
* 扫描任务
* * 添加扫描任务，实例的规则模板应该从项目和全局里找 sqle/api/controller/v1/audit_plan.go:357
* 删除全局和项目规则模板
* * 获取模板数据时应该只从一个指定的项目里拿 
* * * sqle/api/controller/v1/rule.go:916
* * * sqle/api/controller/v1/rule.go:268
* 更新全局和项目规则模板
* * 获取模板数据时应该只从一个指定的项目里拿 
* * * sqle/api/controller/v1/rule.go:750
* * * sqle/api/controller/v1/rule.go:155
* 创建默认模板
* * 获取模板数据时应该只从一个指定的项目里拿
* * * sqle/model/utils.go:245
* 克隆项目模板
* * 使用和克隆全局模板一样的函数判断模板是否存在 sqle/api/controller/v1/rule.go:1053
* 删除全局规则模板
* * 应该检查模板是否在任意项目中被使用 sqle/api/controller/v1/rule.go:275