### PR TITLE
hot-fix: cannot using hash algo in generate token

### DIFF
--- a/sqle/api/controller/v1/audit_plan.go
+++ b/sqle/api/controller/v1/audit_plan.go
@@ -322,7 +322,7 @@ func CreateAuditPlan(c echo.Context) error {
 	// 为了控制JWT Token的长度，保证其长度不超过数据表定义的长度上限(255字符)
 	// 因此使用MD5算法将变长的 currentUserName 和 Name 转换为固定长度
 	j := utils.NewJWT(utils.JWTSecretKey)
-	t, err := j.CreateToken(utils.Md5(currentUserName), time.Now().Add(tokenExpire).Unix(),
+	t, err := j.CreateToken(currentUserName, time.Now().Add(tokenExpire).Unix(),
 		utils.WithAuditPlanName(utils.Md5(req.Name)))
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, errors.New(errors.DataConflict, err))


### PR DESCRIPTION
#1758 
username in jwt token will be check when http request go throuth middleware and use username to check if user exist, if using md5 algorithm to resize username, the middleware cannot find user by token.

@linxiaotao