### PR TITLE
fix-issue1756: panic in dingTalkRotation function

### DIFF
--- a/sqle/model/configuration.go
+++ b/sqle/model/configuration.go
@@ -507,9 +507,9 @@ func (s *Storage) GetDingTalkInstanceListByWorkflowIDs(workflowIds []uint) ([]Di
 	return dingTalkInstances, nil
 }
 
-// batch update ding_talk_instances'status into canceled by workflow_ids
-func (s *Storage) BatchCancelDingTalkInstance(workflowIds []uint) error {
-	err := s.db.Model(&DingTalkInstance{}).Where("workflow_id IN (?)", workflowIds).Updates(map[string]interface{}{"status": ApproveStatusCancel}).Error
+// batch updates ding_talk_instances'status into input status by workflow_ids, the status should be like ApproveStatusXXX in model package.
+func (s *Storage) BatchUptateStatusOfDingTalkInstance(workflowIds []uint, status string) error {
+	err := s.db.Model(&DingTalkInstance{}).Where("workflow_id IN (?)", workflowIds).Updates(map[string]interface{}{"status": status}).Error
 	if err != nil {
 		return err
 	}

--- a/sqle/model/configuration.go
+++ b/sqle/model/configuration.go
@@ -477,6 +477,7 @@ const (
 	ApproveStatusInitialized = "initialized"
 	ApproveStatusAgree       = "agree"
 	ApproveStatusRefuse      = "refuse"
+	ApproveStatusCancel      = "canceled"
 )
 
 type DingTalkInstance struct {
@@ -495,6 +496,24 @@ func (s *Storage) GetDingTalkInstanceByWorkflowID(workflowId uint) (*DingTalkIns
 		return dti, false, nil
 	}
 	return dti, true, errors.New(errors.ConnectStorageError, err)
+}
+
+func (s *Storage) GetDingTalkInstanceListByWorkflowIDs(workflowIds []uint) ([]DingTalkInstance, error) {
+	var dingTalkInstances []DingTalkInstance
+	err := s.db.Model(&DingTalkInstance{}).Where("workflow_id IN (?)", workflowIds).Find(&dingTalkInstances).Error
+	if err != nil {
+		return nil, err
+	}
+	return dingTalkInstances, nil
+}
+
+// batch update ding_talk_instances'status into canceled by workflow_ids
+func (s *Storage) BatchCancelDingTalkInstance(workflowIds []uint) error {
+	err := s.db.Model(&DingTalkInstance{}).Where("workflow_id IN (?)", workflowIds).Updates(map[string]interface{}{"status": ApproveStatusCancel}).Error
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *Storage) GetDingTalkInstByStatus(status string) ([]DingTalkInstance, error) {

--- a/sqle/pkg/im/im.go
+++ b/sqle/pkg/im/im.go
@@ -219,8 +219,8 @@ func BatchCancelApprove(workflowIds []uint) {
 		newLog.Errorf("get dingtalk instance list by workflowid slice error: %v", err)
 		return
 	}
-	// batch update status
-	err = s.BatchCancelDingTalkInstance(workflowIds)
+	// batch update ding_talk_instances'status into canceled
+	err = s.BatchUptateStatusOfDingTalkInstance(workflowIds, model.ApproveStatusCancel)
 	if err != nil {
 		newLog.Errorf("batch update ding_talk_instances'status into canceled, error: %v", err)
 	}

--- a/sqle/pkg/im/im.go
+++ b/sqle/pkg/im/im.go
@@ -7,6 +7,7 @@ import (
 	"github.com/actiontech/sqle/sqle/log"
 	"github.com/actiontech/sqle/sqle/model"
 	"github.com/actiontech/sqle/sqle/pkg/im/dingding"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -189,14 +190,52 @@ func CancelApprove(workflowID uint) {
 	s := model.GetStorage()
 	dingTalkInst, exist, err := s.GetDingTalkInstanceByWorkflowID(workflowID)
 	if err != nil {
-		newLog.Errorf("get dingtalk instance by workflow step id error: %v", err)
+		newLog.Errorf("get dingtalk instance by workflow id error: %v", err)
 		return
 	}
 	if !exist {
 		newLog.Infof("dingtalk instance not exist, workflow id: %v", workflowID)
 		return
 	}
+	// 如果在钉钉上已经同意或者拒绝<=>dingtalk instance的status不为initialized
+	// 则只修改钉钉工单状态为取消，不调用取消钉钉工单的API
+	if dingTalkInst.Status != model.ApproveStatusInitialized {
+		newLog.Infof("the dingtalk instance cannot be canceled if its status is not initialized, workflow id: %v", workflowID)
+	} else {
+		go DingTalkCancelApprove(s, newLog, dingTalkInst.ApproveInstanceCode)
+	}
+	// 关闭工单需要修改工单下的钉钉工单的状态
+	dingTalkInst.Status = model.ApproveStatusCancel
+	if err := s.Save(&dingTalkInst); err != nil {
+		newLog.Errorf("save ding talk instance error: %v", err)
+	}
+}
 
+func BatchCancelApprove(workflowIds []uint) {
+	newLog := log.NewEntry()
+	s := model.GetStorage()
+	instances, err := s.GetDingTalkInstanceListByWorkflowIDs(workflowIds)
+	if err != nil {
+		newLog.Errorf("get dingtalk instance list by workflowid slice error: %v", err)
+		return
+	}
+	// batch update status
+	err = s.BatchCancelDingTalkInstance(workflowIds)
+	if err != nil {
+		newLog.Errorf("batch update ding_talk_instances'status into canceled, error: %v", err)
+	}
+	for idx, instance := range instances {
+		// 如果在钉钉上已经同意或者拒绝<=>dingtalk instance的status不为initialized
+		// 则只修改钉钉工单状态为取消，不调用取消钉钉工单的API
+		if instances[idx].Status != model.ApproveStatusInitialized {
+			newLog.Infof("the dingtalk instance cannot be canceled if its status is not initialized, workflow id: %v", instance.WorkflowId)
+			continue
+		}
+		go DingTalkCancelApprove(s, newLog, instance.ApproveInstanceCode)
+	}
+}
+
+func DingTalkCancelApprove(s *model.Storage, newLog *logrus.Entry, approveInstanceCode string) {
 	ims, err := s.GetAllIMConfig()
 	if err != nil {
 		newLog.Errorf("get im config error: %v", err)
@@ -215,7 +254,7 @@ func CancelApprove(workflowID uint) {
 				AppSecret: im.AppSecret,
 			}
 
-			if err := dingTalk.CancelApprovalInstance(dingTalkInst.ApproveInstanceCode); err != nil {
+			if err := dingTalk.CancelApprovalInstance(approveInstanceCode); err != nil {
 				newLog.Errorf("cancel dingtalk approval instance error: %v", err)
 				return
 			}


### PR DESCRIPTION
#1756 
direct cause: a panic occurred when accessing a nil pointer while retrieving the workflow.assignee in the dingTalkRotation function.

root cause: the status of the dingtalk instance was not updated when the workflow was canceled. as a result, the dingTalkRotation function, which handled the canceled workflow, filtered by the dingtalk instance whose status was not updated correctly.

solution: update the status of the dingtalk instance to “canceled” in the logic for closing the workflow. this will prevent similar issues from occurring in the future.