### PR TITLE
Fix issue1365

### DIFF
--- a/sqle/api/controller/v1/configuration.go
+++ b/sqle/api/controller/v1/configuration.go
@@ -25,6 +25,7 @@ type UpdateSMTPConfigurationReqV1 struct {
 	Port             *string `json:"smtp_port" form:"smtp_port" example:"465" valid:"omitempty,port"`
 	Username         *string `json:"smtp_username" form:"smtp_username" example:"test@qq.com" valid:"omitempty,email"`
 	Password         *string `json:"smtp_password" form:"smtp_password" example:"123"`
+	IsSkipVerify     *bool   `json:"is_skip_verify" form:"is_skip_verify" description:"是否跳过安全认证"`
 }
 
 // @Summary 添加 SMTP 配置
@@ -62,6 +63,9 @@ func UpdateSMTPConfiguration(c echo.Context) error {
 		// It is never possible to trigger an error here
 		_ = smtpC.EnableSMTPNotify.Scan(*req.EnableSMTPNotify)
 	}
+	if req.IsSkipVerify != nil {
+		smtpC.IsSkipVerify = *req.IsSkipVerify
+	}
 
 	if err := s.Save(smtpC); err != nil {
 		return controller.JSONBaseErrorReq(c, err)
@@ -79,6 +83,7 @@ type SMTPConfigurationResV1 struct {
 	Host             string `json:"smtp_host"`
 	Port             string `json:"smtp_port"`
 	Username         string `json:"smtp_username"`
+	IsSkipVerify     bool   `json:"is_skip_verify"`
 }
 
 // @Summary 获取 SMTP 配置
@@ -101,6 +106,7 @@ func GetSMTPConfiguration(c echo.Context) error {
 			Host:             smtpC.Host,
 			Port:             smtpC.Port,
 			Username:         smtpC.Username,
+			IsSkipVerify:     smtpC.IsSkipVerify,
 		},
 	})
 }

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -12354,6 +12354,9 @@ var doc = `{
                 "enable_smtp_notify": {
                     "type": "boolean"
                 },
+                "is_skip_verify": {
+                    "type": "boolean"
+                },
                 "smtp_host": {
                     "type": "string"
                 },
@@ -13126,6 +13129,9 @@ var doc = `{
             "type": "object",
             "properties": {
                 "enable_smtp_notify": {
+                    "type": "boolean"
+                },
+                "is_skip_verify": {
                     "type": "boolean"
                 },
                 "smtp_host": {

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -12338,6 +12338,9 @@
                 "enable_smtp_notify": {
                     "type": "boolean"
                 },
+                "is_skip_verify": {
+                    "type": "boolean"
+                },
                 "smtp_host": {
                     "type": "string"
                 },
@@ -13110,6 +13113,9 @@
             "type": "object",
             "properties": {
                 "enable_smtp_notify": {
+                    "type": "boolean"
+                },
+                "is_skip_verify": {
                     "type": "boolean"
                 },
                 "smtp_host": {

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -2678,6 +2678,8 @@ definitions:
     properties:
       enable_smtp_notify:
         type: boolean
+      is_skip_verify:
+        type: boolean
       smtp_host:
         type: string
       smtp_port:
@@ -3198,6 +3200,8 @@ definitions:
   v1.UpdateSMTPConfigurationReqV1:
     properties:
       enable_smtp_notify:
+        type: boolean
+      is_skip_verify:
         type: boolean
       smtp_host:
         example: smtp.email.qq.com

--- a/sqle/model/configuration.go
+++ b/sqle/model/configuration.go
@@ -25,6 +25,7 @@ type SMTPConfiguration struct {
 	Username         string       `json:"smtp_username" gorm:"column:smtp_username; not null"`
 	Password         string       `json:"-" gorm:"-"`
 	SecretPassword   string       `json:"secret_smtp_password" gorm:"column:secret_smtp_password; not null"`
+	IsSkipVerify     bool         `json:"is_skip_verify" gorm:"default:false; not null"`
 }
 
 func (i *SMTPConfiguration) TableName() string {

--- a/sqle/notification/email.go
+++ b/sqle/notification/email.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strconv"
 	"strings"
@@ -56,6 +57,9 @@ func (n *EmailNotifier) Notify(notification Notification, users []*model.User) e
 
 	port, _ := strconv.Atoi(smtpC.Port)
 	dialer := gomail.NewDialer(smtpC.Host, port, smtpC.Username, smtpC.Password)
+	if smtpC.IsSkipVerify {
+		dialer.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	if err := dialer.DialAndSend(message); err != nil {
 		return fmt.Errorf("send email to %v error: %v", emails, err)
 	}


### PR DESCRIPTION
#1365 
feat:
1. 为表global_configuration_smtp增加字段is_skip_verify
2. 修改/v1/configurations/smtp [get] 和 /v1/configurations/smtp [patch] 接口
3. 发送邮件Notify函数支持跳过认证