### PR TITLE
fix: incorrect fingerprint algorithm parsing result

### DIFF
--- a/spelling_dict.txt
+++ b/spelling_dict.txt
@@ -433,3 +433,4 @@ tdsql
 unhandled
 mkdir
 msar
+recv

--- a/sqle/cmd/scannerd/scanners/common/common_test.go
+++ b/sqle/cmd/scannerd/scanners/common/common_test.go
@@ -1,0 +1,113 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		input               string
+		expectedFingerPrint string
+	}{
+		{
+			` /*asdassa*/  ROLLBACK        TO/*asdassa*//*asdassa*/ SAVEPOINT/*asdassa*/ sp `,
+			`ROLLBACK TO SAVEPOINT sp`,
+		}, // 未能解析 带有注释
+		{
+			`/*2:4536734829-293874657380*/update sa_sdas_das_dsas set value=12128921313213213213,/*2:4536734829-293874657380*/ dt = current_timestamp() /*2:4536734829-293874657380*/where code = 'qq_sdhaidgs_dsaihdisagdias' and/*2:4536734829-293874657380*/name = 'dsadsadsafasd' and/*2:4536734829-293874657380*/value = 345678945678444444444444567`, "UPDATE `sa_sdas_das_dsas` SET `value`=?, `dt`=CURRENT_TIMESTAMP() WHERE `code`=? AND `name`=? AND `value`=?",
+		}, // 能够解析 带有注释
+		{
+			`/*3456789-:56789*/  /*231456789-2786"@@@*/`,
+			``,
+		}, // 纯注释
+		{
+			"SELECT * FROM /*multiline\ncomment*/table",
+			"SELECT * FROM table",
+		}, // 能够解析 带有多行注释
+		{
+			" /*asdassa*/  ROLLBACK    /*multiline\ncomment*/    TO/*asdassa*//*asdassa*/ SAVEPOINT/*asdassa*/ sp ;",
+			`ROLLBACK TO SAVEPOINT sp`,
+		}, // 未能解析 带有多行注释
+		{
+			"SELECT /**/ * FROM table",
+			"SELECT * FROM table",
+		}, // 能够解析 带有空注释
+		{
+			" /*asdassa*/  ROLLBACK    /**/    TO/*asdassa*//*asdassa*/ SAVEPOINT /*asdassa*/sp ;",
+			`ROLLBACK TO SAVEPOINT sp`,
+		}, // 未能解析 带有空注释
+
+		{
+			"/*comments1 */ select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,UNIONCODE, COLLASTION(CUST_NO), COLLATION(UNIONCODE) from `ndfs`.`com_cust_risk_info` group by CUST_NO,UNIONCODE order by CUST)NO , UNIONCODE",
+			"select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,UNIONCODE, COLLASTION(CUST_NO), COLLATION(UNIONCODE) from `ndfs`.`com_cust_risk_info` group by CUST_NO,UNIONCODE order by CUST)NO , UNIONCODE",
+		}, // 未能解析 带有注释1
+		{
+			"/*comments2 */ select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,UNIONCODE, COLLASTION(CUST_NO), COLLATION(UNIONCODE) from `ndfs`.`com_cust_risk_info` group by CUST_NO,UNIONCODE order by CUST)NO , UNIONCODE",
+			"select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,UNIONCODE, COLLASTION(CUST_NO), COLLATION(UNIONCODE) from `ndfs`.`com_cust_risk_info` group by CUST_NO,UNIONCODE order by CUST)NO , UNIONCODE",
+		}, // 未能解析 带有注释2
+	}
+
+	for _, tc := range testCases {
+		ns, err := Parse(context.TODO(), tc.input)
+		assert.NoError(t, err)
+		if len(ns) > 0 {
+			assert.Equal(t, tc.expectedFingerPrint, ns[0].Fingerprint)
+		}
+		if len(ns) == 0 {
+			assert.Equal(t, tc.expectedFingerPrint, ``)
+		}
+	}
+}
+func TestClearComments(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			"SELECT * FROM table /*comment*/;",
+			"SELECT * FROM table",
+		},
+		{
+			"SELECT * FROM table /*comment1*/ /*comment2*/",
+			"SELECT * FROM table",
+		},
+		{
+			"SELECT /*comment*/ * FROM /*comment*/ table",
+			"SELECT * FROM table",
+		},
+		{
+			"SELECT * /*inline comment*/ FROM table",
+			"SELECT * FROM table",
+		},
+		{
+			"SELECT * FROM /*multiline\ncomment*/table",
+			"SELECT * FROM table",
+		},
+		{
+			"  SELECT *  FROM   table   WHERE   id = /*comment*//*comment1*/1",
+			"SELECT * FROM table WHERE id = 1",
+		},
+		{
+			"SELECT /**/ * FROM table",
+			"SELECT * FROM table",
+		},
+		{
+			"SELECT * FROM table /*inline*/ JOIN other_table /*on id*/ ON table.id = other_table.id",
+			"SELECT * FROM table JOIN other_table ON table.id = other_table.id",
+		},
+		{
+			"  /*comment*/SELECT *  FROM   table   WHERE   id = 1;/*comment*/show tables;/*comment*/other string;other string",
+			"SELECT * FROM table WHERE id = 1",
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := clearComments(tc.input)
+		if actual != tc.expected {
+			t.Errorf("Expected %s, got %s", tc.expected, actual)
+		}
+	}
+}

