### PR TITLE
fix: dml_check_fuzzy_search rule cannot handle concat function

### DIFF
--- a/sqle/driver/mysql/util/parser_helper.go
+++ b/sqle/driver/mysql/util/parser_helper.go
@@ -409,6 +409,19 @@ func CheckWhereFuzzySearch(where ast.ExprNode) bool {
 					isExist = true
 					return true
 				}
+			case *ast.FuncCallExpr:
+				if pattern.FnName.L == "concat" {
+					if len(pattern.Args) > 0 {
+						switch pattern := pattern.Args[0].(type) {
+						case *driver.ValueExpr:
+							datum := pattern.Datum.GetString()
+							if strings.HasPrefix(datum, "%") || strings.HasPrefix(datum, "_") {
+								isExist = true
+								return true
+							}
+						}
+					}
+				}
 			}
 		}
 		return false


### PR DESCRIPTION
#1917 

add handling in cases where the like pattern type is FuncCallExprd, match function concat, and prefix match its first variable

@WinfredLIN