### PR TITLE
fix: processlist 审核任务 sql，新增 schema 切换动作

### DIFF
--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -181,7 +181,7 @@ func inspectCase(t *testing.T, desc string, i *MysqlDriverImpl, sql string, resu
 			t.Errorf("%s test failed, \n\nsql:\n %s\n\nexpect level: %s\nexpect result:\n%s\n\nactual level: %s\nactual result:\n%s\n",
 				desc, stmt.Text(), results[idx].level(), results[idx].message(), actualResults[idx].Level(), actualResults[idx].Message())
 		} else {
-			t.Log(fmt.Sprintf("\n\ncase:%s\nactual level: %s\nactual result:\n%s\n\n", desc, actualResults[idx].Level(), actualResults[idx].Message()))
+			t.Logf("\n\ncase:%s\nactual level: %s\nactual result:\n%s\n\n", desc, actualResults[idx].Level(), actualResults[idx].Message())
 		}
 	}
 }

--- a/sqle/server/audit.go
+++ b/sqle/server/audit.go
@@ -163,11 +163,11 @@ func hookAudit(l *logrus.Entry, task *model.Task, p driver.Plugin, hook AuditHoo
 		appendExecuteSqlResults(sql, results[i])
 	}
 
-	replenishTaskStatistics(task)
+	ReplenishTaskStatistics(task)
 	return nil
 }
 
-func replenishTaskStatistics(task *model.Task) {
+func ReplenishTaskStatistics(task *model.Task) {
 	var normalCount float64
 	maxAuditLevel := driverV2.RuleLevelNull
 	for _, executeSQL := range task.ExecuteSQLs {

--- a/sqle/server/auditplan/task.go
+++ b/sqle/server/auditplan/task.go
@@ -1193,9 +1193,9 @@ func (at *MySQLProcesslistTask) Audit() (*model.AuditPlanReportV2, error) {
 
 	auditPlanReport := &model.AuditPlanReportV2{
 		AuditPlanID: at.ap.ID,
-		PassRate:    vTask.PassRate,
-		Score:       vTask.Score,
-		AuditLevel:  vTask.AuditLevel,
+		PassRate:    task.PassRate,
+		Score:       task.Score,
+		AuditLevel:  task.AuditLevel,
 	}
 
 	for i, executeSQL := range task.ExecuteSQLs {

--- a/sqle/server/auditplan/task.go
+++ b/sqle/server/auditplan/task.go
@@ -1131,7 +1131,7 @@ WHERE ID != connection_id() AND info != '' AND db NOT IN ('information_schema','
 	return sql
 }
 
-// NOTE: processlist SQLs may be executed in different Schemas.
+// HACK: processlist SQLs may be executed in different Schemas.
 // Before auditing sql, we need to insert a Schema switching statement.
 // And need to manually execute server.ReplenishTaskStatistics()
 func (at *MySQLProcesslistTask) Audit() (*model.AuditPlanReportV2, error) {

--- a/sqle/server/auditplan/task.go
+++ b/sqle/server/auditplan/task.go
@@ -1133,7 +1133,8 @@ WHERE ID != connection_id() AND info != '' AND db NOT IN ('information_schema','
 
 // HACK: processlist SQLs may be executed in different Schemas.
 // Before auditing sql, we need to insert a Schema switching statement.
-// And need to manually execute server.ReplenishTaskStatistics()
+// And need to manually execute server.ReplenishTaskStatistics() to recalculate
+// real task object score
 func (at *MySQLProcesslistTask) Audit() (*model.AuditPlanReportV2, error) {
 	auditPlanSQLs, err := at.persist.GetAuditPlanSQLs(at.ap.ID)
 	if err != nil {

--- a/sqle/server/auditplan/task.go
+++ b/sqle/server/auditplan/task.go
@@ -1163,9 +1163,6 @@ func (at *MySQLProcesslistTask) Audit() (*model.AuditPlanReportV2, error) {
 				Content: sql.SQLContent,
 			},
 		}
-		task.ExecuteSQLs = append(task.ExecuteSQLs, sqlItem)
-		vTask.ExecuteSQLs = append(vTask.ExecuteSQLs, sqlItem) // vTask is a copy of task for schema switch
-
 		{
 			info := struct {
 				Schema string `json:"schema"`
@@ -1182,6 +1179,9 @@ func (at *MySQLProcesslistTask) Audit() (*model.AuditPlanReportV2, error) {
 				})
 			}
 		}
+		task.ExecuteSQLs = append(task.ExecuteSQLs, sqlItem)
+		vTask.ExecuteSQLs = append(vTask.ExecuteSQLs, sqlItem) // vTask is a copy of task for schema switch
+
 	}
 
 	err = server.Audit(at.logger, vTask, &at.ap.ProjectId, at.ap.RuleTemplateName)


### PR DESCRIPTION
fix：
- (auditplan) processlist 审核任务采集的 SQL，可能执行在不同的 schema 上。因此在审核语句列表中插入了 `USE ${schema_name}` 切换语句。同时审核任务对象 task 会在审核完成后重新生成分数

test:
- 根据 lint 工具优化了一处测试代码