### PR TITLE
fix-issue1756: cancel using goroutine

### DIFF
--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -262,7 +262,7 @@ func CancelWorkflowV2(c echo.Context) error {
 			fmt.Errorf("you are not allow to operate the workflow")))
 	}
 
-	go im.BatchCancelApprove([]uint{workflow.ID}, user)
+	im.BatchCancelApprove([]uint{workflow.ID}, user)
 
 	workflow.Record.Status = model.WorkflowStatusCancel
 	workflow.Record.CurrentWorkflowStepId = 0
@@ -335,7 +335,7 @@ func BatchCancelWorkflowsV2(c echo.Context) error {
 		workflow.Record.CurrentWorkflowStepId = 0
 	}
 
-	go im.BatchCancelApprove(workflowIds, user)
+	im.BatchCancelApprove(workflowIds, user)
 
 	if err := model.GetStorage().BatchUpdateWorkflowStatus(workflows); err != nil {
 		return controller.JSONBaseErrorReq(c, err)


### PR DESCRIPTION
#1756 

method im.BatchCancelApprove() will UPDATE dingtalk_instance, and method BatchUpdateWorkflowStatus() will UPDATE workflow, which after the former, should wait for it.
if we use go im.BatchCancelApprove(), we cannot see the order in which the two functions are executed.
so we cancel the using of goroutine on method im.BatchCancelApprove()

@LinXiaoTao