### PR TITLE
feat: 新增 AuditResults 若干接口实现

### DIFF
--- a/sqle/api/cloudbeaver_wrapper/service/audit.go
+++ b/sqle/api/cloudbeaver_wrapper/service/audit.go
@@ -76,7 +76,7 @@ func generateAuditResult(task *sqleModel.Task) string {
 	for _, executeSQL := range task.ExecuteSQLs {
 		builder.WriteString(strings.TrimSpace(executeSQL.Content))
 		builder.WriteString("\n------------------------------------------------------------------------------------------------\n")
-		builder.WriteString(executeSQL.AuditResult)
+		builder.WriteString(executeSQL.GetAuditResults())
 		builder.WriteString("\n------------------------------------------------------------------------------------------------\n\n")
 	}
 	return builder.String()

--- a/sqle/api/controller/v1/audit_plan.go
+++ b/sqle/api/controller/v1/audit_plan.go
@@ -28,7 +28,7 @@ import (
 var tokenExpire = 365 * 24 * time.Hour
 
 var (
-	errAuditPlanNotExist         = errors.New(errors.DataNotExist, fmt.Errorf("audit plan is not exist"))
+	errAuditPlanNotExist         = errors.New(errors.DataNotExist, fmt.Errorf("audit plan is not exist")) // Deprecated: errors.NewAuditPlanNotExistErr() instead
 	errAuditPlanExisted          = errors.New(errors.DataNotExist, fmt.Errorf("audit plan existed"))
 	errAuditPlanInstanceConflict = errors.New(errors.DataConflict, fmt.Errorf("instance_name can not be empty while instance_database is not empty"))
 )
@@ -1404,7 +1404,7 @@ func GetAuditPlanReportSQLsV1(c echo.Context) error {
 	for i, auditPlanReportSQL := range auditPlanReportSQLs {
 		auditPlanReportSQLsResV1[i] = AuditPlanReportSQLResV1{
 			SQL:         auditPlanReportSQL.SQL,
-			AuditResult: auditPlanReportSQL.AuditResult,
+			AuditResult: auditPlanReportSQL.AuditResults.String(),
 			Number:      auditPlanReportSQL.Number,
 		}
 	}

--- a/sqle/api/controller/v1/sql_audit.go
+++ b/sqle/api/controller/v1/sql_audit.go
@@ -90,7 +90,7 @@ func convertTaskResultToAuditResV1(task *model.Task) *AuditResDataV1 {
 		results[i] = AuditSQLResV1{
 			Number:      sql.Number,
 			ExecSQL:     sql.Content,
-			AuditResult: sql.AuditResult,
+			AuditResult: sql.GetAuditResults(),
 			AuditLevel:  sql.AuditLevel,
 		}
 	}

--- a/sqle/api/controller/v1/sql_audit.go
+++ b/sqle/api/controller/v1/sql_audit.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"net/http"
 
+	parser "github.com/actiontech/mybatis-mapper-2-sql"
 	"github.com/actiontech/sqle/sqle/api/controller"
 	"github.com/actiontech/sqle/sqle/errors"
 	"github.com/actiontech/sqle/sqle/log"
 	"github.com/actiontech/sqle/sqle/model"
 	"github.com/actiontech/sqle/sqle/server"
 
-	parser "github.com/actiontech/mybatis-mapper-2-sql"
 	"github.com/labstack/echo/v4"
 )
 

--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -10,16 +10,15 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/actiontech/sqle/sqle/common"
-	"github.com/actiontech/sqle/sqle/utils"
-
+	mybatis_parser "github.com/actiontech/mybatis-mapper-2-sql"
 	"github.com/actiontech/sqle/sqle/api/controller"
+	"github.com/actiontech/sqle/sqle/common"
 	"github.com/actiontech/sqle/sqle/errors"
 	"github.com/actiontech/sqle/sqle/log"
 	"github.com/actiontech/sqle/sqle/model"
 	"github.com/actiontech/sqle/sqle/server"
+	"github.com/actiontech/sqle/sqle/utils"
 
-	mybatis_parser "github.com/actiontech/mybatis-mapper-2-sql"
 	"github.com/labstack/echo/v4"
 )
 

--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -330,7 +330,7 @@ func GetTaskSQLs(c echo.Context) error {
 			Number:      taskSQL.Number,
 			Description: taskSQL.Description,
 			ExecSQL:     taskSQL.ExecSQL,
-			AuditResult: taskSQL.AuditResult,
+			AuditResult: taskSQL.GetAuditResults(),
 			AuditLevel:  taskSQL.AuditLevel,
 			AuditStatus: taskSQL.AuditStatus,
 			ExecResult:  taskSQL.ExecResult,
@@ -397,8 +397,8 @@ func DownloadTaskSQLReportFile(c echo.Context) error {
 	}
 	for _, td := range taskSQLsDetail {
 		taskSql := &model.ExecuteSQL{
-			AuditResult: td.AuditResult,
-			AuditStatus: td.AuditStatus,
+			AuditResults: td.AuditResults,
+			AuditStatus:  td.AuditStatus,
 		}
 		taskSql.ExecStatus = td.ExecStatus
 		err := cw.Write([]string{

--- a/sqle/api/controller/v2/audit_plan.go
+++ b/sqle/api/controller/v2/audit_plan.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/actiontech/sqle/sqle/api/controller"
 	v1 "github.com/actiontech/sqle/sqle/api/controller/v1"
+	"github.com/actiontech/sqle/sqle/errors"
 	"github.com/actiontech/sqle/sqle/model"
 	"github.com/actiontech/sqle/sqle/server/auditplan"
 	"github.com/actiontech/sqle/sqle/utils"
@@ -180,5 +181,57 @@ type AuditPlanReportSQLResV2 struct {
 // @Success 200 {object} v2.GetAuditPlanReportSQLsResV2
 // @router /v2/projects/{project_name}/audit_plans/{audit_plan_name}/reports/{audit_plan_report_id}/sqls [get]
 func GetAuditPlanReportSQLs(c echo.Context) error {
-	return controller.JSONNewNotImplementedErr(c)
+	s := model.GetStorage()
+
+	req := new(GetAuditPlanReportSQLsReqV2)
+	if err := controller.BindAndValidateReq(c, req); err != nil {
+		return err
+	}
+	projectName := c.Param("project_name")
+	apName := c.Param("audit_plan_name")
+
+	ap, exist, err := v1.GetAuditPlanIfCurrentUserCanAccess(c, projectName, apName, model.OP_AUDIT_PLAN_VIEW_OTHERS)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+	if !exist {
+		return controller.JSONBaseErrorReq(c, errors.NewAuditPlanNotExistErr())
+	}
+
+	var offset uint32
+	if req.PageIndex >= 1 {
+		offset = req.PageSize * (req.PageIndex - 1)
+	}
+
+	data := map[string]interface{}{
+		"audit_plan_report_id": c.Param("audit_plan_report_id"),
+		"audit_plan_id":        ap.ID,
+		"limit":                req.PageSize,
+		"offset":               offset,
+	}
+	auditPlanReportSQLs, count, err := s.GetAuditPlanReportSQLsByReq(data)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+
+	auditPlanReportSQLsRes := make([]*AuditPlanReportSQLResV2, len(auditPlanReportSQLs))
+	for i, auditPlanReportSQL := range auditPlanReportSQLs {
+		auditPlanReportSQLsRes[i] = &AuditPlanReportSQLResV2{
+			SQL:    auditPlanReportSQL.SQL,
+			Number: auditPlanReportSQL.Number,
+		}
+		for j := range auditPlanReportSQL.AuditResults {
+			ar := auditPlanReportSQL.AuditResults[j]
+			auditPlanReportSQLsRes[i].AuditResult = append(auditPlanReportSQLsRes[i].AuditResult, &AuditResult{
+				Level:    ar.Level,
+				Message:  ar.Message,
+				RuleName: ar.RuleName,
+			})
+		}
+	}
+	return c.JSON(http.StatusOK, &GetAuditPlanReportSQLsResV2{
+		BaseRes:   controller.NewBaseReq(nil),
+		Data:      auditPlanReportSQLsRes,
+		TotalNums: count,
+	})
 }

--- a/sqle/api/controller/v2/sql_audit.go
+++ b/sqle/api/controller/v2/sql_audit.go
@@ -3,14 +3,14 @@ package v2
 import (
 	"net/http"
 
-	"github.com/labstack/echo/v4"
-
 	parser "github.com/actiontech/mybatis-mapper-2-sql"
 	"github.com/actiontech/sqle/sqle/api/controller"
 	v1 "github.com/actiontech/sqle/sqle/api/controller/v1"
 	"github.com/actiontech/sqle/sqle/log"
 	"github.com/actiontech/sqle/sqle/model"
 	"github.com/actiontech/sqle/sqle/server"
+
+	"github.com/labstack/echo/v4"
 )
 
 type DirectAuditReqV2 struct {

--- a/sqle/api/controller/v2/sql_audit.go
+++ b/sqle/api/controller/v2/sql_audit.go
@@ -1,9 +1,16 @@
 package v2
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 
+	parser "github.com/actiontech/mybatis-mapper-2-sql"
 	"github.com/actiontech/sqle/sqle/api/controller"
+	v1 "github.com/actiontech/sqle/sqle/api/controller/v1"
+	"github.com/actiontech/sqle/sqle/log"
+	"github.com/actiontech/sqle/sqle/model"
+	"github.com/actiontech/sqle/sqle/server"
 )
 
 type DirectAuditReqV2 struct {
@@ -41,5 +48,59 @@ type DirectAuditResV2 struct {
 // @Success 200 {object} v2.DirectAuditResV2
 // @router /v2/sql_audit [post]
 func DirectAudit(c echo.Context) error {
-	return controller.JSONNewNotImplementedErr(c)
+	req := new(DirectAuditReqV2)
+	err := controller.BindAndValidateReq(c, req)
+	if err != nil {
+		return err
+	}
+
+	sql := req.SQLContent
+	if req.SQLType == v1.SQLTypeMyBatis {
+		sql, err = parser.ParseXML(req.SQLContent)
+		if err != nil {
+			return controller.JSONBaseErrorReq(c, err)
+		}
+	}
+
+	l := log.NewEntry().WithField(c.Path(), "direct audit failed")
+
+	task, err := server.AuditSQLByDBType(l, sql, req.InstanceType, nil, "")
+	if err != nil {
+		l.Errorf("audit sqls failed: %v", err)
+		return controller.JSONBaseErrorReq(c, v1.ErrDirectAudit)
+	}
+
+	return c.JSON(http.StatusOK, DirectAuditResV2{
+		BaseRes: controller.BaseRes{},
+		Data:    convertTaskResultToAuditResV2(task),
+	})
+}
+
+func convertTaskResultToAuditResV2(task *model.Task) *AuditResDataV2 {
+	results := make([]AuditSQLResV2, len(task.ExecuteSQLs))
+	for i, sql := range task.ExecuteSQLs {
+
+		ar := make([]*AuditResult, len(sql.AuditResults))
+		for j := range sql.AuditResults {
+			ar[j] = &AuditResult{
+				Level:    sql.AuditResults[j].Level,
+				Message:  sql.AuditResults[j].Message,
+				RuleName: sql.AuditResults[j].RuleName,
+			}
+		}
+
+		results[i] = AuditSQLResV2{
+			Number:      sql.Number,
+			ExecSQL:     sql.Content,
+			AuditResult: ar,
+			AuditLevel:  sql.AuditLevel,
+		}
+
+	}
+	return &AuditResDataV2{
+		AuditLevel: task.AuditLevel,
+		Score:      task.Score,
+		PassRate:   task.PassRate,
+		SQLResults: results,
+	}
 }

--- a/sqle/api/controller/v2/task.go
+++ b/sqle/api/controller/v2/task.go
@@ -1,9 +1,13 @@
 package v2
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 
 	"github.com/actiontech/sqle/sqle/api/controller"
+	v1 "github.com/actiontech/sqle/sqle/api/controller/v1"
+	"github.com/actiontech/sqle/sqle/model"
 )
 
 type GetAuditTaskSQLsReqV2 struct {
@@ -54,5 +58,70 @@ type AuditResult struct {
 // @Success 200 {object} v2.GetAuditTaskSQLsResV2
 // @router /v2/tasks/audits/{task_id}/sqls [get]
 func GetTaskSQLs(c echo.Context) error {
-	return controller.JSONNewNotImplementedErr(c)
+	req := new(GetAuditTaskSQLsReqV2)
+	if err := controller.BindAndValidateReq(c, req); err != nil {
+		return err
+	}
+	s := model.GetStorage()
+	taskId := c.Param("task_id")
+	task, exist, err := s.GetTaskById(taskId)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+	if !exist {
+		return controller.JSONBaseErrorReq(c, v1.ErrTaskNoAccess)
+	}
+	err = v1.CheckCurrentUserCanViewTask(c, task)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+
+	var offset uint32
+	if req.PageIndex >= 1 {
+		offset = req.PageSize * (req.PageIndex - 1)
+	}
+	data := map[string]interface{}{
+		"task_id":             taskId,
+		"filter_exec_status":  req.FilterExecStatus,
+		"filter_audit_status": req.FilterAuditStatus,
+		"filter_audit_level":  req.FilterAuditLevel,
+		"no_duplicate":        req.NoDuplicate,
+		"limit":               req.PageSize,
+		"offset":              offset,
+	}
+
+	taskSQLs, count, err := s.GetTaskSQLsByReq(data)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+
+	taskSQLsRes := make([]*AuditTaskSQLResV2, 0, len(taskSQLs))
+	for _, taskSQL := range taskSQLs {
+		taskSQLRes := &AuditTaskSQLResV2{
+			Number:      taskSQL.Number,
+			Description: taskSQL.Description,
+			ExecSQL:     taskSQL.ExecSQL,
+			AuditLevel:  taskSQL.AuditLevel,
+			AuditStatus: taskSQL.AuditStatus,
+			ExecResult:  taskSQL.ExecResult,
+			ExecStatus:  taskSQL.ExecStatus,
+			RollbackSQL: taskSQL.RollbackSQL.String,
+		}
+		for i := range taskSQL.AuditResults {
+			ar := taskSQL.AuditResults[i]
+			taskSQLRes.AuditResult = append(taskSQLRes.AuditResult, &AuditResult{
+				Level:    ar.Level,
+				Message:  ar.Message,
+				RuleName: ar.RuleName,
+			})
+		}
+
+		taskSQLsRes = append(taskSQLsRes, taskSQLRes)
+	}
+
+	return c.JSON(http.StatusOK, &GetAuditTaskSQLsResV2{
+		BaseRes:   controller.NewBaseReq(nil),
+		Data:      taskSQLsRes,
+		TotalNums: count,
+	})
 }

--- a/sqle/driver/v2/driver_interface.go
+++ b/sqle/driver/v2/driver_interface.go
@@ -140,8 +140,9 @@ type AuditResults struct {
 }
 
 type AuditResult struct {
-	Level   RuleLevel
-	Message string
+	Level    RuleLevel
+	Message  string
+	RuleName string
 }
 
 func NewAuditResults() *AuditResults {

--- a/sqle/errors/errors.go
+++ b/sqle/errors/errors.go
@@ -114,3 +114,7 @@ func NewAccessDeniedErr(format string, a ...interface{}) error {
 func NewUserNotPermissionError(op string) error {
 	return New(UserNotPermission, fmt.Errorf("当前用户没有 %v 的权限, 无法执行此操作", op))
 }
+
+func NewAuditPlanNotExistErr() error {
+	return New(DataNotExist, fmt.Errorf("audit plan is not exist"))
+}

--- a/sqle/model/audit_plan.go
+++ b/sqle/model/audit_plan.go
@@ -8,6 +8,7 @@ import (
 	"github.com/actiontech/sqle/sqle/errors"
 	"github.com/actiontech/sqle/sqle/pkg/params"
 	"github.com/actiontech/sqle/sqle/utils"
+
 	"github.com/jinzhu/gorm"
 )
 

--- a/sqle/model/audit_plan_list_test.go
+++ b/sqle/model/audit_plan_list_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -157,10 +158,13 @@ func TestStorage_GetAuditPlanReportSQLsByReq(t *testing.T) {
 	assert.NoError(t, err)
 	defer mockDB.Close()
 	InitMockStorage(mockDB)
-	mock.ExpectPrepare(fmt.Sprintf(`SELECT report_sqls.sql, report_sqls.audit_result, report_sqls.number %v LIMIT ? OFFSET ?`, tableAndRowOfSQL)).
+	mockResult := []AuditResult{{Level: "error", Message: "FAKE AUDIT RESULT"}}
+	mockResultBytes, _ := json.Marshal(mockResult)
+
+	mock.ExpectPrepare(fmt.Sprintf(`SELECT report_sqls.sql, report_sqls.audit_results, report_sqls.number %v LIMIT ? OFFSET ?`, tableAndRowOfSQL)).
 		ExpectQuery().WithArgs(1, 1, 100, 10).WillReturnRows(sqlmock.NewRows([]string{
-		"sql", "audit_result", "number",
-	}).AddRow("select * from t1 where id = 1", "FAKE AUDIT RESULT", "1"))
+		"sql", "audit_results", "number",
+	}).AddRow("select * from t1 where id = 1", mockResultBytes, "1"))
 
 	mock.ExpectPrepare(fmt.Sprintf(`SELECT COUNT(*) %v`, tableAndRowOfSQL)).
 		ExpectQuery().WithArgs(1, 1).WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow("2"))

--- a/sqle/model/audit_plan_report.go
+++ b/sqle/model/audit_plan_report.go
@@ -22,10 +22,10 @@ func (a AuditPlanReportV2) TableName() string {
 
 type AuditPlanReportSQLV2 struct {
 	Model
-	AuditPlanReportID uint   `json:"audit_plan_report_id" gorm:"index"`
-	SQL               string `json:"sql" gorm:"type:text;not null"`
-	Number            uint   `json:"number"`
-	AuditResult       string `json:"audit_result" gorm:"type:text"`
+	AuditPlanReportID uint         `json:"audit_plan_report_id" gorm:"index"`
+	SQL               string       `json:"sql" gorm:"type:text;not null"`
+	Number            uint         `json:"number"`
+	AuditResults      AuditResults `json:"audit_results" gorm:"type:json"`
 
 	AuditPlanReport *AuditPlanReportV2 `gorm:"foreignkey:AuditPlanReportID"`
 }

--- a/sqle/model/audit_plan_report.go
+++ b/sqle/model/audit_plan_report.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"github.com/actiontech/sqle/sqle/errors"
+
 	"github.com/jinzhu/gorm"
 )
 

--- a/sqle/model/audit_plan_report_list.go
+++ b/sqle/model/audit_plan_report_list.go
@@ -58,13 +58,13 @@ func (s *Storage) GetAuditPlanReportsByReq(data map[string]interface{}) (
 }
 
 type AuditPlanReportSQLListDetail struct {
-	SQL         string `json:"sql"`
-	AuditResult string `json:"audit_result"`
-	Number      uint   `json:"number"`
+	SQL          string       `json:"sql"`
+	AuditResults AuditResults `json:"audit_results"`
+	Number       uint         `json:"number"`
 }
 
 var auditPlanReportSQLQueryTpl = `
-SELECT report_sqls.sql, report_sqls.audit_result, report_sqls.number
+SELECT report_sqls.sql, report_sqls.audit_results, report_sqls.number
 
 {{- template "body" . -}} 
 

--- a/sqle/model/task.go
+++ b/sqle/model/task.go
@@ -144,7 +144,7 @@ func (a *AuditResults) Scan(input interface{}) error {
 	return json.Unmarshal(input.([]byte), a)
 }
 
-func (a *AuditResults) string() string {
+func (a *AuditResults) String() string {
 	msgs := make([]string, len(*a))
 	for i := range *a {
 		res := (*a)[i]
@@ -187,7 +187,7 @@ func (s *ExecuteSQL) GetAuditResults() string {
 		return ""
 	}
 
-	return s.AuditResults.string()
+	return s.AuditResults.String()
 }
 
 func (s *ExecuteSQL) GetAuditResultDesc() string {
@@ -195,7 +195,7 @@ func (s *ExecuteSQL) GetAuditResultDesc() string {
 		return "审核通过"
 	}
 
-	return s.AuditResults.string()
+	return s.AuditResults.String()
 }
 
 type RollbackSQL struct {
@@ -420,7 +420,7 @@ func (t *TaskSQLDetail) GetAuditResults() string {
 		return ""
 	}
 
-	return t.AuditResults.string()
+	return t.AuditResults.String()
 }
 
 var taskSQLsQueryTpl = `SELECT e_sql.number, e_sql.description, e_sql.content AS exec_sql, r_sql.content AS rollback_sql,

--- a/sqle/model/task.go
+++ b/sqle/model/task.go
@@ -128,8 +128,8 @@ func (s *BaseSQL) GetExecStatusDesc() string {
 }
 
 type AuditResult struct {
-	Level    string `json:"lvl"`
-	Message  string `json:"msg"`
+	Level    string `json:"level"`
+	Message  string `json:"message"`
 	RuleName string `json:"rule_name"`
 }
 

--- a/sqle/model/task.go
+++ b/sqle/model/task.go
@@ -140,14 +140,23 @@ func (a AuditResults) Value() (driver.Value, error) {
 	return string(b), err
 }
 
-func (c *AuditResults) Scan(input interface{}) error {
-	return json.Unmarshal(input.([]byte), c)
+func (a *AuditResults) Scan(input interface{}) error {
+	return json.Unmarshal(input.([]byte), a)
+}
+
+func (a *AuditResults) string() string {
+	msgs := make([]string, len(*a))
+	for i := range *a {
+		res := (*a)[i]
+		msg := fmt.Sprintf("[%s]%s", res.Level, res.Message)
+		msgs[i] = msg
+	}
+	return strings.Join(msgs, "\n")
 }
 
 type ExecuteSQL struct {
 	BaseSQL
 	AuditStatus  string       `json:"audit_status" gorm:"default:\"initialized\""`
-	AuditResult  string       `json:"audit_result" gorm:"type:text"`
 	AuditResults AuditResults `json:"audit_results" gorm:"type:json"`
 	// AuditFingerprint generate from SQL and SQL audit result use MD5 hash algorithm,
 	// it used for deduplication in one audit task.
@@ -173,11 +182,20 @@ func (s *ExecuteSQL) GetAuditStatusDesc() string {
 	}
 }
 
+func (s *ExecuteSQL) GetAuditResults() string {
+	if len(s.AuditResults) == 0 {
+		return ""
+	}
+
+	return s.AuditResults.string()
+}
+
 func (s *ExecuteSQL) GetAuditResultDesc() string {
-	if s.AuditResult == "" {
+	if len(s.AuditResults) == 0 {
 		return "审核通过"
 	}
-	return s.AuditResult
+
+	return s.AuditResults.string()
 }
 
 type RollbackSQL struct {
@@ -386,19 +404,27 @@ func (s *Storage) GetTaskByInstanceId(instanceId uint) ([]Task, error) {
 }
 
 type TaskSQLDetail struct {
-	Number      uint           `json:"number"`
-	Description string         `json:"description"`
-	ExecSQL     string         `json:"exec_sql"`
-	AuditResult string         `json:"audit_result"`
-	AuditLevel  string         `json:"audit_level"`
-	AuditStatus string         `json:"audit_status"`
-	ExecResult  string         `json:"exec_result"`
-	ExecStatus  string         `json:"exec_status"`
-	RollbackSQL sql.NullString `json:"rollback_sql"`
+	Number       uint           `json:"number"`
+	Description  string         `json:"description"`
+	ExecSQL      string         `json:"exec_sql"`
+	AuditResults AuditResults   `json:"audit_results"`
+	AuditLevel   string         `json:"audit_level"`
+	AuditStatus  string         `json:"audit_status"`
+	ExecResult   string         `json:"exec_result"`
+	ExecStatus   string         `json:"exec_status"`
+	RollbackSQL  sql.NullString `json:"rollback_sql"`
+}
+
+func (t *TaskSQLDetail) GetAuditResults() string {
+	if len(t.AuditResults) == 0 {
+		return ""
+	}
+
+	return t.AuditResults.string()
 }
 
 var taskSQLsQueryTpl = `SELECT e_sql.number, e_sql.description, e_sql.content AS exec_sql, r_sql.content AS rollback_sql,
-e_sql.audit_result, e_sql.audit_level, e_sql.audit_status, e_sql.exec_result, e_sql.exec_status
+e_sql.audit_results, e_sql.audit_level, e_sql.audit_status, e_sql.exec_result, e_sql.exec_status
 
 {{- template "body" . -}}
 

--- a/sqle/model/task.go
+++ b/sqle/model/task.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jinzhu/gorm"
-
 	"github.com/actiontech/sqle/sqle/errors"
 	"github.com/actiontech/sqle/sqle/utils"
+
+	"github.com/jinzhu/gorm"
 )
 
 const (

--- a/sqle/server/audit.go
+++ b/sqle/server/audit.go
@@ -160,13 +160,7 @@ func hookAudit(l *logrus.Entry, task *model.Task, p driver.Plugin, hook AuditHoo
 		sql.AuditStatus = model.SQLAuditStatusFinished
 		sql.AuditLevel = string(results[i].Level())
 		sql.AuditFingerprint = utils.Md5String(string(append([]byte(results[i].Message()), []byte(nodes[i].Fingerprint)...)))
-		for j := range results {
-			sql.AuditResults = append(sql.AuditResults, model.AuditResult{
-				Level:    string(results[i].Results[j].Level),
-				Message:  results[i].Results[j].Message,
-				RuleName: results[i].Results[j].RuleName,
-			})
-		}
+		appendExecuteSqlResults(sql, results[i])
 	}
 
 	replenishTaskStatistics(task)
@@ -292,13 +286,7 @@ func genRollbackSQL(l *logrus.Entry, task *model.Task, p driver.Plugin) ([]*mode
 		result.Add(driverV2.RuleLevel(executeSQL.AuditLevel), executeSQL.GetAuditResults())
 		result.Add(driverV2.RuleLevelNotice, reason)
 		executeSQL.AuditLevel = string(result.Level())
-		for i := range result.Results {
-			executeSQL.AuditResults = append(executeSQL.AuditResults, model.AuditResult{
-				Level:    string(result.Results[i].Level),
-				Message:  result.Results[i].Message,
-				RuleName: result.Results[i].RuleName,
-			})
-		}
+		appendExecuteSqlResults(executeSQL, result)
 
 		rollbackSQLs = append(rollbackSQLs, &model.RollbackSQL{
 			BaseSQL: model.BaseSQL{

--- a/sqle/server/audit.go
+++ b/sqle/server/audit.go
@@ -137,14 +137,7 @@ func hookAudit(l *logrus.Entry, task *model.Task, p driver.Plugin, hook AuditHoo
 			executeSQL.AuditStatus = model.SQLAuditStatusFinished
 			executeSQL.AuditLevel = string(result.Level())
 			executeSQL.AuditFingerprint = utils.Md5String(string(append([]byte(result.Message()), []byte(node.Fingerprint)...)))
-			for i := range result.Results {
-				executeSQL.AuditResults = append(executeSQL.AuditResults, model.AuditResult{
-					Level:    string(result.Results[i].Level),
-					Message:  result.Results[i].Message,
-					RuleName: result.Results[i].RuleName,
-				})
-			}
-
+			appendExecuteSqlResults(executeSQL, result)
 		} else {
 			auditSqls = append(auditSqls, executeSQL)
 			sqls = append(sqls, executeSQL.Content)
@@ -316,4 +309,16 @@ func genRollbackSQL(l *logrus.Entry, task *model.Task, p driver.Plugin) ([]*mode
 		})
 	}
 	return rollbackSQLs, nil
+}
+
+func appendExecuteSqlResults(executeSQL *model.ExecuteSQL, result *driverV2.AuditResults) {
+	for i := range result.Results {
+		ar := result.Results[i]
+		executeSQL.AuditResults = append(executeSQL.AuditResults, model.AuditResult{
+			Level:    string(ar.Level),
+			Message:  ar.Message,
+			RuleName: ar.RuleName,
+		})
+	}
+
 }

--- a/sqle/server/audit.go
+++ b/sqle/server/audit.go
@@ -11,8 +11,8 @@ import (
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
 	"github.com/actiontech/sqle/sqle/model"
 	"github.com/actiontech/sqle/sqle/utils"
-	"github.com/pkg/errors"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/sqle/server/auditplan/task.go
+++ b/sqle/server/auditplan/task.go
@@ -133,7 +133,7 @@ func (at *baseTask) audit(task *model.Task) (*model.AuditPlanReportV2, error) {
 		auditPlanReport.AuditPlanReportSQLs = append(auditPlanReport.AuditPlanReportSQLs, &model.AuditPlanReportSQLV2{
 			SQL:         executeSQL.Content,
 			Number:      uint(i + 1),
-			AuditResult: executeSQL.AuditResult,
+			AuditResult: executeSQL.GetAuditResults(),
 		})
 	}
 	err = at.persist.Save(auditPlanReport)
@@ -687,7 +687,7 @@ func (at *TiDBAuditLogTask) Audit() (*model.AuditPlanReportV2, error) {
 		auditPlanReport.AuditPlanReportSQLs = append(auditPlanReport.AuditPlanReportSQLs, &model.AuditPlanReportSQLV2{
 			SQL:         executeSQL.Content,
 			Number:      uint(i + 1),
-			AuditResult: executeSQL.AuditResult,
+			AuditResult: executeSQL.GetAuditResults(),
 		})
 	}
 	err = at.persist.Save(auditPlanReport)

--- a/sqle/server/auditplan/task.go
+++ b/sqle/server/auditplan/task.go
@@ -131,9 +131,9 @@ func (at *baseTask) audit(task *model.Task) (*model.AuditPlanReportV2, error) {
 	}
 	for i, executeSQL := range task.ExecuteSQLs {
 		auditPlanReport.AuditPlanReportSQLs = append(auditPlanReport.AuditPlanReportSQLs, &model.AuditPlanReportSQLV2{
-			SQL:         executeSQL.Content,
-			Number:      uint(i + 1),
-			AuditResult: executeSQL.GetAuditResults(),
+			SQL:          executeSQL.Content,
+			Number:       uint(i + 1),
+			AuditResults: executeSQL.AuditResults,
 		})
 	}
 	err = at.persist.Save(auditPlanReport)
@@ -685,9 +685,9 @@ func (at *TiDBAuditLogTask) Audit() (*model.AuditPlanReportV2, error) {
 	}
 	for i, executeSQL := range task.ExecuteSQLs {
 		auditPlanReport.AuditPlanReportSQLs = append(auditPlanReport.AuditPlanReportSQLs, &model.AuditPlanReportSQLV2{
-			SQL:         executeSQL.Content,
-			Number:      uint(i + 1),
-			AuditResult: executeSQL.GetAuditResults(),
+			SQL:          executeSQL.Content,
+			Number:       uint(i + 1),
+			AuditResults: executeSQL.AuditResults,
 		})
 	}
 	err = at.persist.Save(auditPlanReport)

--- a/sqle/server/sqled_test.go
+++ b/sqle/server/sqled_test.go
@@ -165,7 +165,7 @@ func Test_action_audit_UpdateTask(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `execute_sql_detail`")).
-		WithArgs(model.MockTime, model.MockTime, nil, 0, 0, act.task.ExecuteSQLs[0].Content, "", "", 0, "", 0, 0, "", "", model.SQLAuditStatusFinished, "[normal]白名单", "2882fdbb7d5bcda7b49ea0803493467e", "normal").
+		WithArgs(model.MockTime, model.MockTime, nil, 0, 0, act.task.ExecuteSQLs[0].Content, "", "", 0, "", 0, 0, "", "", model.SQLAuditStatusFinished, `[{"lvl":"normal","msg":"白名单","rule_name":""}]`, "2882fdbb7d5bcda7b49ea0803493467e", "normal").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 

--- a/sqle/server/sqled_test.go
+++ b/sqle/server/sqled_test.go
@@ -166,7 +166,7 @@ func Test_action_audit_UpdateTask(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `execute_sql_detail`")).
-		WithArgs(model.MockTime, model.MockTime, nil, 0, 0, act.task.ExecuteSQLs[0].Content, "", "", 0, "", 0, 0, "", "", model.SQLAuditStatusFinished, `[{"lvl":"normal","msg":"白名单","rule_name":""}]`, "2882fdbb7d5bcda7b49ea0803493467e", "normal").
+		WithArgs(model.MockTime, model.MockTime, nil, 0, 0, act.task.ExecuteSQLs[0].Content, "", "", 0, "", 0, 0, "", "", model.SQLAuditStatusFinished, `[{"level":"normal","message":"白名单","rule_name":""}]`, "2882fdbb7d5bcda7b49ea0803493467e", "normal").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 

--- a/sqle/server/sqled_test.go
+++ b/sqle/server/sqled_test.go
@@ -9,12 +9,13 @@ import (
 	"regexp"
 	"testing"
 
-	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/actiontech/sqle/sqle/driver"
 	_ "github.com/actiontech/sqle/sqle/driver/mysql"
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
 	"github.com/actiontech/sqle/sqle/log"
 	"github.com/actiontech/sqle/sqle/model"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/agiledragon/gomonkey"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
feat:
- 新增接口实现。与旧接口相比，接口功能没有太大变化。仅字段 audit_result 格式有所变化。
    - /v2/projects/{project_name}/audit_plans/{audit_plan_name}/reports/{audit_plan_report_id}/sqls。
    - /v2/sql_audit。
    - /v2/tasks/audits/{task_id}/sqls

fix:
- model 模型字段格式调整，需要升级工具支持
    - AuditPlanReportSQLV2，表名 "audit_plan_report_sqls_v2"
    - ExecuteSQL，表名 execute_sql_detail
- 由于模型字段格式调整，同时调整了单元测试用例代码

related: #1411 