### PR TITLE
fix: extract sqls from xml file only save one

### DIFF
--- a/sqle/api/controller/v1/sql_audit_record.go
+++ b/sqle/api/controller/v1/sql_audit_record.go
@@ -394,9 +394,16 @@ func getSqlsFromGit(c echo.Context) (sqls string, exist bool, err error) {
 				if len(ss) == 0 {
 					return nil
 				}
-				_, err = sqlBuffer.WriteString(ss[0])
-				if err != nil {
-					return fmt.Errorf("gather sqls from xml file failed: %v", err)
+				for i := range ss {
+					if sqlBuffer.Len() > 0 && !strings.HasSuffix(sqlBuffer.String(), ";") {
+						if _, err = sqlBuffer.WriteString(";"); err != nil {
+							return fmt.Errorf("gather sqls from xml file failed: %v", err)
+						}
+					}
+					_, err = sqlBuffer.WriteString(ss[i])
+					if err != nil {
+						return fmt.Errorf("gather sqls from xml file failed: %v", err)
+					}
 				}
 			case strings.HasSuffix(path, ".sql"):
 				content, err := os.ReadFile(path)

--- a/sqle/api/controller/v1/sql_audit_record.go
+++ b/sqle/api/controller/v1/sql_audit_record.go
@@ -394,13 +394,13 @@ func getSqlsFromGit(c echo.Context) (sqls string, exist bool, err error) {
 				if len(ss) == 0 {
 					return nil
 				}
-				for i := range ss {
-					if sqlBuffer.Len() > 0 && !strings.HasSuffix(sqlBuffer.String(), ";") {
-						if _, err = sqlBuffer.WriteString(";"); err != nil {
-							return fmt.Errorf("gather sqls from xml file failed: %v", err)
-						}
+				if sqlBuffer.Len() > 0 && !strings.HasSuffix(sqlBuffer.String(), ";") {
+					if _, err = sqlBuffer.WriteString(";"); err != nil {
+						return fmt.Errorf("gather sqls from xml file failed: %v", err)
 					}
-					_, err = sqlBuffer.WriteString(ss[i])
+				}
+				for i := range ss {
+					_, err = sqlBuffer.WriteString(ss[i] + ";")
 					if err != nil {
 						return fmt.Errorf("gather sqls from xml file failed: %v", err)
 					}


### PR DESCRIPTION
https://github.com/actiontech/sqle-ee/issues/1027

replace the logic of only pushing the first item of the parsed SQL list into the buffer with traversing each SQL and pushing it into the buffer

@winfredLIN