### PR TITLE
fix-issue1758: create audit plan failed

### DIFF
--- a/sqle/api/controller/v1/audit_plan.go
+++ b/sqle/api/controller/v1/audit_plan.go
@@ -318,7 +318,7 @@ func CreateAuditPlan(c echo.Context) error {
 
 	// generate token
 	// 为了控制JWT Token的长度，保证其长度不超过数据表定义的长度上限(255字符)
-	// 因此使用MD5算法将变长的 currentUserName 和 Name 转换为到固定长度
+	// 因此使用MD5算法将变长的 currentUserName 和 Name 转换为固定长度
 	j := utils.NewJWT(utils.JWTSecretKey)
 	t, err := j.CreateToken(utils.Md5(currentUserName), time.Now().Add(tokenExpire).Unix(),
 		utils.WithAuditPlanName(utils.Md5(req.Name)))

--- a/sqle/api/controller/v1/audit_plan.go
+++ b/sqle/api/controller/v1/audit_plan.go
@@ -317,6 +317,8 @@ func CreateAuditPlan(c echo.Context) error {
 	}
 
 	// generate token
+	// 为了控制JWT Token的长度，保证其长度不超过数据表定义的长度上限(255字符)
+	// 因此使用MD5算法将变长的 currentUserName 和 Name 转换为到固定长度
 	j := utils.NewJWT(utils.JWTSecretKey)
 	t, err := j.CreateToken(utils.Md5(currentUserName), time.Now().Add(tokenExpire).Unix(),
 		utils.WithAuditPlanName(utils.Md5(req.Name)))

--- a/sqle/api/controller/v1/audit_plan.go
+++ b/sqle/api/controller/v1/audit_plan.go
@@ -318,8 +318,8 @@ func CreateAuditPlan(c echo.Context) error {
 
 	// generate token
 	j := utils.NewJWT(utils.JWTSecretKey)
-	t, err := j.CreateToken(currentUserName, time.Now().Add(tokenExpire).Unix(),
-		utils.WithAuditPlanName(req.Name))
+	t, err := j.CreateToken(utils.Md5(currentUserName), time.Now().Add(tokenExpire).Unix(),
+		utils.WithAuditPlanName(utils.Md5(req.Name)))
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, errors.New(errors.DataConflict, err))
 	}

--- a/sqle/api/middleware/jwt.go
+++ b/sqle/api/middleware/jwt.go
@@ -64,6 +64,8 @@ func ScannerVerifier() echo.MiddlewareFunc {
 			}
 			projectName := c.Param("project_name")
 			apnInParam := c.Param("audit_plan_name")
+			// 由于对生成的JWT Token的负载使用MD5算法进行预处理，因此在验证的时候也需要对param中的apn使用MD5处理
+			// 为了兼容老版本的JWT Token需要增加不经MD5处理的apnInParam和apnInToken的判断
 			if apnInToken != apnInParam && apnInToken != utils.Md5(apnInParam) {
 				return echo.NewHTTPError(http.StatusInternalServerError, errAuditPlanMisMatch.Error())
 			}

--- a/sqle/api/middleware/jwt.go
+++ b/sqle/api/middleware/jwt.go
@@ -64,7 +64,7 @@ func ScannerVerifier() echo.MiddlewareFunc {
 			}
 			projectName := c.Param("project_name")
 			apnInParam := c.Param("audit_plan_name")
