### PR TITLE
feat: sqle action 新增 terminate 信号监听

### DIFF
--- a/sqle/driver/mysql/mysql.go
+++ b/sqle/driver/mysql/mysql.go
@@ -212,6 +212,11 @@ func (i *MysqlDriverImpl) Tx(ctx context.Context, queries ...string) ([]_driver.
 	return conn.Db.Transact(queries...)
 }
 
+// TODO
+func (i *MysqlDriverImpl) KillProcess(ctx context.Context) error {
+	return nil
+}
+
 func (i *MysqlDriverImpl) query(ctx context.Context, query string, args ...interface{}) ([]map[string]sql.NullString, error) {
 	conn, err := i.getDbConn()
 	if err != nil {

--- a/sqle/driver/plugin_adapter_v1.go
+++ b/sqle/driver/plugin_adapter_v1.go
@@ -123,6 +123,10 @@ func (p *PluginImplV1) Close(ctx context.Context) {
 	p.DriverManager.Close(ctx)
 }
 
+func (p *PluginImplV1) KillProcess(ctx context.Context) error {
+	return nil
+}
+
 func (p *PluginImplV1) Parse(ctx context.Context, sqlText string) ([]driverV2.Node, error) {
 	client, err := p.DriverManager.GetAuditDriver()
 	if err != nil {

--- a/sqle/driver/plugin_adapter_v2.go
+++ b/sqle/driver/plugin_adapter_v2.go
@@ -171,6 +171,10 @@ func (s *PluginImplV2) Close(ctx context.Context) {
 	s.afterLog(api, err)
 }
 
+func (s *PluginImplV2) KillProcess(ctx context.Context) error {
+	return nil
+}
+
 // audit
 
 func (s *PluginImplV2) Parse(ctx context.Context, sqlText string) ([]driverV2.Node, error) {

--- a/sqle/driver/plugin_interface.go
+++ b/sqle/driver/plugin_interface.go
@@ -27,6 +27,9 @@ type Plugin interface {
 	Query(ctx context.Context, sql string, conf *driverV2.QueryConf) (*driverV2.QueryResult, error)
 	Explain(ctx context.Context, conf *driverV2.ExplainConf) (*driverV2.ExplainResult, error)
 
+	// KillProcess uses a new connection to send the "Kill process_id" command to terminate the thread that is currently running.
+	KillProcess(ctx context.Context) (err error)
+
 	// Schemas export all supported schemas.
 	//
 	// For example, performance_schema/performance_schema... which in MySQL is not allowed for auditing.

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -309,7 +309,7 @@ func (a *action) execute() (err error) {
 
 	{
 		go func() { // execute
-			err = a.execTask(task)
+			err = a.execTask()
 			errChan <- err
 		}()
 
@@ -361,10 +361,12 @@ func (a *action) updateTaskStatus(err error) {
 	a.task.Status = model.TaskStatusExecuteSucceeded
 }
 
-func (a *action) execTask(task *model.Task) (err error) {
+func (a *action) execTask() (err error) {
 	defer func() {
 		a.updateTaskStatus(err)
 	}()
+
+	task := a.task
 
 	// txSQLs keep adjacent DMLs, execute in one transaction.
 	var txSQLs []*model.ExecuteSQL

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -378,6 +378,12 @@ func (a *action) execTask() (err error) {
 			return err
 		}
 
+		select {
+		case <-a.killExecutionChan:
+			return fmt.Errorf("task has been terminated")
+		default:
+		}
+
 		switch nodes[0].Type {
 		case driverV2.SQLTypeDML:
 			txSQLs = append(txSQLs, executeSQL)

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -286,9 +286,9 @@ func (a *action) audit() (err error) {
 	return nil
 }
 
-func (a *action) terminateExecution() error {
-	// TODO: kill process and update status
-	return nil
+// TODO: update task status
+func (a *action) terminateExecution(ctx context.Context) error {
+	return a.plugin.KillProcess(ctx)
 }
 
 func (a *action) execute() (err error) {
@@ -315,7 +315,7 @@ func (a *action) execute() (err error) {
 
 		go func() { // wait for kill signal
 			<-a.killExecutionChan
-			err = a.terminateExecution()
+			err = a.terminateExecution(context.TODO())
 			if err != nil {
 				errChan <- err
 			}

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/actiontech/sqle/sqle/driver"
+	"github.com/actiontech/sqle/sqle/utils"
 
 	_ "github.com/actiontech/sqle/sqle/driver/mysql"
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
@@ -164,10 +165,8 @@ func (s *Sqled) do(action *action) error {
 	delete(s.currentTask, taskId)
 	s.Unlock()
 
-	select {
-	case action.done <- struct{}{}:
-	default:
-	}
+	utils.TryClose(action.done)
+
 	return err
 }
 

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -300,15 +300,17 @@ func (a *action) execute() (err error) {
 	errChan := make(chan error)
 
 	{
-		go func() {
+		go func() { // execute
 			err = a.execTask(task)
 			errChan <- err
 		}()
 
-		go func() {
+		go func() { // wait for kill signal
 			<-a.killExecutionChan
 			err = a.terminateExecution()
-			errChan <- err
+			if err != nil {
+				errChan <- err
+			}
 		}()
 	}
 

--- a/sqle/server/sqled_test.go
+++ b/sqle/server/sqled_test.go
@@ -53,6 +53,10 @@ func (d *mockDriver) Ping(ctx context.Context) error {
 	return nil
 }
 
+func (d *mockDriver) KillProcess(ctx context.Context) error {
+	return nil
+}
+
 func (d *mockDriver) Exec(ctx context.Context, query string) (_driver.Result, error) {
 	return nil, nil
 }

--- a/sqle/server/workflow_schedule.go
+++ b/sqle/server/workflow_schedule.go
@@ -74,7 +74,7 @@ func (j *WorkflowScheduleJob) WorkflowSchedule(entry *logrus.Entry) {
 	}
 }
 
-// TODO
+// TODO: send terminate signal to sqled action
 func TerminateWorkflowTasks(workflow *model.Workflow, needExecTaskIdToUserId map[uint]uint) error {
 	return errors.NewNotImplementedError("TerminateWorkflow has not been terminated yet")
 }


### PR DESCRIPTION
- refactor(action): 重构了 action.execute() 代码，使之支持异步terminate。
- feat：
    - (action): 新增了 action.terminateExecution()，使得可以阻塞等待中止操作。
    - (plugin): 新增审核插件 KillProcess() 接口定义。

related: #1519 