### PR TITLE
fix: small probability of causing panic

### DIFF
--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -262,8 +262,6 @@ func CancelWorkflowV2(c echo.Context) error {
 			fmt.Errorf("you are not allow to operate the workflow")))
 	}
 
-	go im.BatchCancelApprove([]uint{workflow.ID}, user)
-
 	workflow.Record.Status = model.WorkflowStatusCancel
 	workflow.Record.CurrentWorkflowStepId = 0
 
@@ -271,6 +269,8 @@ func CancelWorkflowV2(c echo.Context) error {
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}
+
+	go im.BatchCancelApprove([]uint{workflow.ID}, user)
 
 	return controller.JSONBaseErrorReq(c, nil)
 }
@@ -335,11 +335,11 @@ func BatchCancelWorkflowsV2(c echo.Context) error {
 		workflow.Record.CurrentWorkflowStepId = 0
 	}
 
-	go im.BatchCancelApprove(workflowIds, user)
-
 	if err := model.GetStorage().BatchUpdateWorkflowStatus(workflows); err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}
+
+	go im.BatchCancelApprove(workflowIds, user)
 
 	return controller.JSONBaseErrorReq(c, nil)
 }

--- a/sqle/server/ding_talk.go
+++ b/sqle/server/ding_talk.go
@@ -62,6 +62,10 @@ func (j *DingTalkJob) dingTalkRotation(entry *logrus.Entry) {
 						entry.Errorf("workflow not exist, id: %d", dingTalkInstance.WorkflowId)
 						continue
 					}
+					if workflow.Record.Status == model.WorkflowStatusCancel {
+						entry.Errorf("workflow has cancled skip, id: %d", dingTalkInstance.WorkflowId)
+						continue
+					}
 
 					nextStep := workflow.NextStep()
 
@@ -95,6 +99,10 @@ func (j *DingTalkJob) dingTalkRotation(entry *logrus.Entry) {
 					}
 					if !exist {
 						entry.Errorf("workflow not exist, id: %d", dingTalkInstance.WorkflowId)
+						continue
+					}
+					if workflow.Record.Status == model.WorkflowStatusCancel {
+						entry.Errorf("workflow has cancled skip, id: %d", dingTalkInstance.WorkflowId)
 						continue
 					}
 


### PR DESCRIPTION
#1756 
when canceling the workflow, before the goroutine to cancel dingtalk_instance has been executed, the background scheduled task will obtain and access the closed workflow, causing panic. Solution: Verify its status after obtaining the workflow by the background scheduled task. If it is canceled, the next logic will not be executed

@linxiaotao