### PR TITLE
fix: method of optimizer

### DIFF
--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -2621,15 +2621,11 @@ func checkHasJoinCondition(input *RuleHandlerInput) error {
 	return nil
 }
 
-func doesNotJoinTables(tableRefs *ast.Join) bool {
-	return tableRefs.Left == nil || tableRefs.Right == nil
-}
-
 func checkJoinConditionInJoinNode(ctx *session.Context, whereStmt ast.ExprNode, joinNode *ast.Join) (joinTables, hasCondition bool) {
 	if joinNode == nil {
 		return false, false
 	}
-	if doesNotJoinTables(joinNode) {
+	if util.DoesNotJoinTables(joinNode) {
 		// 非JOIN两表的JOIN节点 一般是叶子节点 不检查
 		return false, false
 	}
@@ -2643,24 +2639,16 @@ func checkJoinConditionInJoinNode(ctx *session.Context, whereStmt ast.ExprNode, 
 	}
 
 	// 判断该节点是否有显式声明连接条件
-	if isJoinConditionInOnClause(joinNode) {
+	if util.IsJoinConditionInOnClause(joinNode) {
 		return true, true
 	}
-	if isJoinConditionInUsingClause(joinNode) {
+	if util.IsJoinConditionInUsingClause(joinNode) {
 		return true, true
 	}
 	if isJoinConditionInWhereStmt(ctx, whereStmt, joinNode) {
 		return true, true
 	}
 	return true, false
-}
-
-func isJoinConditionInOnClause(joinNode *ast.Join) bool {
-	return joinNode.On != nil
-}
-
-func isJoinConditionInUsingClause(joinNode *ast.Join) bool {
-	return len(joinNode.Using) > 0
 }
 
 func isJoinConditionInWhereStmt(ctx *session.Context, stmt ast.ExprNode, node *ast.Join) bool {


### PR DESCRIPTION
#1955
### 功能描述
这个方法的功能是解析Select语句中的表，然后放到Optimizer的tables中去
有两种情况：
1. 当Select语句中的表是单表，即非JOIN多表的情形，将对应Select语句放到tables中，如果表有别名，则要将别名也存一份，共两份
2. 当Select语句中的表是JOIN的多表，将表参与连接的列存储到tables中，但不存储Select语句

### 解决三个问题：
1. 对Using的支持不好，没判断空指针，导致panic
2. 获取ON两边的列不达预期，当存在多个表JOIN，并且ON的相同表有两个以上时，只保存最后一个，例如：JOIN .. ON t1.id = t2.id JOIN .. ON t2.name = t3.name 这时候t2保存的列是name 没有id
3. 不支持多JOIN嵌套