-			if apnInToken != apnInParam || apnInToken != utils.Md5(apnInParam) {
+			if apnInToken != apnInParam && apnInToken != utils.Md5(apnInParam) {
 				return echo.NewHTTPError(http.StatusInternalServerError, errAuditPlanMisMatch.Error())
 			}
 

--- a/sqle/api/middleware/jwt.go
+++ b/sqle/api/middleware/jwt.go
@@ -64,7 +64,7 @@ func ScannerVerifier() echo.MiddlewareFunc {
 			}
 			projectName := c.Param("project_name")
 			apnInParam := c.Param("audit_plan_name")
-			if apnInToken != apnInParam {
+			if apnInToken != utils.Md5(apnInParam) {
 				return echo.NewHTTPError(http.StatusInternalServerError, errAuditPlanMisMatch.Error())
 			}
 

--- a/sqle/api/middleware/jwt.go
+++ b/sqle/api/middleware/jwt.go
@@ -64,7 +64,7 @@ func ScannerVerifier() echo.MiddlewareFunc {
 			}
 			projectName := c.Param("project_name")
 			apnInParam := c.Param("audit_plan_name")
-			if apnInToken != utils.Md5(apnInParam) {
+			if apnInToken != apnInParam || apnInToken != utils.Md5(apnInParam) {
 				return echo.NewHTTPError(http.StatusInternalServerError, errAuditPlanMisMatch.Error())
 			}
 

--- a/sqle/api/middleware/jwt_test.go
+++ b/sqle/api/middleware/jwt_test.go
@@ -146,3 +146,62 @@ func TestScannerVerifier(t *testing.T) {
 		assert.NoError(t, err)
 	}
 }
+
+func TestScannerVerifierIssue1758(t *testing.T) {
+	e := echo.New()
+
+	jwt := utils.NewJWT(utils.JWTSecretKey)
+	apName120 := "aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbb120"
+	projectName := "default"
+	userName := "admin"
+	assert.Equal(t, 120, len(apName120))
+	h := func(c echo.Context) error {
+		return c.HTML(http.StatusOK, "hello, world")
+	}
+
+	mw := ScannerVerifier()
+	newContextFunc := func(token, apName string) (echo.Context, *httptest.ResponseRecorder) {
+		req := httptest.NewRequest(http.MethodGet, "/:audit_plan_name/", nil)
+		req.Header.Set(echo.HeaderAuthorization, token)
+		res := httptest.NewRecorder()
+		ctx := e.NewContext(req, res)
+		ctx.SetParamNames("audit_plan_name", "project_name")
+		ctx.SetParamValues(apName, projectName)
+		return ctx, res
+	}
+	{ // test check success
+		token, err := jwt.CreateToken(utils.Md5(userName), time.Now().Add(1*time.Hour).Unix(), utils.WithAuditPlanName(utils.Md5(apName120)))
+		assert.NoError(t, err)
+
+		mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		assert.NoError(t, err)
+		model.InitMockStorage(mockDB)
+		mock.ExpectQuery("SELECT `audit_plans`.* FROM `audit_plans` LEFT JOIN projects ON projects.id = audit_plans.project_id WHERE `audit_plans`.`deleted_at` IS NULL AND ((projects.name = ? AND audit_plans.name = ?))").
+			WithArgs(projectName, apName120).
+			WillReturnRows(sqlmock.NewRows([]string{"name", "token"}).AddRow(userName, token))
+		mock.ExpectClose()
+
+		ctx, res := newContextFunc(token, apName120) //这里模拟上下文不需要哈希
+		err = mw(h)(ctx)
+		assert.NoError(t, err)
+		assert.Contains(t, res.Body.String(), "hello, world")
+
+		mockDB.Close()
+		err = mock.ExpectationsWereMet()
+		assert.NoError(t, err)
+	}
+	{ // test audit plan name don't match the token
+		token, err := jwt.CreateToken(utils.Md5(userName), time.Now().Add(1*time.Hour).Unix(), utils.WithAuditPlanName(utils.Md5(apName120)))
+		assert.NoError(t, err)
+		ctx, _ := newContextFunc(token, fmt.Sprintf("%s_modified", apName120))
+		err = mw(h)(ctx)
+		assert.Contains(t, err.Error(), errAuditPlanMisMatch.Error())
+	}
+	{ // test unknown token
+		token, err := jwt.CreateToken(utils.Md5(userName), time.Now().Add(1*time.Hour).Unix())
+		assert.NoError(t, err)
+		ctx, _ := newContextFunc(token, apName120)
+		err = mw(h)(ctx)
+		assert.Contains(t, err.Error(), "unknown token")
+	}
+}


### PR DESCRIPTION
#1758 

Details: Create audit plan failed due to the audit plan name being too long. 

Direct reason: The length of the jwt token exceeds the upper limit of varchar(255) defined in the data table, resulting in insert failure. 

Deep reason: The length of apn(audit plan name) is too long, resulting in the generated jwt token being too long. 

Solution: Use MD5 to hash the name and apn that may be too long to make the name and apn for generating each token become fixed-length, thereby controlling the length of the token.

@linxiaotao