### PR TITLE
feat(task): add new task sql execution status 

### DIFF
--- a/sqle/api/controller/v2/task.go
+++ b/sqle/api/controller/v2/task.go
@@ -50,7 +50,7 @@ type AuditResult struct {
 // @Id getAuditTaskSQLsV2
 // @Security ApiKeyAuth
 // @Param task_id path string true "task id"
-// @Param filter_exec_status query string false "filter: exec status of task sql" Enums(initialized,doing,succeeded,failed,manually_executed)
+// @Param filter_exec_status query string false "filter: exec status of task sql" Enums(initialized,doing,succeeded,failed,manually_executed,terminating,terminate_succ,terminate_fail)
 // @Param filter_audit_status query string false "filter: audit status of task sql" Enums(initialized,doing,finished)
 // @Param filter_audit_level query string false "filter: audit level of task sql" Enums(normal,notice,warn,error)
 // @Param no_duplicate query boolean false "select unique (fingerprint and audit result) for task sql"

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -8324,7 +8324,10 @@ var doc = `{
                             "doing",
                             "succeeded",
                             "failed",
-                            "manually_executed"
+                            "manually_executed",
+                            "terminating",
+                            "terminate_succ",
+                            "terminate_fail"
                         ],
                         "type": "string",
                         "description": "filter: exec status of task sql",

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -8308,7 +8308,10 @@
                             "doing",
                             "succeeded",
                             "failed",
-                            "manually_executed"
+                            "manually_executed",
+                            "terminating",
+                            "terminate_succ",
+                            "terminate_fail"
                         ],
                         "type": "string",
                         "description": "filter: exec status of task sql",

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -9636,6 +9636,9 @@ paths:
         - succeeded
         - failed
         - manually_executed
+        - terminating
+        - terminate_succ
+        - terminate_fail
         in: query
         name: filter_exec_status
         type: string


### PR DESCRIPTION
Add new filters to the API to allow filtering by the new task sql execution status and audit status values. The new values are:
- terminating
- terminate_succ
- terminate_fail

This change was made to allow better filtering of task sqls in the API.

related: #1519 