### PR TITLE
fix: 修复action.task 对象中状态没有更新的问题

### DIFF
--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -406,6 +406,8 @@ func (a *action) execute() (err error) {
 	a.entry.WithField("task_status", taskStatus).
 		Infof("execution is completed, err:%v", err)
 
+	a.task.Status = taskStatus
+
 	attrs = map[string]interface{}{
 		"status":      taskStatus,
 		"exec_end_at": time.Now(),

--- a/sqle/server/workflow_schedule.go
+++ b/sqle/server/workflow_schedule.go
@@ -142,15 +142,19 @@ func ExecuteWorkflow(workflow *model.Workflow, needExecTaskIdToUserId map[uint]u
 		go func() {
 			sqledServer := GetSqled()
 			task, err := sqledServer.AddTaskWaitResult(strconv.Itoa(int(id)), ActionTypeExecute)
+
+			{ // NOTE: Update the workflow status before sending notifications to ensure that the notification content reflects the latest information.
+				lock.Lock()
+				updateStatus(s, workflow, l)
+				lock.Unlock()
+			}
+
 			if err != nil || task.Status == model.TaskStatusExecuteFailed {
 				go notification.NotifyWorkflow(fmt.Sprintf("%v", workflow.ID), notification.WorkflowNotifyTypeExecuteFail)
 			} else {
 				go notification.NotifyWorkflow(fmt.Sprintf("%v", workflow.ID), notification.WorkflowNotifyTypeExecuteSuccess)
 			}
 
-			lock.Lock()
-			updateStatus(s, workflow, l)
-			lock.Unlock()
 		}()
 	}
 

--- a/sqle/utils/func_test.go
+++ b/sqle/utils/func_test.go
@@ -11,19 +11,19 @@ import (
 )
 
 func elapsedFunc(s int, e error) error {
-	time.Sleep(time.Millisecond * time.Duration(s))
+	time.Sleep(time.Second * time.Duration(s))
 	return e
 }
 
 var errTestMsg = errors.New("test err message")
 
 func cancelFn(cancel context.CancelFunc, timeout int) {
-	time.Sleep(time.Millisecond * time.Duration(timeout))
+	time.Sleep(time.Second * time.Duration(timeout))
 	cancel()
 }
 
 func getTimeoutCtx(timeout int) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), time.Millisecond*time.Duration(timeout))
+	return context.WithTimeout(context.Background(), time.Second*time.Duration(timeout))
 }
 
 func TestAsyncCallTimeout(t *testing.T) {


### PR DESCRIPTION
fix:
- 修复在上线完成后，action.task.status 字段没有及时更新的问题。
  #1519 

- 在通知之前更新工单状态，以确保通知内容为最新内容
  #450 

test:
- 调整测试用例的时间，以确保 cancel 发生的时间的准确性。