--- a/sqle/cmd/scannerd/scanners/common/common_test.go
+++ b/sqle/cmd/scannerd/scanners/common/common_test.go
@@ -13,11 +13,11 @@ func TestParse(t *testing.T) {
 		expectedFingerPrint string
 	}{
 		{
-			` /*asdassa*/  ROLLBACK        TO/*asdassa*//*asdassa*/ SAVEPOINT/*asdassa*/ sp `,
-			`ROLLBACK TO SAVEPOINT sp`,
+			` /*some comments*/  ROLLBACK        TO/*some comments*//*some comments*/ savePoint/*some comments*/ sp `,
+			`ROLLBACK TO savePoint sp`,
 		}, // 未能解析 带有注释
 		{
-			`/*2:4536734829-293874657380*/update sa_sdas_das_dsas set value=12128921313213213213,/*2:4536734829-293874657380*/ dt = current_timestamp() /*2:4536734829-293874657380*/where code = 'qq_sdhaidgs_dsaihdisagdias' and/*2:4536734829-293874657380*/name = 'dsadsadsafasd' and/*2:4536734829-293874657380*/value = 345678945678444444444444567`, "UPDATE `sa_sdas_das_dsas` SET `value`=?, `dt`=CURRENT_TIMESTAMP() WHERE `code`=? AND `name`=? AND `value`=?",
+			`/*2:4536734829-293874657380*/update some_value set value=12128921313213213213,/*2:4536734829-293874657380*/ dt = current_timestamp() /*2:4536734829-293874657380*/where code = 'some_value' and/*2:4536734829-293874657380*/name = 'some_value' and/*2:4536734829-293874657380*/value = 345678945678444444444444567`, "UPDATE `some_value` SET `value`=?, `dt`=CURRENT_TIMESTAMP() WHERE `code`=? AND `name`=? AND `value`=?",
 		}, // 能够解析 带有注释
 		{
 			`/*3456789-:56789*/  /*231456789-2786"@@@*/`,
@@ -28,25 +28,25 @@ func TestParse(t *testing.T) {
 			"SELECT * FROM table",
 		}, // 能够解析 带有多行注释
 		{
-			" /*asdassa*/  ROLLBACK    /*multiline\ncomment*/    TO/*asdassa*//*asdassa*/ SAVEPOINT/*asdassa*/ sp ;",
-			`ROLLBACK TO SAVEPOINT sp`,
+			" /*some comments*/  ROLLBACK    /*multiline\ncomment*/    TO/*some comments*//*some comments*/ savePoint/*some comments*/ sp ;",
+			`ROLLBACK TO savePoint sp`,
 		}, // 未能解析 带有多行注释
 		{
 			"SELECT /**/ * FROM table",
 			"SELECT * FROM table",
 		}, // 能够解析 带有空注释
 		{
-			" /*asdassa*/  ROLLBACK    /**/    TO/*asdassa*//*asdassa*/ SAVEPOINT /*asdassa*/sp ;",
-			`ROLLBACK TO SAVEPOINT sp`,
+			" /*some comments*/  ROLLBACK    /**/    TO/*some comments*//*some comments*/ savePoint /*some comments*/sp ;",
+			`ROLLBACK TO savePoint sp`,
 		}, // 未能解析 带有空注释
 
 		{
-			"/*comments1 */ select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,UNIONCODE, COLLASTION(CUST_NO), COLLATION(UNIONCODE) from `ndfs`.`com_cust_risk_info` group by CUST_NO,UNIONCODE order by CUST)NO , UNIONCODE",
-			"select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,UNIONCODE, COLLASTION(CUST_NO), COLLATION(UNIONCODE) from `ndfs`.`com_cust_risk_info` group by CUST_NO,UNIONCODE order by CUST)NO , UNIONCODE",
+			"/*comments1 */ select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,some_code, COLLATION(CUST_NO), COLLATION(some_code) from `table1`.`com_cust_risk_info` group by CUST_NO,some_code order by CUST)NO , some_code",
+			"select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,some_code, COLLATION(CUST_NO), COLLATION(some_code) from `table1`.`com_cust_risk_info` group by CUST_NO,some_code order by CUST)NO , some_code",
 		}, // 未能解析 带有注释1
 		{
-			"/*comments2 */ select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,UNIONCODE, COLLASTION(CUST_NO), COLLATION(UNIONCODE) from `ndfs`.`com_cust_risk_info` group by CUST_NO,UNIONCODE order by CUST)NO , UNIONCODE",
-			"select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,UNIONCODE, COLLASTION(CUST_NO), COLLATION(UNIONCODE) from `ndfs`.`com_cust_risk_info` group by CUST_NO,UNIONCODE order by CUST)NO , UNIONCODE",
+			"/*comments2 */ select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,some_code, COLLATION(CUST_NO), COLLATION(some_code) from `table1`.`com_cust_risk_info` group by CUST_NO,some_code order by CUST)NO , some_code",
+			"select CUST_NO,count(CUST_NO) as `count(CUST_NO)`,some_code, COLLATION(CUST_NO), COLLATION(some_code) from `table1`.`com_cust_risk_info` group by CUST_NO,some_code order by CUST)NO , some_code",
 		}, // 未能解析 带有注释2
 	}
 

--- a/sqle/cmd/scannerd/scanners/common/parse.go
+++ b/sqle/cmd/scannerd/scanners/common/parse.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"context"
+	"regexp"
+	"strings"
 
 	"github.com/actiontech/sqle/sqle/driver/mysql/util"
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
@@ -16,25 +18,42 @@ func Parse(_ context.Context, sqlText string) ([]driverV2.Node, error) {
 		return nil, err
 	}
 
-	ns := make([]driverV2.Node, len(nodes))
+	ns := make([]driverV2.Node, 0, len(nodes))
 	for i := range nodes {
 		n := driverV2.Node{}
-		fingerprint, err := util.Fingerprint(nodes[i].Text(), true)
-		if err != nil {
-			return nil, err
-		}
-		n.Fingerprint = fingerprint
 		n.Text = nodes[i].Text()
 		switch nodes[i].(type) {
+		case *ast.UnparsedStmt:
+			nodes[i].SetText(clearComments(nodes[i].Text()))
+			// TODO https://github.com/actiontech/sqle-ee/issues/1075 未解析节点的类型是未知的，是否应该新增一个unknown类型，作为未解析的SQL的类型
+			n.Type = driverV2.SQLTypeDDL
 		case ast.DMLNode:
 			n.Type = driverV2.SQLTypeDML
 		default:
 			n.Type = driverV2.SQLTypeDDL
 		}
 
-		ns[i] = n
+		n.Fingerprint, err = util.Fingerprint(nodes[i].Text(), true)
+		if err != nil {
+			return nil, err
+		}
+		ns = append(ns, n)
 	}
 	return ns, nil
+}
+
+// TODO https://github.com/actiontech/sqle-ee/issues/1075 这是临时方案的函数，暂时不放到公共工具中
+func clearComments(sqlText string) string {
+	// 将注释替换为一个空格，防止语句粘连
+	sqlText = regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(sqlText, " ")
+	// 去除结尾分号后的内容
+	idx := strings.Index(sqlText, ";")
+	if idx >= 0 {
+		sqlText = sqlText[:idx]
+	}
+	// 去除开头结尾的空格，并且替换中间连续的空格为一个空格
+	sqlText = strings.Join(strings.Fields(sqlText), " ")
+	return sqlText
 }
 
 func ParseSql(sql string) ([]ast.Node, error) {


### PR DESCRIPTION
Problem solved:
1. Upload pure annotations as SQL
2. For unresolved statements, aggregation is not possible

Solution:
1. Modify the condition judgment for the parsing result, and do not upload for cases where the parsing result is not empty but successfully parsed
2. For unresolved statements, process their strings and remove comments,

@winfredLIN