### PR TITLE
fix(mysql_rule): 调整检查selec where子句中绑定变量的方式

### DIFF
--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5719,7 +5719,9 @@ func checkAffectedRows(input *RuleHandlerInput) error {
 	return nil
 }
 
-// NOTE: ParamMarkerExpr is actually "?"
+// NOTE: ParamMarkerExpr is actually "?".
+// ref: https://docs.pingcap.com/zh/tidb/dev/expression-syntax#%E8%A1%A8%E8%BE%BE%E5%BC%8F%E8%AF%AD%E6%B3%95-expression-syntax
+// ref: https://github.com/pingcap/tidb/blob/master/types/parser_driver/value_expr.go#L247
 func checkPrepareStatementPlaceholders(input *RuleHandlerInput) error {
 
 	placeholdersCount := 0

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5719,6 +5719,7 @@ func checkAffectedRows(input *RuleHandlerInput) error {
 	return nil
 }
 
+// NOTE: ParamMarkerExpr is actually "?"
 func checkPrepareStatementPlaceholders(input *RuleHandlerInput) error {
 
 	placeholdersCount := 0
@@ -5730,7 +5731,7 @@ func checkPrepareStatementPlaceholders(input *RuleHandlerInput) error {
 		if whereStmt, ok := stmt.Where.(*ast.PatternInExpr); ok && stmt.Where != nil {
 			for i := range whereStmt.List {
 				item := whereStmt.List[i]
-				if _, ok := item.(*parserdriver.ParamMarkerExpr); ok { // ParamMarkerExpr is actually "?"
+				if _, ok := item.(*parserdriver.ParamMarkerExpr); ok {
 					placeholdersCount++
 				}
 			}
@@ -5774,7 +5775,7 @@ func checkPrepareStatementPlaceholders(input *RuleHandlerInput) error {
 		for i := range stmt.Lists {
 			for j := range stmt.Lists[i] {
 				item := stmt.Lists[i][j]
-				if _, ok := item.(*parserdriver.ParamMarkerExpr); ok { // ParamMarkerExpr is actually "?"
+				if _, ok := item.(*parserdriver.ParamMarkerExpr); ok {
 					placeholdersCount++
 				}
 			}


### PR DESCRIPTION
参考文档：

- https://github.com/pingcap/tidb/blob/master/types/parser_driver/value_expr.go#L247
- https://docs.pingcap.com/zh/tidb/dev/expression-syntax#%E8%A1%A8%E8%BE%BE%E5%BC%8F%E8%AF%AD%E6%B3%95-expression-syntax

related: #1432 #1447 