### PR TITLE
fix(audit): 修复输入的sql中index被转为小写的问题

### DIFF
--- a/sqle/driver/mysql/audit.go
+++ b/sqle/driver/mysql/audit.go
@@ -362,9 +362,8 @@ func (i *MysqlDriverImpl) checkInvalidAlterTable(stmt *ast.AlterTableStmt) error
 	}
 
 	for _, spec := range util.GetAlterTableSpecByTp(stmt.Specs, ast.AlterTableDropIndex) {
-		indexName := strings.ToLower(spec.Name)
-		if _, ok := indexNameMap[indexName]; !ok {
-			needExistsIndexesName = append(needExistsIndexesName, indexName)
+		if _, ok := indexNameMap[spec.Name]; !ok {
+			needExistsIndexesName = append(needExistsIndexesName, spec.Name)
 		}
 	}
 


### PR DESCRIPTION
当对待审核的SQL近进行审核时，index命名被转为了小写。导致使用了错误的index命名做了比较。
#1399 