### PR TITLE
Fix issue1756 append

### DIFF
--- a/sqle/api/app.go
+++ b/sqle/api/app.go
@@ -374,11 +374,11 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config config.SqleConfi
 	v1Router.GET("/sql_analysis", v1.DirectGetSQLAnalysis)
 
 	// UI
-	e.File("/", "ui/index.html")
-	e.Static("/static", "ui/static")
-	e.File("/favicon.png", "ui/favicon.png")
+	e.File("/", "/home/lxt/dev/sqle/sqle/ui/index.html")
+	e.Static("/static", "/home/lxt/dev/sqle/sqle/ui/static")
+	e.File("/favicon.png", "/home/lxt/dev/sqle/sqle/ui/favicon.png")
 	e.GET("/*", func(c echo.Context) error {
-		return c.File("ui/index.html")
+		return c.File("/home/lxt/dev/sqle/sqle/ui/index.html")
 	})
 
 	address := fmt.Sprintf(":%v", config.SqleServerPort)

--- a/sqle/api/controller/v1/configuration_comm.go
+++ b/sqle/api/controller/v1/configuration_comm.go
@@ -13,7 +13,7 @@ const (
 	LogoUrlBase = "/static/media"
 
 	// LogoDir sqle logo 的本地目录
-	LogoDir = "./ui/static/media"
+	LogoDir = "/home/lxt/dev/sqle/sqle/ui/static/media"
 )
 
 // GetDefaultLogoUrl 获取默认logo的静态资源url

--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -262,7 +262,7 @@ func CancelWorkflowV2(c echo.Context) error {
 			fmt.Errorf("you are not allow to operate the workflow")))
 	}
 
-	go im.BatchCancelApprove([]uint{workflow.ID}, user)
+	im.BatchCancelApprove([]uint{workflow.ID}, user)
 
 	workflow.Record.Status = model.WorkflowStatusCancel
 	workflow.Record.CurrentWorkflowStepId = 0
@@ -335,7 +335,7 @@ func BatchCancelWorkflowsV2(c echo.Context) error {
 		workflow.Record.CurrentWorkflowStepId = 0
 	}
 
-	go im.BatchCancelApprove(workflowIds, user)
+	im.BatchCancelApprove(workflowIds, user)
 
 	if err := model.GetStorage().BatchUpdateWorkflowStatus(workflows); err != nil {
 		return controller.JSONBaseErrorReq(c, err)

--- a/sqle/cmd/sqled/sqled.go
+++ b/sqle/cmd/sqled/sqled.go
@@ -17,7 +17,7 @@ import (
 var version string
 var port int
 
-//var user string
+// var user string
 var mysqlUser string
 var mysqlPass string
 var mysqlHost string
@@ -80,6 +80,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	var cfg = &config.Config{}
 
 	// read config from file first, then read from cmd args.
+	configPath = "/home/lxt/dev/sqle/.vscode/config.yaml"
 	if configPath != "" {
 		b, err := ioutil.ReadFile(configPath)
 		if err != nil {


### PR DESCRIPTION
#1756 

method im.BatchCancelApprove() will UPDATE dingtalk_instance, and method BatchUpdateWorkflowStatus() will UPDATE workflow, which after the former, should wait for it.
if we use go im.BatchCancelApprove(), we cannot see the order in which the two functions are executed.
so we cancel the using of goroutine on method im.BatchCancelApprove()

@linxiaotao