### PR TITLE
fix log, field don't add message

### DIFF
--- a/sqle/api/controller/v1/sql_audit.go
+++ b/sqle/api/controller/v1/sql_audit.go
@@ -191,7 +191,7 @@ func DirectAuditFiles(c echo.Context) error {
 		sqls = req.FileContents[0]
 	}
 
-	l := log.NewEntry().WithField("/v2/audit_files", "direct audit files failed")
+	l := log.NewEntry().WithField("api", "[post]/v1/audit_files")
 
 	var instance *model.Instance
 	var exist bool


### PR DESCRIPTION
修复日志打印的问题，”direct audit files failed“ 不应该作为标签，这会让所有后续日志都打印该信息。
```bash
time="2023-09-14T14:16:27+08:00" level=info msg="starting call plugin interface [Audit]" /v2/audit_files="direct audit files failed" plugin=Oracle plugin_version=2 session_id=be1e689c04a2436ab2ecd37cacd2afd2 thread_id=S73
```
