### PR TITLE
fix: get index selectivity error, when table not exist

### DIFF
--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5258,7 +5258,8 @@ func checkIndexOption(input *RuleHandlerInput) error {
 
 	columnSelectivityMap, err := input.Ctx.GetSelectivityOfColumns(tableName, indexColumns)
 	if err != nil {
-		return err
+		log.NewEntry().Errorf("get selectivity of columns failed, sqle: %v, error: %v", input.Node.Text(), err)
+		return nil
 	}
 
 	max := input.Rule.Params.GetParam(DefaultSingleParamKeyName).Int()
@@ -6676,6 +6677,7 @@ func checkIndexSelectivity(input *RuleHandlerInput) error {
 				}
 				indexSelectivityMap, err := input.Ctx.GetSelectivityOfIndex(tableName, indexes)
 				if err != nil {
+					log.NewEntry().Errorf("get selectivity of index failed, sqle: %v, error: %v", input.Node.Text(), err)
 					continue
 				}
 				max := input.Rule.Params.GetParam(DefaultSingleParamKeyName).Int()

--- a/sqle/driver/mysql/session/context.go
+++ b/sqle/driver/mysql/session/context.go
@@ -851,7 +851,7 @@ func (c *Context) GetSelectivityOfColumns(stmt *ast.TableName, indexColumns []st
 	}
 	columnSelectivity, err := c.getSelectivityByColumn(columns)
 	if err != nil {
-		return nil, fmt.Errorf("get selectivity by index error: %v", err)
+		return nil, fmt.Errorf("get selectivity by column error: %v", err)
 	}
 	for indexName, selectivity := range columnSelectivity {
 		c.addSelectivity(schemaName, tableName, indexName, selectivity)

--- a/sqle/driver/mysql/session/context.go
+++ b/sqle/driver/mysql/session/context.go
@@ -743,6 +743,10 @@ func (c *Context) GetSelectivityOfIndex(stmt *ast.TableName, indexNames []string
 	if len(indexNames) == 0 || stmt == nil {
 		return nil, nil
 	}
+	if exist, _ := c.IsTableExist(stmt); !exist {
+		// would not get selectivity if table not exist
+		return nil, nil
+	}
 	schemaName := c.GetSchemaName(stmt)
 	tableName := stmt.Name.L
 	cachedIndexSelectivity := make(map[string]float64)
@@ -824,6 +828,10 @@ func (c *Context) getSelectivityByColumn(columns []column) (map[string] /*index 
 
 func (c *Context) GetSelectivityOfColumns(stmt *ast.TableName, indexColumns []string) (map[string] /*column name*/ float64, error) {
 	if stmt == nil || len(indexColumns) == 0 {
+		return nil, nil
+	}
+	if exist, _ := c.IsTableExist(stmt); !exist {
+		// would not get selectivity if table not exist
 		return nil, nil
 	}
 	schemaName := c.GetSchemaName(stmt)

--- a/sqle/driver/mysql/session/context.go
+++ b/sqle/driver/mysql/session/context.go
@@ -745,7 +745,7 @@ func (c *Context) GetSelectivityOfIndex(stmt *ast.TableName, indexNames []string
 	}
 	if exist, _ := c.IsTableExist(stmt); !exist {
 		// would not get selectivity if table not exist
-		return nil, nil
+		return nil, fmt.Errorf("table not exist")
 	}
 	schemaName := c.GetSchemaName(stmt)
 	tableName := stmt.Name.L
@@ -832,7 +832,7 @@ func (c *Context) GetSelectivityOfColumns(stmt *ast.TableName, indexColumns []st
 	}
 	if exist, _ := c.IsTableExist(stmt); !exist {
 		// would not get selectivity if table not exist
-		return nil, nil
+		return nil, fmt.Errorf("table not exist")
 	}
 	schemaName := c.GetSchemaName(stmt)
 	tableName := stmt.Name.L


### PR DESCRIPTION
#2015 
Resolve this issue by checking the existence of the corresponding table before obtaining selectivity.
