### PR TITLE
feat: 新增 API 定义，升级了 audit_result 审核结果结构定义

### DIFF
--- a/sqle/api/app.go
+++ b/sqle/api/app.go
@@ -290,6 +290,7 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config config.SqleConfi
 	v1Router.POST("/projects/:project_name/tasks/audits", v1.CreateAndAuditTask)
 	v1Router.GET("/tasks/audits/:task_id/", v1.GetTask)
 	v1Router.GET("/tasks/audits/:task_id/sqls", v1.GetTaskSQLs)
+	v1Router.GET("/tasks/audits/:task_id/sqls", v2.GetTaskSQLs)
 	v1Router.GET("/tasks/audits/:task_id/sql_report", v1.DownloadTaskSQLReportFile)
 	v1Router.GET("/tasks/audits/:task_id/sql_file", v1.DownloadTaskSQLFile)
 	v1Router.GET("/tasks/audits/:task_id/sql_content", v1.GetAuditTaskSQLContent)
@@ -329,6 +330,7 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config config.SqleConfi
 	v1Router.GET("/projects/:project_name/audit_plans/:audit_plan_name/notify_config/test", v1.TestAuditPlanNotifyConfig)
 	v1Router.GET("/projects/:project_name/audit_plans/:audit_plan_name/reports/:audit_plan_report_id/sqls/:number/analysis", v1.GetAuditPlanAnalysisData)
 	v1Router.GET("/projects/:project_name/audit_plans/:audit_plan_name/reports/:audit_plan_report_id/sqls", v1.GetAuditPlanReportSQLsV1)
+	v1Router.GET("/projects/:project_name/audit_plans/:audit_plan_name/reports/:audit_plan_report_id/sqls", v2.GetAuditPlanReportSQLs)
 
 	// sql query
 	if err := cloudbeaver_wrapper.StartApp(e); err != nil {
@@ -339,6 +341,7 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config config.SqleConfi
 
 	// sql audit
 	v1Router.POST("/sql_audit", v1.DirectAudit)
+	v1Router.POST("/sql_audit", v2.DirectAudit)
 
 	// UI
 	e.File("/", "ui/index.html")

--- a/sqle/api/controller/v2/audit_plan.go
+++ b/sqle/api/controller/v2/audit_plan.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/labstack/echo/v4"
+
 	"github.com/actiontech/sqle/sqle/api/controller"
 	v1 "github.com/actiontech/sqle/sqle/api/controller/v1"
 	"github.com/actiontech/sqle/sqle/model"
 	"github.com/actiontech/sqle/sqle/server/auditplan"
 	"github.com/actiontech/sqle/sqle/utils"
-	"github.com/labstack/echo/v4"
 )
 
 type GetAuditPlansReqV2 struct {
@@ -147,4 +148,37 @@ func GetAuditPlans(c echo.Context) error {
 		Data:      auditPlansResV1,
 		TotalNums: count,
 	})
+}
+
+type GetAuditPlanReportSQLsReqV2 struct {
+	PageIndex uint32 `json:"page_index" query:"page_index" valid:"required"`
+	PageSize  uint32 `json:"page_size" query:"page_size" valid:"required"`
+}
+
+type GetAuditPlanReportSQLsResV2 struct {
+	controller.BaseRes
+	Data      []*AuditPlanReportSQLResV2 `json:"data"`
+	TotalNums uint64                     `json:"total_nums"`
+}
+
+type AuditPlanReportSQLResV2 struct {
+	SQL         string         `json:"audit_plan_report_sql" example:"select * from t1 where id = 1"`
+	AuditResult []*AuditResult `json:"audit_plan_report_sql_audit_result" example:"same format as task audit result"`
+	Number      uint           `json:"number" example:"1"`
+}
+
+// @Summary 获取指定扫描任务的SQL扫描详情
+// @Description get audit plan report SQLs
+// @Id getAuditPlanReportsSQLs
+// @Tags audit_plan
+// @Security ApiKeyAuth
+// @Param project_name path string true "project name"
+// @Param audit_plan_name path string true "audit plan name"
+// @Param audit_plan_report_id path string true "audit plan report id"
+// @Param page_index query uint32 true "page index"
+// @Param page_size query uint32 true "size of per page"
+// @Success 200 {object} v2.GetAuditPlanReportSQLsResV2
+// @router /v2/projects/{project_name}/audit_plans/{audit_plan_name}/reports/{audit_plan_report_id}/sqls [get]
+func GetAuditPlanReportSQLs(c echo.Context) error {
+	return controller.JSONNewNotImplementedErr(c)
 }

