### PR TITLE
feat(api): API 新增「性能统计」字段，返回「影响行数」等信息

### DIFF
--- a/sqle/api/controller/v1/audit_plan.go
+++ b/sqle/api/controller/v1/audit_plan.go
@@ -1228,8 +1228,9 @@ type TableMeta struct {
 }
 
 type GetSQLAnalysisDataResItemV1 struct {
-	SQLExplain SQLExplain  `json:"sql_explain"`
-	TableMetas []TableMeta `json:"table_metas"`
+	SQLExplain            SQLExplain            `json:"sql_explain"`
+	TableMetas            []TableMeta           `json:"table_metas"`
+	PerformanceStatistics PerformanceStatistics `json:"performance_statistics"`
 }
 
 type GetAuditPlanAnalysisDataResV1 struct {

--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -564,8 +564,18 @@ type ExplainClassicResult struct {
 }
 
 type GetTaskAnalysisDataResItemV1 struct {
-	SQLExplain SQLExplain  `json:"sql_explain"`
-	TableMetas []TableMeta `json:"table_metas"`
+	SQLExplain            SQLExplain            `json:"sql_explain"`
+	TableMetas            []TableMeta           `json:"table_metas"`
+	PerformanceStatistics PerformanceStatistics `json:"performance_statistics"`
+}
+
+type PerformanceStatistics struct {
+	AffectRows AffectRows `json:"affect_rows"`
+}
+
+type AffectRows struct {
+	Count      int    `json:"count"`
+	ErrMessage string `json:"err_message"`
 }
 
 type GetTaskAnalysisDataResV1 struct {

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -8122,6 +8122,17 @@ var doc = `{
                 }
             }
         },
+        "v1.AffectRows": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "err_message": {
+                    "type": "string"
+                }
+            }
+        },
         "v1.AuditPlanMetaV1": {
             "type": "object",
             "properties": {
@@ -10362,6 +10373,10 @@ var doc = `{
         "v1.GetSQLAnalysisDataResItemV1": {
             "type": "object",
             "properties": {
+                "performance_statistics": {
+                    "type": "object",
+                    "$ref": "#/definitions/v1.PerformanceStatistics"
+                },
                 "sql_explain": {
                     "type": "object",
                     "$ref": "#/definitions/v1.SQLExplain"
@@ -10563,6 +10578,10 @@ var doc = `{
         "v1.GetTaskAnalysisDataResItemV1": {
             "type": "object",
             "properties": {
+                "performance_statistics": {
+                    "type": "object",
+                    "$ref": "#/definitions/v1.PerformanceStatistics"
+                },
                 "sql_explain": {
                     "type": "object",
                     "$ref": "#/definitions/v1.SQLExplain"
@@ -11708,6 +11727,15 @@ var doc = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "v1.PerformanceStatistics": {
+            "type": "object",
+            "properties": {
+                "affect_rows": {
+                    "type": "object",
+                    "$ref": "#/definitions/v1.AffectRows"
                 }
             }
         },

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -8106,6 +8106,17 @@
                 }
             }
         },
+        "v1.AffectRows": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "err_message": {
+                    "type": "string"
+                }
+            }
+        },
         "v1.AuditPlanMetaV1": {
             "type": "object",
             "properties": {
@@ -10346,6 +10357,10 @@
         "v1.GetSQLAnalysisDataResItemV1": {
             "type": "object",
             "properties": {
+                "performance_statistics": {
+                    "type": "object",
+                    "$ref": "#/definitions/v1.PerformanceStatistics"
+                },
                 "sql_explain": {
                     "type": "object",
                     "$ref": "#/definitions/v1.SQLExplain"
@@ -10547,6 +10562,10 @@
         "v1.GetTaskAnalysisDataResItemV1": {
             "type": "object",
             "properties": {
+                "performance_statistics": {
+                    "type": "object",
+                    "$ref": "#/definitions/v1.PerformanceStatistics"
+                },
                 "sql_explain": {
                     "type": "object",
                     "$ref": "#/definitions/v1.SQLExplain"
@@ -11692,6 +11711,15 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "v1.PerformanceStatistics": {
+            "type": "object",
+            "properties": {
+                "affect_rows": {
+                    "type": "object",
+                    "$ref": "#/definitions/v1.AffectRows"
                 }
             }
         },

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -9,6 +9,13 @@ definitions:
         example: ok
         type: string
     type: object
+  v1.AffectRows:
+    properties:
+      count:
+        type: integer
+      err_message:
+        type: string
+    type: object
   v1.AuditPlanMetaV1:
     properties:
       audit_plan_params:
@@ -1546,6 +1553,9 @@ definitions:
     type: object
   v1.GetSQLAnalysisDataResItemV1:
     properties:
+      performance_statistics:
+        $ref: '#/definitions/v1.PerformanceStatistics'
+        type: object
       sql_explain:
         $ref: '#/definitions/v1.SQLExplain'
         type: object
@@ -1684,6 +1694,9 @@ definitions:
     type: object
   v1.GetTaskAnalysisDataResItemV1:
     properties:
+      performance_statistics:
+        $ref: '#/definitions/v1.PerformanceStatistics'
+        type: object
       sql_explain:
         $ref: '#/definitions/v1.SQLExplain'
         type: object
@@ -2463,6 +2476,12 @@ definitions:
         items:
           type: string
         type: array
+    type: object
+  v1.PerformanceStatistics:
+    properties:
+      affect_rows:
+        $ref: '#/definitions/v1.AffectRows'
+        type: object
     type: object
   v1.PersonaliseReqV1:
     properties:


### PR DESCRIPTION
feat:
- GET:/v1/tasks/audits/{task_id}/sqls/{number}/analysis 新增「性能统计」字段，返回「影响行数」等信息
- GET:/v1/projects/{project_name}/audit_plans/{audit_plan_name}/reports/{audit_plan_report_id}/sqls/{number}/analysis 新增「性能统计」字段，返回「影响行数」等信息

related: #1413 