### PR TITLE
fix: two questions, involving four rules

### DIFF
--- a/sqle/driver/mysql/audit_offline_test.go
+++ b/sqle/driver/mysql/audit_offline_test.go
@@ -84,71 +84,128 @@ DROP INDEX IF EXISTS idx_2 ON exist_db.exist_tb_1;
 }
 
 func TestCheckWhereInvalidOffline(t *testing.T) {
+	// results in this unit test
+	noResult := newTestResult()
+	whereIsInvalid := newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid)
+	// the rule this unit test test
 	rule := rulepkg.RuleHandlerMap[rulepkg.DMLCheckWhereIsInvalid].Rule
-	runSingleRuleInspectCase(rule, t, "select_from: has where condition", DefaultMysqlInspectOffline(),
-		"select id from exist_db.exist_tb_1 where id > 1;",
-		newTestResult(),
-	)
 
-	runSingleRuleInspectCase(rule, t, "select_from: no where condition(1)", DefaultMysqlInspectOffline(),
-		"select id from exist_db.exist_tb_1;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid),
-	)
-
-	runSingleRuleInspectCase(rule, t, "select_from: no where condition(2)", DefaultMysqlInspectOffline(),
-		"select id from exist_db.exist_tb_1 where 1=1 and 2=2;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid),
-	)
-
-	runSingleRuleInspectCase(rule, t, "select_from: no where condition(3)", DefaultMysqlInspectOffline(),
-		"select id from exist_db.exist_tb_1 where id=id;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid),
-	)
-
-	runSingleRuleInspectCase(rule, t, "select_from: no where condition(4)", DefaultMysqlInspectOffline(),
-		"select id from exist_db.exist_tb_1 where exist_tb_1.id=exist_tb_1.id;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid),
-	)
-
-	runSingleRuleInspectCase(rule, t, "update: has where condition", DefaultMysqlInspectOffline(),
-		"update exist_db.exist_tb_1 set v1='v1' where id = 1;",
-		newTestResult())
-
-	runSingleRuleInspectCase(rule, t, "update: no where condition(1)", DefaultMysqlInspectOffline(),
-		"update exist_db.exist_tb_1 set v1='v1';",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid))
-
-	runSingleRuleInspectCase(rule, t, "update: no where condition(2)", DefaultMysqlInspectOffline(),
-		"update exist_db.exist_tb_1 set v1='v1' where 1=1 and 2=2;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid))
-
-	runSingleRuleInspectCase(rule, t, "update: no where condition(3)", DefaultMysqlInspectOffline(),
-		"update exist_db.exist_tb_1 set v1='v1' where id=id;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid))
-
-	runSingleRuleInspectCase(rule, t, "update: no where condition(4)", DefaultMysqlInspectOffline(),
-		"update exist_db.exist_tb_1 set v1='v1' where exist_tb_1.id=exist_tb_1.id;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid))
-
-	runSingleRuleInspectCase(rule, t, "delete: has where condition", DefaultMysqlInspectOffline(),
-		"delete from exist_db.exist_tb_1 where id = 1;",
-		newTestResult())
-
-	runSingleRuleInspectCase(rule, t, "delete: no where condition(1)", DefaultMysqlInspectOffline(),
-		"delete from exist_db.exist_tb_1;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid))
-
-	runSingleRuleInspectCase(rule, t, "delete: no where condition(2)", DefaultMysqlInspectOffline(),
-		"delete from exist_db.exist_tb_1 where 1=1 and 2=2;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid))
-
-	runSingleRuleInspectCase(rule, t, "delete: no where condition(3)", DefaultMysqlInspectOffline(),
-		"delete from exist_db.exist_tb_1 where 1=1 and id=id;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid))
-
-	runSingleRuleInspectCase(rule, t, "delete: no where condition(4)", DefaultMysqlInspectOffline(),
-		"delete from exist_db.exist_tb_1 where 1=1 and exist_tb_1.id=exist_tb_1.id;",
-		newTestResult().addResult(rulepkg.DMLCheckWhereIsInvalid))
+	testCases := []struct {
+		testName string
+		sql      string
+		result   *testResult
+	}{
+		// WHERE
+		{
+			"select_from: has where condition",
+			"select id from exist_db.exist_tb_1 where id > 1;",
+			noResult,
+		},
+		{
+			"select_from: no where condition(1)",
+			"select id from exist_db.exist_tb_1;",
+			whereIsInvalid,
+		},
+		{
+			"select_from: no where condition(2)",
+			"select id from exist_db.exist_tb_1 where 1=1 and 2=2;",
+			whereIsInvalid,
+		},
+		{
+			"select_from: no where condition(3)",
+			"select id from exist_db.exist_tb_1 where id=id;",
+			whereIsInvalid,
+		},
+		{
+			"select_from: no where condition(4)",
+			"select id from exist_db.exist_tb_1 where exist_tb_1.id=exist_tb_1.id;",
+			whereIsInvalid,
+		},
+		{
+			"select_from: no where condition(5)",
+			"select id from (select * from exist_db.exist_tb_1 where exist_tb_1.id=exist_tb_1.id) t;",
+			whereIsInvalid,
+		},
+		{
+			"select_from: no where condition(6)",
+			"select id from (select * from exist_db.exist_tb_1 where exist_tb_1.id>1) t;",
+			noResult,
+		},
+		// UPDATE
+		{
+			"update: has where condition",
+			"update exist_db.exist_tb_1 set v1='v1' where id = 1;",
+			noResult,
+		},
+		{
+			"update: no where condition(1)",
+			"update exist_db.exist_tb_1 set v1='v1';",
+			whereIsInvalid,
+		},
+		{
+			"update: no where condition(2)",
+			"update exist_db.exist_tb_1 set v1='v1' where 1=1 and 2=2;",
+			whereIsInvalid,
+		},
+		{
+			"update: no where condition(3)",
+			"update exist_db.exist_tb_1 set v1='v1' where id=id;",
+			whereIsInvalid,
+		},
+		{
+			"update: no where condition(4)",
+			"update exist_db.exist_tb_1 set v1='v1' where exist_tb_1.id=exist_tb_1.id;", whereIsInvalid,
+		},
+		{
+			"update: has where condition(5)",
+			"update exist_db.exist_tb_1 set v1=v1 = v1 * (SELECT AVG(id) FROM exist_db.exist_tb_1 WHERE v1=1)/100 where id = 1;",
+			noResult,
+		},
+		{
+			"update: has where condition(6)",
+			"update exist_db.exist_tb_1 set v1=v1 = v1 * (SELECT AVG(id) FROM exist_db.exist_tb_1 WHERE exist_tb_1.id=exist_tb_1.id)/100 where id = 1;",
+			whereIsInvalid,
+		},
+		// DELETE
+		{
+			"delete: has where condition",
+			"delete from exist_db.exist_tb_1 where id = 1;",
+			noResult,
+		},
+		{
+			"delete: no where condition(1)",
+			"delete from exist_db.exist_tb_1;",
+			whereIsInvalid,
+		},
+		{
+			"delete: no where condition(2)",
+			"delete from exist_db.exist_tb_1 where 1=1 and 2=2;",
+			whereIsInvalid,
+		},
+		{
+			"update: no where condition(3)",
+			"delete from exist_db.exist_tb_1 where 1=1 and id=id;",
+			whereIsInvalid,
+		},
+		{
+			"update: no where condition(4)",
+			"delete from exist_db.exist_tb_1 where 1=1 and exist_tb_1.id=exist_tb_1.id;", whereIsInvalid,
+		},
+		{
+			"delete: has where condition(5)",
+			"delete from exist_db.exist_tb_1 USING (SELECT * FROM exist_db.exist_tb_1 WHERE v1='v1') t WHERE t.id > 10;",
+			noResult,
+		},
+		{
+			"delete: has where condition(6)",
+			"delete from exist_db.exist_tb_1 USING (SELECT * FROM exist_db.exist_tb_1 WHERE exist_tb_1.id=exist_tb_1.id) t WHERE t.id > 10;",
+			whereIsInvalid,
+		},
+	}
+	offlineInspect := DefaultMysqlInspectOffline()
+	for _, testCase := range testCases {
+		runSingleRuleInspectCase(rule, t, testCase.testName, offlineInspect, testCase.sql, testCase.result)
+	}
 }
 
 func TestCheckWhereInvalid_FPOffline(t *testing.T) {
@@ -1172,6 +1229,12 @@ select v1 from exist_db.exist_tb_1 where v2 <> "3";
 `,
 		newTestResult().addResult(rulepkg.DMLCheckWhereExistNot),
 	)
+	runSingleRuleInspectCase(rule, t, "select: check where exist <> ", DefaultMysqlInspectOffline(),
+		`
+		select v1 from (select * from exist_db.exist_tb_1 where v2 <> "3") t;
+		`,
+		newTestResult().addResult(rulepkg.DMLCheckWhereExistNot),
+	)
 	runSingleRuleInspectCase(rule, t, "select: check where exist not like ", DefaultMysqlInspectOffline(),
 		`
 select v1 from exist_db.exist_tb_1 where v2 not like "%3%";
@@ -1301,11 +1364,41 @@ select v1 from exist_db.exist_tb_1 where v1 in (select v1 from  exist_db.exist_t
 `,
 		newTestResult().addResult(rulepkg.DMLCheckWhereExistScalarSubquery),
 	)
+	runSingleRuleInspectCase(rule, t, "select: check where exist scalar sub queries", DefaultMysqlInspectOffline(),
+		`
+	select v1 from (select v1 from exist_db.exist_tb_1 where v1 in (select v1 from  exist_db.exist_tb_2)) t;
+	`,
+		newTestResult().addResult(rulepkg.DMLCheckWhereExistScalarSubquery),
+	)
 	runSingleRuleInspectCase(rule, t, "select: passing the check where exist scalar sub queries", DefaultMysqlInspectOffline(),
 		`
 select a.v1 from exist_db.exist_tb_1 a, exist_db.exist_tb_2 b  where a.v1 = b.v1 ;
 `,
 		newTestResult(),
+	)
+	// FIXME 子查询 (SELECT COUNT(*) FROM orders WHERE customer_id = customers.customer_id) 返回了每个客户的订单数量，并作为查询结果集中的一个列使用。这个子查询是一个标量子查询，因为它只返回一个值，即每个客户的订单数量。
+	runSingleRuleInspectCase(rule, t, "select: passing the check where exist scalar sub queries", DefaultMysqlInspectOffline(),
+		`
+		SELECT customer_name, (SELECT COUNT(*) FROM orders WHERE customer_id = customers.customer_id) AS order_count FROM customers;
+		`,
+		newTestResult(),
+		// newTestResult().addResult(rulepkg.DMLCheckWhereExistScalarSubquery),
+	)
+	// FIXME same with above
+	runSingleRuleInspectCase(rule, t, "select: passing the check where exist scalar sub queries", DefaultMysqlInspectOffline(),
+		`
+		SELECT customer_name, (SELECT MAX(age) FROM students) AS student_count FROM customers;
+		`,
+		newTestResult(),
+		// newTestResult().addResult(rulepkg.DMLCheckWhereExistScalarSubquery),
+	)
+	// FIXME same with above
+	runSingleRuleInspectCase(rule, t, "select: passing the check where exist scalar sub queries", DefaultMysqlInspectOffline(),
+		`
+		SELECT EXISTS(SELECT 1 FROM customers WHERE customer_name = 'John Doe');
+		`,
+		newTestResult(),
+		// newTestResult().addResult(rulepkg.DMLCheckWhereExistScalarSubquery),
 	)
 }
 
@@ -1747,6 +1840,8 @@ func TestCheckFuzzySearchOffline(t *testing.T) {
 		`SELECT * FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '%a';`,
 		`SELECT * FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '%a%';`,
 		`SELECT * FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '_a';`,
+		`SELECT * FROM (SELECT * FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '_a') t;`,
+		`SELECT * FROM (SELECT * FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '%a') t;`,
 
 		`UPDATE exist_db.exist_tb_1 SET id = 1 WHERE v1 LIKE '%a%';`,
 		`UPDATE exist_db.exist_tb_1 SET id = 1 WHERE v1 LIKE '%a';`,
@@ -1754,6 +1849,8 @@ func TestCheckFuzzySearchOffline(t *testing.T) {
 		`UPDATE exist_db.exist_tb_1 SET id = 1 WHERE v1 NOT LIKE '%a';`,
 		`UPDATE exist_db.exist_tb_1 SET id = 1 WHERE v1 NOT LIKE '%a%';`,
 		`UPDATE exist_db.exist_tb_1 SET id = 1 WHERE v1 NOT LIKE '_a';`,
+		`UPDATE exist_db.exist_tb_1 SET v1 = v1 * (SELECT AVG(id) FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '%a')/100;`,
+		`UPDATE exist_db.exist_tb_1 SET v1 = v1 * (SELECT AVG(id) FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '_a')/100;`,
 
 		`DELETE FROM exist_db.exist_tb_1 WHERE v1 LIKE '%a%';`,
 		`DELETE FROM exist_db.exist_tb_1 WHERE v1 LIKE '%a';`,
@@ -1761,6 +1858,7 @@ func TestCheckFuzzySearchOffline(t *testing.T) {
 		`DELETE FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '%a';`,
 		`DELETE FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '%a%';`,
 		`DELETE FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE '_a';`,
+		`DELETE FROM exist_db.exist_tb_1 USING (SELECT * FROM exist_db.exist_tb_1 WHERE v1 LIKE '%a%') t WHERE t.id = exist_db.exist_tb_1.id;`,
 	} {
 		runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DMLCheckFuzzySearch].Rule, t, "", DefaultMysqlInspectOffline(), sql, newTestResult().addResult(rulepkg.DMLCheckFuzzySearch))
 	}
@@ -1768,12 +1866,15 @@ func TestCheckFuzzySearchOffline(t *testing.T) {
 	for _, sql := range []string{
 		`SELECT * FROM exist_db.exist_tb_1 WHERE v1 LIKE 'a%';`,
 		`SELECT * FROM exist_db.exist_tb_1 WHERE v1 LIKE 'a___';`,
+		`SELECT * FROM (SELECT * FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE 'a_') t;`,
 
 		`UPDATE exist_db.exist_tb_1 SET id = 1 WHERE v1 LIKE 'a%';`,
 		`UPDATE exist_db.exist_tb_1 SET id = 1 WHERE v1 LIKE 'a___';`,
+		`UPDATE exist_db.exist_tb_1 SET v1 = v1 * (SELECT AVG(id) FROM exist_db.exist_tb_1 WHERE v1 NOT LIKE 'a_')/100;`,
 
 		`DELETE FROM exist_db.exist_tb_1 WHERE v1 LIKE 'a%';`,
 		`DELETE FROM exist_db.exist_tb_1 WHERE v1 LIKE 'a____';`,
+		`DELETE FROM exist_db.exist_tb_1 USING (SELECT * FROM exist_db.exist_tb_1 WHERE v1 LIKE 'a%') t WHERE t.id = exist_db.exist_tb_1.id;`,
 	} {
 		runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DMLCheckFuzzySearch].Rule, t, "", DefaultMysqlInspectOffline(), sql, newTestResult())
 	}

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -3144,34 +3144,39 @@ func checkSelectWhere(input *RuleHandlerInput) error {
 }
 
 func checkWhere(rule driverV2.Rule, res *driverV2.AuditResults, whereList []ast.ExprNode) {
-	if len(whereList) == 0 {
-		addResult(res, rule, DMLCheckWhereIsInvalid)
-	}
-	for _, where := range whereList {
-		if !util.WhereStmtHasOneColumn(where) {
+	switch rule.Name {
+	case DMLCheckWhereIsInvalid:
+		if len(whereList) == 0 {
 			addResult(res, rule, DMLCheckWhereIsInvalid)
-			break
+		}
+		for _, where := range whereList {
+			if !util.WhereStmtHasOneColumn(where) {
+				addResult(res, rule, DMLCheckWhereIsInvalid)
+				break
+			}
+		}
+	case DMLCheckWhereExistNot:
+		for _, where := range whereList {
+			if util.WhereStmtExistNot(where) {
+				addResult(res, rule, DMLCheckWhereExistNot)
+				break
+			}
+		}
+	case DMLCheckWhereExistScalarSubquery:
+		for _, where := range whereList {
+			if util.WhereStmtExistScalarSubQueries(where) {
+				addResult(res, rule, DMLCheckWhereExistScalarSubquery)
+				break
+			}
+		}
+	case DMLCheckFuzzySearch:
+		for _, where := range whereList {
+			if util.CheckWhereFuzzySearch(where) {
+				addResult(res, rule, DMLCheckFuzzySearch)
+				break
+			}
 		}
 	}
-	for _, where := range whereList {
-		if util.WhereStmtExistNot(where) {
-			addResult(res, rule, DMLCheckWhereExistNot)
-			break
-		}
-	}
-	for _, where := range whereList {
-		if util.WhereStmtExistScalarSubQueries(where) {
-			addResult(res, rule, DMLCheckWhereExistScalarSubquery)
-			break
-		}
-	}
-	for _, where := range whereList {
-		if util.CheckWhereFuzzySearch(where) {
-			addResult(res, rule, DMLCheckFuzzySearch)
-			break
-		}
-	}
-
 }
 func checkWhereExistNull(input *RuleHandlerInput) error {
 	if where := getWhereExpr(input.Node); where != nil {

--- a/sqle/driver/mysql/util/function_result_generator.go
+++ b/sqle/driver/mysql/util/function_result_generator.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/pingcap/parser/ast"
+	driver "github.com/pingcap/tidb/types/parser_driver"
+)
+
+/*
+FuncCallStringResultGenerator:
+
+ 1. Process the *ast.FuncCallExpr node and return the corresponding result
+ 2. Support functions in MySQL document: string functions
+ 3. Support function nesting
+
+https://dev.mysql.com/doc/refman/8.0/en/string-functions.html
+*/
+type FuncCallStringResultGenerator interface {
+	GenerateResult() string // returns an empty string when encounter an unsupported function
+}
+
+func NewFuncCallStringResultGenerator(funcCall *ast.FuncCallExpr) FuncCallStringResultGenerator {
+	switch funcCall.FnName.L {
+	case "concat":
+		return &ConCatFunc{ConCat: funcCall}
+	case "upper":
+		return &UpperFunc{Upper: funcCall}
+	default:
+		return &UnsupportFunc{}
+	}
+}
+
+type UnsupportFunc struct {
+	Unsupport *ast.FuncCallExpr
+}
+
+func (f *UnsupportFunc) GenerateResult() string {
+	return ""
+}
+
+// https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_concat
+type ConCatFunc struct {
+	ConCat *ast.FuncCallExpr
+}
+
+func (f *ConCatFunc) GenerateResult() string {
+	var result string
+	for _, arg := range f.ConCat.Args {
+		switch pattern := arg.(type) {
+		case *driver.ValueExpr:
+			result += pattern.Datum.GetString()
+		case *ast.FuncCallExpr:
+			result += NewFuncCallStringResultGenerator(pattern).GenerateResult()
+		}
+	}
+	return result
+}
+
+// https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_upper
+type UpperFunc struct {
+	Upper *ast.FuncCallExpr
+}
+
+func (f *UpperFunc) GenerateResult() string {
+	if len(f.Upper.Args) > 0 {
+		switch pattern := f.Upper.Args[0].(type) {
+		case *driver.ValueExpr:
+			return strings.ToUpper(pattern.Datum.GetString())
+		case *ast.FuncCallExpr:
+			return strings.ToUpper(NewFuncCallStringResultGenerator(pattern).GenerateResult())
+		}
+	}
+	return ""
+}

--- a/sqle/driver/mysql/util/function_result_generator_test.go
+++ b/sqle/driver/mysql/util/function_result_generator_test.go
@@ -1,0 +1,74 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/pingcap/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConCatFunc(t *testing.T) {
+	testCases := []struct {
+		SQL          string
+		ExpectResult string
+	}{
+		{
+			SQL:          "SELECT CONCAT('a','b','c');",
+			ExpectResult: "abc",
+		},
+		{
+			SQL:          "SELECT CONCAT('a_',UPPER('b'),'_c');",
+			ExpectResult: "a_B_c",
+		},
+		{
+			SQL:          "SELECT CONCAT(CONCAT('a_',UPPER('b'),'_c'),'_','a_',UPPER('b'),'_c');",
+			ExpectResult: "a_B_c_a_B_c",
+		},
+	}
+	conCatGenerator := ConCatFunc{}
+	for _, testCase := range testCases {
+		funcCallVisitor := FuncCallExprVisitor{}
+		stmts, _, err := parser.New().PerfectParse(testCase.SQL, "", "")
+		assert.NoError(t, err)
+		for _, stmt := range stmts {
+			stmt.Accept(&funcCallVisitor)
+		}
+		if assert.NotEmpty(t, funcCallVisitor.FuncCallList) {
+			conCatGenerator.ConCat = funcCallVisitor.FuncCallList[0]
+			assert.Equal(t, testCase.ExpectResult, conCatGenerator.GenerateResult())
+		}
+	}
+}
+
+func TestUpperFunc(t *testing.T) {
+	testCases := []struct {
+		SQL          string
+		ExpectResult string
+	}{
+		{
+			SQL:          "SELECT UPPER('a');",
+			ExpectResult: "A",
+		},
+		{
+			SQL:          "SELECT UPPER(CONCAT('a_',UPPER('b'),'_c'));",
+			ExpectResult: "A_B_C",
+		},
+		{
+			SQL:          "SELECT UPPER(CONCAT(CONCAT('a_',UPPER('b'),'_c'),'_','a_',UPPER('b'),'_c'));",
+			ExpectResult: "A_B_C_A_B_C",
+		},
+	}
+	upperGenerator := UpperFunc{}
+	for _, testCase := range testCases {
+		funcCallVisitor := FuncCallExprVisitor{}
+		stmts, _, err := parser.New().PerfectParse(testCase.SQL, "", "")
+		assert.NoError(t, err)
+		for _, stmt := range stmts {
+			stmt.Accept(&funcCallVisitor)
+		}
+		if assert.NotEmpty(t, funcCallVisitor.FuncCallList) {
+			upperGenerator.Upper = funcCallVisitor.FuncCallList[0]
+			assert.Equal(t, testCase.ExpectResult, upperGenerator.GenerateResult())
+		}
+	}
+}

--- a/sqle/driver/mysql/util/parser_helper.go
+++ b/sqle/driver/mysql/util/parser_helper.go
@@ -410,18 +410,13 @@ func CheckWhereFuzzySearch(where ast.ExprNode) bool {
 					return true
 				}
 			case *ast.FuncCallExpr:
-				if pattern.FnName.L == "concat" {
-					if len(pattern.Args) > 0 {
-						switch pattern := pattern.Args[0].(type) {
-						case *driver.ValueExpr:
-							datum := pattern.Datum.GetString()
-							if strings.HasPrefix(datum, "%") || strings.HasPrefix(datum, "_") {
-								isExist = true
-								return true
-							}
-						}
-					}
+				result := NewFuncCallStringResultGenerator(pattern).GenerateResult()
+				if strings.HasPrefix(result, "%") || strings.HasPrefix(result, "_") {
+					isExist = true
+					return true
 				}
+				// unsupport subquery result as value of like
+				// example (select '%' 'any_string' '%')
 			}
 		}
 		return false

--- a/sqle/driver/mysql/util/visitor.go
+++ b/sqle/driver/mysql/util/visitor.go
@@ -309,3 +309,19 @@ func (v *EqualConditionVisitor) Enter(in ast.Node) (out ast.Node, skipChildren b
 func (v *EqualConditionVisitor) Leave(in ast.Node) (out ast.Node, ok bool) {
 	return in, true
 }
+
+type FuncCallExprVisitor struct {
+	FuncCallList []*ast.FuncCallExpr
+}
+
+func (v *FuncCallExprVisitor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+	switch stmt := in.(type) {
+	case *ast.FuncCallExpr:
+		v.FuncCallList = append(v.FuncCallList, stmt)
+	}
+	return in, false
+}
+
+func (v *FuncCallExprVisitor) Leave(in ast.Node) (out ast.Node, ok bool) {
+	return in, true
+}

--- a/sqle/driver/mysql/util/visitor_test.go
+++ b/sqle/driver/mysql/util/visitor_test.go
@@ -166,3 +166,27 @@ func TestEqualConditionVisitor(t *testing.T) {
 		})
 	}
 }
+
+func TestFuncCallVisitor(t *testing.T) {
+	tests := []struct {
+		input          string
+		conditionCount int
+	}{
+		{"SELECT * FROM t1 WHERE t1.id1 = t3.id3 OR t2.id2 = t1.id1", 0},
+		{"SELECT UPPER(CONCAT(CONCAT('a_',UPPER('b'),'_c'),'_','a_',UPPER('b'),'_c'));", 5},
+		{"SELECT UPPER('a');", 1},
+		{"SELECT UPPER(CONCAT('a_',UPPER('b'),'_c'));", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			stmt, err := parser.New().ParseOneStmt(tt.input, "", "")
+			assert.NoError(t, err)
+
+			visitor := &FuncCallExprVisitor{}
+			stmt.Accept(visitor)
+
+			assert.Equal(t, tt.conditionCount, len(visitor.FuncCallList))
+		})
+	}
+}


### PR DESCRIPTION
#1974 
### two question:
1. the rule DMLCheckFuzzySearch unsupport upper function
2. when there is no where in the outer layer of the SQL statement, the where statement of the subquery will not be checked
### involve four rules:
  1. DMLCheckWhereIsInvalid
  2. DMLCheckWhereExistNot
  3. DMLCheckWhereExistScalarSubquery
  4. DMLCheckFuzzySearch
### Solution
1. Rule DMLCheckFuzzySearch supports the upper function
2. When there is no WHERE in the outer layer of the SQL statement but there is a WHERE statement in its subquery, the WHERE statement in the subquery will also be checked