--- a/sqle/api/controller/v2/sql_audit.go
+++ b/sqle/api/controller/v2/sql_audit.go
@@ -1,0 +1,45 @@
+package v2
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/actiontech/sqle/sqle/api/controller"
+)
+
+type DirectAuditReqV2 struct {
+	InstanceType string `json:"instance_type" form:"instance_type" example:"MySQL" valid:"required"`
+	// 调用方不应该关心SQL是否被完美的拆分成独立的条目, 拆分SQL由SQLE实现
+	SQLContent string `json:"sql_content" form:"sql_content" example:"select * from t1; select * from t2;" valid:"required"`
+	SQLType    string `json:"sql_type" form:"sql_type" example:"sql" enums:"sql,mybatis," valid:"omitempty,oneof=sql mybatis"`
+}
+
+type AuditResDataV2 struct {
+	AuditLevel string          `json:"audit_level" enums:"normal,notice,warn,error,"`
+	Score      int32           `json:"score"`
+	PassRate   float64         `json:"pass_rate"`
+	SQLResults []AuditSQLResV2 `json:"sql_results"`
+}
+
+type AuditSQLResV2 struct {
+	Number      uint           `json:"number"`
+	ExecSQL     string         `json:"exec_sql"`
+	AuditResult []*AuditResult `json:"audit_result"`
+	AuditLevel  string         `json:"audit_level"`
+}
+
+type DirectAuditResV2 struct {
+	controller.BaseRes
+	Data *AuditResDataV2 `json:"data"`
+}
+
+// @Summary 直接审核SQL
+// @Description Direct audit sql
+// @Id directAuditV2
+// @Tags sql_audit
+// @Security ApiKeyAuth
+// @Param req body v2.DirectAuditReqV2 true "sqls that should be audited"
+// @Success 200 {object} v2.DirectAuditResV2
+// @router /v2/sql_audit [post]
+func DirectAudit(c echo.Context) error {
+	return controller.JSONNewNotImplementedErr(c)
+}

--- a/sqle/api/controller/v2/task.go
+++ b/sqle/api/controller/v2/task.go
@@ -1,0 +1,58 @@
+package v2
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/actiontech/sqle/sqle/api/controller"
+)
+
+type GetAuditTaskSQLsReqV2 struct {
+	FilterExecStatus  string `json:"filter_exec_status" query:"filter_exec_status"`
+	FilterAuditStatus string `json:"filter_audit_status" query:"filter_audit_status"`
+	FilterAuditLevel  string `json:"filter_audit_level" query:"filter_audit_level"`
+	NoDuplicate       bool   `json:"no_duplicate" query:"no_duplicate"`
+	PageIndex         uint32 `json:"page_index" query:"page_index" valid:"required"`
+	PageSize          uint32 `json:"page_size" query:"page_size" valid:"required"`
+}
+
+type GetAuditTaskSQLsResV2 struct {
+	controller.BaseRes
+	Data      []*AuditTaskSQLResV2 `json:"data"`
+	TotalNums uint64               `json:"total_nums"`
+}
+
+type AuditTaskSQLResV2 struct {
+	Number      uint           `json:"number"`
+	ExecSQL     string         `json:"exec_sql"`
+	AuditResult string         `json:"audit_result"`
+	AuditLevel  string         `json:"audit_level"`
+	AuditStatus string         `json:"audit_status"`
+	ExecResult  []*AuditResult `json:"exec_result"`
+	ExecStatus  string         `json:"exec_status"`
+	RollbackSQL string         `json:"rollback_sql,omitempty"`
+	Description string         `json:"description"`
+}
+
+type AuditResult struct {
+	Level    string `json:"level"`
+	Message  string `json:"message"`
+	RuleName string `json:"rule_name"`
+}
+
+// @Summary 获取指定扫描任务的SQLs信息
+// @Description get information of all SQLs belong to the specified audit task
+// @Tags task
+// @Id getAuditTaskSQLsV2
+// @Security ApiKeyAuth
+// @Param task_id path string true "task id"
+// @Param filter_exec_status query string false "filter: exec status of task sql" Enums(initialized,doing,succeeded,failed,manually_executed)
+// @Param filter_audit_status query string false "filter: audit status of task sql" Enums(initialized,doing,finished)
+// @Param filter_audit_level query string false "filter: audit level of task sql" Enums(normal,notice,warn,error)
+// @Param no_duplicate query boolean false "select unique (fingerprint and audit result) for task sql"
+// @Param page_index query string true "page index"
+// @Param page_size query string true "page size"
+// @Success 200 {object} v2.GetAuditTaskSQLsResV2
+// @router /v2/tasks/audits/{task_id}/sqls [get]
+func GetTaskSQLs(c echo.Context) error {
+	return controller.JSONNewNotImplementedErr(c)
+}

--- a/sqle/api/controller/v2/task.go
+++ b/sqle/api/controller/v2/task.go
@@ -24,10 +24,10 @@ type GetAuditTaskSQLsResV2 struct {
 type AuditTaskSQLResV2 struct {
 	Number      uint           `json:"number"`
 	ExecSQL     string         `json:"exec_sql"`
-	AuditResult string         `json:"audit_result"`
+	AuditResult []*AuditResult `json:"audit_result"`
 	AuditLevel  string         `json:"audit_level"`
 	AuditStatus string         `json:"audit_status"`
-	ExecResult  []*AuditResult `json:"exec_result"`
+	ExecResult  string         `json:"exec_result"`
 	ExecStatus  string         `json:"exec_status"`
 	RollbackSQL string         `json:"rollback_sql,omitempty"`
 	Description string         `json:"description"`

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -7250,6 +7250,66 @@ var doc = `{
                 }
             }
         },
+        "/v2/projects/{project_name}/audit_plans/{audit_plan_name}/reports/{audit_plan_report_id}/sqls": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get audit plan report SQLs",
+                "tags": [
+                    "audit_plan"
+                ],
+                "summary": "获取指定扫描任务的SQL扫描详情",
+                "operationId": "getAuditPlanReportsSQLs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "audit plan name",
+                        "name": "audit_plan_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "audit plan report id",
+                        "name": "audit_plan_report_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page index",
+                        "name": "page_index",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "size of per page",
+                        "name": "page_size",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.GetAuditPlanReportSQLsResV2"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/projects/{project_name}/instances": {
             "get": {
                 "security": [
@@ -7914,6 +7974,128 @@ var doc = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/controller.BaseRes"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/sql_audit": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Direct audit sql",
+                "tags": [
+                    "sql_audit"
+                ],
+                "summary": "直接审核SQL",
+                "operationId": "directAuditV2",
+                "parameters": [
+                    {
+                        "description": "sqls that should be audited",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v2.DirectAuditReqV2"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.DirectAuditResV2"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/tasks/audits/{task_id}/sqls": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get information of all SQLs belong to the specified audit task",
+                "tags": [
+                    "task"
+                ],
+                "summary": "获取指定扫描任务的SQLs信息",
+                "operationId": "getAuditTaskSQLsV2",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "task id",
+                        "name": "task_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "initialized",
+                            "doing",
+                            "succeeded",
+                            "failed",
+                            "manually_executed"
+                        ],
+                        "type": "string",
+                        "description": "filter: exec status of task sql",
+                        "name": "filter_exec_status",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "initialized",
+                            "doing",
+                            "finished"
+                        ],
+                        "type": "string",
+                        "description": "filter: audit status of task sql",
+                        "name": "filter_audit_status",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "normal",
+                            "notice",
+                            "warn",
+                            "error"
+                        ],
+                        "type": "string",
+                        "description": "filter: audit level of task sql",
+                        "name": "filter_audit_level",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "select unique (fingerprint and audit result) for task sql",
+                        "name": "no_duplicate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "page index",
+                        "name": "page_index",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "page size",
+                        "name": "page_size",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.GetAuditTaskSQLsResV2"
                         }
                     }
                 }
@@ -13386,6 +13568,102 @@ var doc = `{
                 }
             }
         },
+        "v2.AuditResDataV2": {
+            "type": "object",
+            "properties": {
+                "audit_level": {
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "notice",
+                        "warn",
+                        "error",
+                        ""
+                    ]
+                },
+                "pass_rate": {
+                    "type": "number"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "sql_results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditSQLResV2"
+                    }
+                }
+            }
+        },
+        "v2.AuditResult": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "rule_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.AuditSQLResV2": {
+            "type": "object",
+            "properties": {
+                "audit_level": {
+                    "type": "string"
+                },
+                "audit_result": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditResult"
+                    }
+                },
+                "exec_sql": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.AuditTaskSQLResV2": {
+            "type": "object",
+            "properties": {
+                "audit_level": {
+                    "type": "string"
+                },
+                "audit_result": {
+                    "type": "string"
+                },
+                "audit_status": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "exec_result": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditResult"
+                    }
+                },
+                "exec_sql": {
+                    "type": "string"
+                },
+                "exec_status": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "integer"
+                },
+                "rollback_sql": {
+                    "type": "string"
+                }
+            }
+        },
         "v2.BatchCancelWorkflowsReqV2": {
             "type": "object",
             "properties": {
@@ -13477,6 +13755,68 @@ var doc = `{
                 }
             }
         },
+        "v2.DirectAuditReqV2": {
+            "type": "object",
+            "properties": {
+                "instance_type": {
+                    "type": "string",
+                    "example": "MySQL"
+                },
+                "sql_content": {
+                    "description": "调用方不应该关心SQL是否被完美的拆分成独立的条目, 拆分SQL由SQLE实现",
+                    "type": "string",
+                    "example": "select * from t1; select * from t2;"
+                },
+                "sql_type": {
+                    "type": "string",
+                    "enum": [
+                        "sql",
+                        "mybatis",
+                        ""
+                    ],
+                    "example": "sql"
+                }
+            }
+        },
+        "v2.DirectAuditResV2": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "object",
+                    "$ref": "#/definitions/v2.AuditResDataV2"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                }
+            }
+        },
+        "v2.GetAuditPlanReportSQLsResV2": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditPlanReportSQLResV2"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                },
+                "total_nums": {
+                    "type": "integer"
+                }
+            }
+        },
         "v2.GetAuditPlansResV2": {
             "type": "object",
             "properties": {
@@ -13488,6 +13828,28 @@ var doc = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/v2.AuditPlanResV2"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                },
+                "total_nums": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.GetAuditTaskSQLsResV2": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditTaskSQLResV2"
                     }
                 },
                 "message": {

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -7234,6 +7234,66 @@
                 }
             }
         },
+        "/v2/projects/{project_name}/audit_plans/{audit_plan_name}/reports/{audit_plan_report_id}/sqls": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get audit plan report SQLs",
+                "tags": [
+                    "audit_plan"
+                ],
+                "summary": "获取指定扫描任务的SQL扫描详情",
+                "operationId": "getAuditPlanReportsSQLs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "audit plan name",
+                        "name": "audit_plan_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "audit plan report id",
+                        "name": "audit_plan_report_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page index",
+                        "name": "page_index",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "size of per page",
+                        "name": "page_size",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.GetAuditPlanReportSQLsResV2"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/projects/{project_name}/instances": {
             "get": {
                 "security": [
@@ -7898,6 +7958,128 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/controller.BaseRes"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/sql_audit": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Direct audit sql",
+                "tags": [
+                    "sql_audit"
+                ],
+                "summary": "直接审核SQL",
+                "operationId": "directAuditV2",
+                "parameters": [
+                    {
+                        "description": "sqls that should be audited",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v2.DirectAuditReqV2"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.DirectAuditResV2"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/tasks/audits/{task_id}/sqls": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get information of all SQLs belong to the specified audit task",
+                "tags": [
+                    "task"
+                ],
+                "summary": "获取指定扫描任务的SQLs信息",
+                "operationId": "getAuditTaskSQLsV2",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "task id",
+                        "name": "task_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "initialized",
+                            "doing",
+                            "succeeded",
+                            "failed",
+                            "manually_executed"
+                        ],
+                        "type": "string",
+                        "description": "filter: exec status of task sql",
+                        "name": "filter_exec_status",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "initialized",
+                            "doing",
+                            "finished"
+                        ],
+                        "type": "string",
+                        "description": "filter: audit status of task sql",
+                        "name": "filter_audit_status",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "normal",
+                            "notice",
+                            "warn",
+                            "error"
+                        ],
+                        "type": "string",
+                        "description": "filter: audit level of task sql",
+                        "name": "filter_audit_level",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "select unique (fingerprint and audit result) for task sql",
+                        "name": "no_duplicate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "page index",
+                        "name": "page_index",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "page size",
+                        "name": "page_size",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.GetAuditTaskSQLsResV2"
                         }
                     }
                 }
@@ -13370,6 +13552,102 @@
                 }
             }
         },
+        "v2.AuditResDataV2": {
+            "type": "object",
+            "properties": {
+                "audit_level": {
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "notice",
+                        "warn",
+                        "error",
+                        ""
+                    ]
+                },
+                "pass_rate": {
+                    "type": "number"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "sql_results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditSQLResV2"
+                    }
+                }
+            }
+        },
+        "v2.AuditResult": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "rule_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.AuditSQLResV2": {
+            "type": "object",
+            "properties": {
+                "audit_level": {
+                    "type": "string"
+                },
+                "audit_result": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditResult"
+                    }
+                },
+                "exec_sql": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.AuditTaskSQLResV2": {
+            "type": "object",
+            "properties": {
+                "audit_level": {
+                    "type": "string"
+                },
+                "audit_result": {
+                    "type": "string"
+                },
+                "audit_status": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "exec_result": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditResult"
+                    }
+                },
+                "exec_sql": {
+                    "type": "string"
+                },
+                "exec_status": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "integer"
+                },
+                "rollback_sql": {
+                    "type": "string"
+                }
+            }
+        },
         "v2.BatchCancelWorkflowsReqV2": {
             "type": "object",
             "properties": {
@@ -13461,6 +13739,68 @@
                 }
             }
         },
+        "v2.DirectAuditReqV2": {
+            "type": "object",
+            "properties": {
+                "instance_type": {
+                    "type": "string",
+                    "example": "MySQL"
+                },
+                "sql_content": {
+                    "description": "调用方不应该关心SQL是否被完美的拆分成独立的条目, 拆分SQL由SQLE实现",
+                    "type": "string",
+                    "example": "select * from t1; select * from t2;"
+                },
+                "sql_type": {
+                    "type": "string",
+                    "enum": [
+                        "sql",
+                        "mybatis",
+                        ""
+                    ],
+                    "example": "sql"
+                }
+            }
+        },
+        "v2.DirectAuditResV2": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "object",
+                    "$ref": "#/definitions/v2.AuditResDataV2"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                }
+            }
+        },
+        "v2.GetAuditPlanReportSQLsResV2": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditPlanReportSQLResV2"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                },
+                "total_nums": {
+                    "type": "integer"
+                }
+            }
+        },
         "v2.GetAuditPlansResV2": {
             "type": "object",
             "properties": {
@@ -13472,6 +13812,28 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/v2.AuditPlanResV2"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                },
+                "total_nums": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.GetAuditTaskSQLsResV2": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AuditTaskSQLResV2"
                     }
                 },
                 "message": {

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -3713,6 +3713,70 @@ definitions:
         $ref: '#/definitions/v2.RuleTemplateV2'
         type: object
     type: object
+  v2.AuditResDataV2:
+    properties:
+      audit_level:
+        enum:
+        - normal
+        - notice
+        - warn
+        - error
+        - ""
+        type: string
+      pass_rate:
+        type: number
+      score:
+        type: integer
+      sql_results:
+        items:
+          $ref: '#/definitions/v2.AuditSQLResV2'
+        type: array
+    type: object
+  v2.AuditResult:
+    properties:
+      level:
+        type: string
+      message:
+        type: string
+      rule_name:
+        type: string
+    type: object
+  v2.AuditSQLResV2:
+    properties:
+      audit_level:
+        type: string
+      audit_result:
+        items:
+          $ref: '#/definitions/v2.AuditResult'
+        type: array
+      exec_sql:
+        type: string
+      number:
+        type: integer
+    type: object
+  v2.AuditTaskSQLResV2:
+    properties:
+      audit_level:
+        type: string
+      audit_result:
+        type: string
+      audit_status:
+        type: string
+      description:
+        type: string
+      exec_result:
+        items:
+          $ref: '#/definitions/v2.AuditResult'
+        type: array
+      exec_sql:
+        type: string
+      exec_status:
+        type: string
+      number:
+        type: integer
+      rollback_sql:
+        type: string
+    type: object
   v2.BatchCancelWorkflowsReqV2:
     properties:
       workflow_id_list:
@@ -3775,6 +3839,50 @@ definitions:
       workflow_subject:
         type: string
     type: object
+  v2.DirectAuditReqV2:
+    properties:
+      instance_type:
+        example: MySQL
+        type: string
+      sql_content:
+        description: 调用方不应该关心SQL是否被完美的拆分成独立的条目, 拆分SQL由SQLE实现
+        example: select * from t1; select * from t2;
+        type: string
+      sql_type:
+        enum:
+        - sql
+        - mybatis
+        - ""
+        example: sql
+        type: string
+    type: object
+  v2.DirectAuditResV2:
+    properties:
+      code:
+        example: 0
+        type: integer
+      data:
+        $ref: '#/definitions/v2.AuditResDataV2'
+        type: object
+      message:
+        example: ok
+        type: string
+    type: object
+  v2.GetAuditPlanReportSQLsResV2:
+    properties:
+      code:
+        example: 0
+        type: integer
+      data:
+        items:
+          $ref: '#/definitions/v2.AuditPlanReportSQLResV2'
+        type: array
+      message:
+        example: ok
+        type: string
+      total_nums:
+        type: integer
+    type: object
   v2.GetAuditPlansResV2:
     properties:
       code:
@@ -3783,6 +3891,21 @@ definitions:
       data:
         items:
           $ref: '#/definitions/v2.AuditPlanResV2'
+        type: array
+      message:
+        example: ok
+        type: string
+      total_nums:
+        type: integer
+    type: object
+  v2.GetAuditTaskSQLsResV2:
+    properties:
+      code:
+        example: 0
+        type: integer
+      data:
+        items:
+          $ref: '#/definitions/v2.AuditTaskSQLResV2'
         type: array
       message:
         example: ok
@@ -8663,6 +8786,46 @@ paths:
       summary: 获取扫描任务信息列表
       tags:
       - audit_plan
+  /v2/projects/{project_name}/audit_plans/{audit_plan_name}/reports/{audit_plan_report_id}/sqls:
+    get:
+      description: get audit plan report SQLs
+      operationId: getAuditPlanReportsSQLs
+      parameters:
+      - description: project name
+        in: path
+        name: project_name
+        required: true
+        type: string
+      - description: audit plan name
+        in: path
+        name: audit_plan_name
+        required: true
+        type: string
+      - description: audit plan report id
+        in: path
+        name: audit_plan_report_id
+        required: true
+        type: string
+      - description: page index
+        in: query
+        name: page_index
+        required: true
+        type: integer
+      - description: size of per page
+        in: query
+        name: page_size
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.GetAuditPlanReportSQLsResV2'
+      security:
+      - ApiKeyAuth: []
+      summary: 获取指定扫描任务的SQL扫描详情
+      tags:
+      - audit_plan
   /v2/projects/{project_name}/instances:
     get:
       description: get instance info list
@@ -9097,6 +9260,88 @@ paths:
       summary: 批量完成工单
       tags:
       - workflow
+  /v2/sql_audit:
+    post:
+      description: Direct audit sql
+      operationId: directAuditV2
+      parameters:
+      - description: sqls that should be audited
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/v2.DirectAuditReqV2'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.DirectAuditResV2'
+      security:
+      - ApiKeyAuth: []
+      summary: 直接审核SQL
+      tags:
+      - sql_audit
+  /v2/tasks/audits/{task_id}/sqls:
+    get:
+      description: get information of all SQLs belong to the specified audit task
+      operationId: getAuditTaskSQLsV2
+      parameters:
+      - description: task id
+        in: path
+        name: task_id
+        required: true
+        type: string
+      - description: 'filter: exec status of task sql'
+        enum:
+        - initialized
+        - doing
+        - succeeded
+        - failed
+        - manually_executed
+        in: query
+        name: filter_exec_status
+        type: string
+      - description: 'filter: audit status of task sql'
+        enum:
+        - initialized
+        - doing
+        - finished
+        in: query
+        name: filter_audit_status
+        type: string
+      - description: 'filter: audit level of task sql'
+        enum:
+        - normal
+        - notice
+        - warn
+        - error
+        in: query
+        name: filter_audit_level
+        type: string
+      - description: select unique (fingerprint and audit result) for task sql
+        in: query
+        name: no_duplicate
+        type: boolean
+      - description: page index
+        in: query
+        name: page_index
+        required: true
+        type: string
+      - description: page size
+        in: query
+        name: page_size
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.GetAuditTaskSQLsResV2'
+      security:
+      - ApiKeyAuth: []
+      summary: 获取指定扫描任务的SQLs信息
+      tags:
+      - task
 securityDefinitions:
   ApiKeyAuth:
     in: header


### PR DESCRIPTION
feat:
- 新增 API 定义 GET: /v2/tasks/audits/{task_id}/sqls
- 新增 API 定义 POST: /v2/sql_audit
- 新增 API 定义 GET: /v2/projects/{project_name}/audit_plans/{audit_plan_name}/reports/{audit_plan_report_id}/sqls

related: #1411