### PR TITLE
fix: rule DDLRecommendTableColumnCharsetSame mistriggered 

### DIFF
--- a/spelling_dict.txt
+++ b/spelling_dict.txt
@@ -13,6 +13,7 @@ asensitive
 atoi
 attrs
 auditplan
+armscii
 backoff
 bcda
 beeefore

--- a/spelling_dict.txt
+++ b/spelling_dict.txt
@@ -20,6 +20,7 @@ bigint
 binlog
 blkid
 btree
+chinese
 cardinalities
 ccug
 chanxuehong

--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -5317,21 +5317,65 @@ func TestDDLCheckColumnQuantity(t *testing.T) {
 }
 
 func TestDDLRecommendTableColumnCharsetSame(t *testing.T) {
-	for _, sql := range []string{
-		"CREATE TABLE `t` ( `id` int(11) DEFAULT NULL, `col` char(10) CHARACTER SET utf8 DEFAULT NULL)",
-		//TODO　"alter table exist_tb_1 change v1 v1 char(10) CHARACTER SET utf8 DEFAULT NULL;",
-		"CREATE TABLE `t` ( `id` int(11) DEFAULT NULL, `col` char(10) CHARACTER SET utf8 DEFAULT NULL) DEFAULT CHARSET=utf8mb4",
-	} {
-		runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "", DefaultMysqlInspect(), sql, newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
-	}
+	// 无需连库
 
-	for _, sql := range []string{
-		"CREATE TABLE `t` ( `id` int(10) )",
-		//TODO　"CREATE TABLE `t` ( `id` varchar(10) CHARACTER SET utf8 ) DEFAULT CHARSET=utf8",
-	} {
-		runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", DefaultMysqlInspect(), sql, newTestResult())
-	}
+	// 不触发规则
+	// 创建表 声明列字符集与表字符集 二者一致
+	runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", DefaultMysqlInspect(), "CREATE TABLE `t` ( `id` varchar(10) CHARACTER SET utf8 ) CHARACTER SET utf8", newTestResult())
+	// 创建表 未声明列字符集
+	runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", DefaultMysqlInspect(), "CREATE TABLE `t` ( `id` int(11), `col` char(10) DEFAULT NULL) CHARACTER SET gbk COLLATE gbk_chinese_ci", newTestResult())
+	// 需要查询数据库 获取数据库默认字符集
+	e, handler, err := executor.NewMockExecutor()
+	assert.NoError(t, err)
+	inspect1 := NewMockInspect(e)
+	// 触发规则
+	// 创建表 声明列字符集与表字符集 二者不一致
+	runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "", DefaultMysqlInspect(), "CREATE TABLE `t` (`id` int(11) DEFAULT NULL, `col` char(10) CHARACTER SET utf8 DEFAULT NULL) DEFAULT CHARSET=utf8mb4", newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
 
+	// 需要连库
+
+	// 不触发规则
+	// 先修改列的字符集，再修改表的字符集
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, `ALTER TABLE exist_tb_1 MODIFY column_1 VARCHAR(255) CHARACTER SET cp850,
+		CONVERT TO CHARACTER SET gbk COLLATE gbk_chinese_ci;`, newTestResult())
+	// 先修改表的字符集，再修改列的字符集，二者字符集一致
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, `ALTER TABLE exist_tb_1 CONVERT TO CHARACTER SET latin1 COLLATE latin1_general_ci,
+		MODIFY column_1 VARCHAR(255) CHARACTER SET latin1;`, newTestResult())
+	// 修改列的字符集和原表字符集一致
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, `ALTER TABLE exist_tb_1 MODIFY column_1 VARCHAR(255) CHARACTER SET utf8mb4;`, newTestResult())
+	// 创建表未声明字符集和排序 列字符集与默认字符集一致
+	handler.ExpectQuery(regexp.QuoteMeta("select @@character_set_database")).
+		WillReturnRows(sqlmock.NewRows([]string{"@@character_set_database"}).AddRow("utf8mb4"))
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t0` ( `col` char(10) CHARACTER SET utf8mb4 DEFAULT NULL)", newTestResult())
+	// 创建表只声明排序 列字符集与排序对应字符集一致
+	handler.ExpectQuery(regexp.QuoteMeta(`SELECT CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.COLLATIONS WHERE COLLATION_NAME = "gbk_chinese_ci"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"CHARACTER_SET_NAME"}).AddRow("gbk"))
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t1` ( `col` char(10) CHARACTER SET gbk DEFAULT NULL) DEFAULT COLLATE=gbk_chinese_ci", newTestResult())
+
+	// 触发规则
+	// 创建表未声明字符集和排序 列字符集与默认字符集不一致
+	handler.ExpectQuery(regexp.QuoteMeta("select @@character_set_database")).
+		WillReturnRows(sqlmock.NewRows([]string{"@@character_set_database"}).AddRow("utf8mb4"))
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t2` ( `col` char(10) CHARACTER SET gbk DEFAULT NULL)", newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
+	// 创建表只声明排序 列字符集与排序对应字符集不一致
+	handler.ExpectQuery(regexp.QuoteMeta(`SELECT CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.COLLATIONS WHERE COLLATION_NAME = "gbk_chinese_ci"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"CHARACTER_SET_NAME"}).AddRow("gbk"))
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t3` ( `col` char(10) CHARACTER SET utf8mb4 DEFAULT NULL) DEFAULT COLLATE=gbk_chinese_ci", newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
+
+	// 先修改表的字符集，再修改列的字符集，二者字符集不一致
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, `ALTER TABLE exist_tb_1 CONVERT TO CHARACTER SET latin1 COLLATE latin1_general_ci,
+		MODIFY column_1 VARCHAR(255) CHARACTER SET gbk;`, newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
+	// 修改列的字符集和原表字符集一致
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, `ALTER TABLE exist_tb_1 MODIFY column_1 VARCHAR(255) CHARACTER SET gbk;`, newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
 }
 
 func TestDDLCheckColumnTypeInteger(t *testing.T) {

--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -5319,15 +5319,16 @@ func TestDDLCheckColumnQuantity(t *testing.T) {
 func TestDDLRecommendTableColumnCharsetSame(t *testing.T) {
 	// 无需连库
 
+	// 需要查询数据库 获取数据库默认字符集
+	e, handler, err := executor.NewMockExecutor()
+	assert.NoError(t, err)
+	inspect1 := NewMockInspect(e)
+
 	// 不触发规则
 	// 创建表 声明列字符集与表字符集 二者一致
 	runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", DefaultMysqlInspect(), "CREATE TABLE `t` ( `id` varchar(10) CHARACTER SET utf8 ) CHARACTER SET utf8", newTestResult())
 	// 创建表 未声明列字符集
 	runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", DefaultMysqlInspect(), "CREATE TABLE `t` ( `id` int(11), `col` char(10) DEFAULT NULL) CHARACTER SET gbk COLLATE gbk_chinese_ci", newTestResult())
-	// 需要查询数据库 获取数据库默认字符集
-	e, handler, err := executor.NewMockExecutor()
-	assert.NoError(t, err)
-	inspect1 := NewMockInspect(e)
 	// 触发规则
 	// 创建表 声明列字符集与表字符集 二者不一致
 	runSingleRuleInspectCase(rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "", DefaultMysqlInspect(), "CREATE TABLE `t` (`id` int(11) DEFAULT NULL, `col` char(10) CHARACTER SET utf8 DEFAULT NULL) DEFAULT CHARSET=utf8mb4", newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
@@ -5347,8 +5348,6 @@ func TestDDLRecommendTableColumnCharsetSame(t *testing.T) {
 	runSingleRuleInspectCase(
 		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, `ALTER TABLE exist_tb_1 MODIFY column_1 VARCHAR(255) CHARACTER SET utf8mb4;`, newTestResult())
 	// 创建表未声明字符集和排序 列字符集与默认字符集一致
-	handler.ExpectQuery(regexp.QuoteMeta("select @@character_set_database")).
-		WillReturnRows(sqlmock.NewRows([]string{"@@character_set_database"}).AddRow("utf8mb4"))
 	runSingleRuleInspectCase(
 		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t0` ( `col` char(10) CHARACTER SET utf8mb4 DEFAULT NULL)", newTestResult())
 	// 创建表只声明排序 列字符集与排序对应字符集一致
@@ -5356,11 +5355,14 @@ func TestDDLRecommendTableColumnCharsetSame(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"CHARACTER_SET_NAME"}).AddRow("gbk"))
 	runSingleRuleInspectCase(
 		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t1` ( `col` char(10) CHARACTER SET gbk DEFAULT NULL) DEFAULT COLLATE=gbk_chinese_ci", newTestResult())
+	// 创建表声明列排序 列字符集与排序对应字符集一致
+	handler.ExpectQuery(regexp.QuoteMeta(`SELECT CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.COLLATIONS WHERE COLLATION_NAME = "gbk_chinese_ci"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"CHARACTER_SET_NAME"}).AddRow("gbk"))
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t4` ( `col` char(10) COLLATE gbk_chinese_ci DEFAULT NULL) CHARACTER SET gbk COLLATE gbk_chinese_ci", newTestResult())
 
 	// 触发规则
 	// 创建表未声明字符集和排序 列字符集与默认字符集不一致
-	handler.ExpectQuery(regexp.QuoteMeta("select @@character_set_database")).
-		WillReturnRows(sqlmock.NewRows([]string{"@@character_set_database"}).AddRow("utf8mb4"))
 	runSingleRuleInspectCase(
 		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t2` ( `col` char(10) CHARACTER SET gbk DEFAULT NULL)", newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
 	// 创建表只声明排序 列字符集与排序对应字符集不一致
@@ -5376,6 +5378,11 @@ func TestDDLRecommendTableColumnCharsetSame(t *testing.T) {
 	// 修改列的字符集和原表字符集一致
 	runSingleRuleInspectCase(
 		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, `ALTER TABLE exist_tb_1 MODIFY column_1 VARCHAR(255) CHARACTER SET gbk;`, newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
+	// 创建表声明列排序 列字符集与排序对应字符集一致
+	handler.ExpectQuery(regexp.QuoteMeta(`SELECT CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.COLLATIONS WHERE COLLATION_NAME = "latin1_general_ci"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"CHARACTER_SET_NAME"}).AddRow("latin1"))
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t5` ( `col` char(10) COLLATE latin1_general_ci DEFAULT NULL,`col2` char(10)) CHARACTER SET gbk COLLATE gbk_chinese_ci", newTestResult().addResult(rulepkg.DDLRecommendTableColumnCharsetSame))
 }
 
 func TestDDLCheckColumnTypeInteger(t *testing.T) {

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5839,7 +5839,7 @@ func recommendTableColumnCharsetSame(input *RuleHandlerInput) error {
 		// 获取建表语句中的字符集
 		charset := getCharsetFromCreateTableStmt(input.Ctx, stmt)
 		if charset.StrValue == "" {
-			log.Logger().Infof("对于SQL:%s;规则%s未能获取字符集无法比较", input.Node.Text(), input.Rule.Desc)
+			log.Logger().Warnf("skip rule:%s. reason: for sql %s, rule failed to obtain character set for comparison", input.Rule.Name, input.Node.Text())
 			// 未能获取字符集 无法比较 返回
 			return nil
 		}
@@ -5893,7 +5893,7 @@ func recommendTableColumnCharsetSame(input *RuleHandlerInput) error {
 				2. 根据SQL语句修改列的字符集到目标字符集
 				3. 判断最终表字符集和最终列字符集是否一致
 			*/
-			log.Logger().Info("暂不支持修改表字符集但不使用CONVERT的情况")
+			log.Logger().Warnf("skip rule:%s. reason: for sql %s,alter the table character but not using CONVERT TO is currently not supported.", input.Rule.Name, input.Node.Text())
 			return nil
 		}
 		if newCharset == nil {
@@ -5904,18 +5904,18 @@ func recommendTableColumnCharsetSame(input *RuleHandlerInput) error {
 			// 若未更改表的字符集，则获取原表字符集作为表字符集
 			originTable, exist, err := input.Ctx.GetCreateTableStmt(stmt.Table)
 			if err != nil {
-				log.Logger().Errorf("对于SQL:%s,规则%s获取表失败%v", input.Node.Text(), input.Rule.Desc, err)
+				log.Logger().Errorf("skip rule:%s. reason: for sql %s, an error occur when rule try to obtain the corresponding table,err:%v", input.Rule.Name, input.Node.Text(), err)
 				return nil
 			}
 			if !exist {
-				log.Logger().Infof("对于SQL:%s,规则%s找不到对应的表", input.Node.Text(), input.Rule.Desc)
+				log.Logger().Warnf("skip rule:%s. reason: for sql %s,the corresponding table is not exist", input.Rule.Name, input.Node.Text())
 				return nil
 			}
 			// 若没有修改表字符集
 			charset := getCharsetFromCreateTableStmt(input.Ctx, originTable)
 			if charset.StrValue == "" {
 				// 未能获取字符集 无法比较 返回
-				log.Logger().Infof("对于SQL:%s;规则%s未能获取字符集无法比较", input.Node.Text(), input.Rule.Desc)
+				log.Logger().Warnf("skip rule:%s. reason: for sql %s, rule failed to obtain character set for comparison", input.Rule.Name, input.Node.Text())
 				return nil
 			}
 			for _, column := range columnWithCharset {

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5839,6 +5839,7 @@ func recommendTableColumnCharsetSame(input *RuleHandlerInput) error {
 		// 获取建表语句中的字符集
 		charset := getCharsetFromCreateTableStmt(input.Ctx, stmt)
 		if charset.StrValue == "" {
+			log.Logger().Infof("对于SQL:%s;规则%s未能获取字符集无法比较", input.Node.Text(), input.Rule.Desc)
 			// 未能获取字符集 无法比较 返回
 			return nil
 		}
@@ -5852,12 +5853,6 @@ func recommendTableColumnCharsetSame(input *RuleHandlerInput) error {
 		var columnWithCharset []*ast.ColumnDef
 		var newCharset *ast.TableOption
 		var useConvert bool
-		// 若未更改表的字符集，则获取原表字符集作为表字符集
-		originTable, exist, err := input.Ctx.GetCreateTableStmt(stmt.Table)
-		if err != nil || !exist {
-			return nil
-		}
-
 		for _, spec := range stmt.Specs {
 			// 修改的列
 			for _, col := range spec.NewColumns {
@@ -5887,31 +5882,40 @@ func recommendTableColumnCharsetSame(input *RuleHandlerInput) error {
 				}
 				return nil
 			}
-			if !useConvert {
-				/*
-					暂不支持修改表字符集但不使用CONVERT的情况
-					若不使用CONVERT，仅修改表的字符集，不修改表中列的字符集
-					需要判断最终的表字符集和列字符集是否一致，
-					1. 获取原表各列字符集:
-						SELECT column_name, character_set_name
-						FROM information_schema.columns
-						WHERE table_name = 'your_table_name';
-					2. 根据SQL语句修改列的字符集到目标字符集
-					3. 判断最终表字符集和最终列字符集是否一致
-				*/
-				log.Logger().Info("暂不支持修改表字符集但不使用CONVERT的情况")
-				return nil
-			}
+			/*
+				暂不支持修改表字符集但不使用CONVERT的情况
+				若不使用CONVERT，仅修改表的字符集，不修改表中列的字符集
+				需要判断最终的表字符集和列字符集是否一致，
+				1. 获取原表各列字符集:
+					SELECT column_name, character_set_name
+					FROM information_schema.columns
+					WHERE table_name = 'your_table_name';
+				2. 根据SQL语句修改列的字符集到目标字符集
+				3. 判断最终表字符集和最终列字符集是否一致
+			*/
+			log.Logger().Info("暂不支持修改表字符集但不使用CONVERT的情况")
+			return nil
 		}
 		if newCharset == nil {
 			if len(columnWithCharset) == 0 {
 				// 没有指定字符集的列时，列的字符集被设定为表字符集
 				return nil
 			}
+			// 若未更改表的字符集，则获取原表字符集作为表字符集
+			originTable, exist, err := input.Ctx.GetCreateTableStmt(stmt.Table)
+			if err != nil {
+				log.Logger().Errorf("对于SQL:%s,规则%s获取表失败%v", input.Node.Text(), input.Rule.Desc, err)
+				return nil
+			}
+			if !exist {
+				log.Logger().Infof("对于SQL:%s,规则%s找不到对应的表", input.Node.Text(), input.Rule.Desc)
+				return nil
+			}
 			// 若没有修改表字符集
 			charset := getCharsetFromCreateTableStmt(input.Ctx, originTable)
 			if charset.StrValue == "" {
 				// 未能获取字符集 无法比较 返回
+				log.Logger().Infof("对于SQL:%s;规则%s未能获取字符集无法比较", input.Node.Text(), input.Rule.Desc)
 				return nil
 			}
 			for _, column := range columnWithCharset {

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5796,19 +5796,128 @@ func checkColumnQuantity(input *RuleHandlerInput) error {
 	}
 }
 
+/*
+recommendTableColumnCharsetSame
+
+	触发条件：
+	1 若DDL语句是建表语句：
+		1.1 若列和表都声明了字符集。列的字符集与表字符集不同，触发规则。
+		1.2 若列声明了字符集，表未声明字符集只声明排序规则。排序规则对应字符集与列字符集不同，触发规则。
+		1.3 若列声明了字符集，表未声明字符集和排序规则。列字符集和数据库默认字符集不同，触发规则。
+	2 若DDL语句是修改表语句
+		2.1 若只修改列字符集。字符集与原表不同，触发规则。
+		2.2 若先修改表的字符集，再修改列的字符集。新列字符集与新表字符集不同，触发规则。
+		2.3 若先修改列的字符集，再修改表的字符集。表中列的字符集会统一为新字符集，不触发规则。
+
+	注意：若建表语句的字符集缺失，会按照mysql选择使用哪种字符集的逻辑获取字符集
+	建表语句选择使用哪种字符集以及排序规则的逻辑如下：
+	1 若两者都指定，则根据指定的字符集以及排序规则设定
+	2 若未指定字符集，但指定了排序规则，字符集设定为排序规则关联的字符集
+	3 若未指定排序规则，但指定了字符集，排序规则设定为字符集关联的排序规则
+	4 若字符集和排序规则都不指定，二者将被设定为database的字符集及排序的默认值
+
+	不支持：
+	1 反复修改同一列的字符集
+	2 检查修改的列是否在表中
+
+参考文档：https://dev.mysql.com/doc/refman/8.0/en/charset-database.html
+*/
 func recommendTableColumnCharsetSame(input *RuleHandlerInput) error {
+	charset := &ast.TableOption{}
+	collation := &ast.TableOption{}
+	var columns []*ast.ColumnDef
 	switch stmt := input.Node.(type) {
 	case *ast.CreateTableStmt:
-		for _, col := range stmt.Cols {
-			if col.Tp.Charset != "" {
-				addResult(input.Res, input.Rule, input.Rule.Name)
-				break
+		if len(stmt.Options) > 0 {
+			newCharset, newCollation := getCharsetAndCollation(stmt.Options)
+			if newCharset != nil {
+				charset = newCharset
+			}
+			if newCollation != nil {
+				collation = newCollation
 			}
 		}
-		return nil
+		for _, col := range stmt.Cols {
+			if col.Tp.Charset != "" {
+				columns = append(columns, col)
+			}
+		}
+	case *ast.AlterTableStmt:
+		originTable, exist, err := input.Ctx.GetCreateTableStmt(stmt.Table)
+		if err != nil || !exist {
+			return nil
+		}
+		newCharset, newCollation := getCharsetAndCollation(originTable.Options)
+		if newCharset != nil {
+			charset = newCharset
+		}
+		if newCollation != nil {
+			collation = newCollation
+		}
+		for idx, spec := range stmt.Specs {
+			if len(spec.Options) > 0 {
+				// 若修改表的字符集，表中列的字符集都会
+				newCharset, _ := getCharsetAndCollation(spec.Options)
+				if newCharset != nil {
+					if idx == len(stmt.Specs)-1 {
+						// 若修改表的字符集是修改语句的最后一句，则表的字符集会统一为该字符集
+						return nil
+					}
+					charset = newCharset
+				}
+			}
+			for _, col := range spec.NewColumns {
+				if col.Tp.Charset != "" {
+					columns = append(columns, col)
+				}
+			}
+
+		}
 	default:
 		return nil
 	}
+	if len(columns) == 0 {
+		return nil
+	}
+	if charset.StrValue == "" {
+		// 获取字符集
+		executor := input.Ctx.GetExecutor()
+		if executor != nil {
+			// 获取排序对应的字符集
+			if collation.StrValue != "" {
+				charset.StrValue, _ = executor.ShowDefaultConfiguration(
+					fmt.Sprintf("SELECT CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.COLLATIONS WHERE COLLATION_NAME = \"%s\"", collation.StrValue), "CHARACTER_SET_NAME",
+				)
+			}
+			// 获取数据库默认的字符集
+			if collation.StrValue == "" {
+				charset.StrValue, _ = executor.ShowDefaultConfiguration(
+					"select @@character_set_database", "@@character_set_database")
+			}
+		}
+		if charset.StrValue == "" {
+			return nil
+		}
+	}
+	for _, column := range columns {
+		if column.Tp.Charset != charset.StrValue {
+			addResult(input.Res, input.Rule, input.Rule.Name)
+			break
+		}
+	}
+	return nil
+}
+
+func getCharsetAndCollation(options []*ast.TableOption) (charset *ast.TableOption, collation *ast.TableOption) {
+	for _, option := range options {
+		if option.Tp == ast.TableOptionCharset {
+			charset = option
+		}
+		if option.Tp == ast.TableOptionCollate {
+			collation = option
+		}
+	}
+	return
 }
 
 func checkColumnTypeInteger(input *RuleHandlerInput) error {

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5899,6 +5899,7 @@ func recommendTableColumnCharsetSame(input *RuleHandlerInput) error {
 					2. 根据SQL语句修改列的字符集到目标字符集
 					3. 判断最终表字符集和最终列字符集是否一致
 				*/
+				log.Logger().Info("暂不支持修改表字符集但不使用CONVERT的情况")
 				return nil
 			}
 		}

--- a/sqle/driver/mysql/session/context.go
+++ b/sqle/driver/mysql/session/context.go
@@ -889,6 +889,25 @@ func (c *Context) GetSchemaCharacter(stmt *ast.TableName, schemaName string) (st
 	return character, nil
 }
 
+/*
+Example:
+
+	mysql> SELECT CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.COLLATIONS WHERE COLLATION_NAME = "armscii8_bin";
+	+--------------------+
+	| CHARACTER_SET_NAME |
+	+--------------------+
+	| armscii8           |
+	+--------------------+
+	1 row in set (0.01 sec)
+*/
+func (c *Context) GetSchemaCharacterByCollation(collation string) (string, error) {
+	if collation == "" || c.e == nil  {
+		return "", nil
+	}
+	return c.e.ShowDefaultConfiguration(
+		fmt.Sprintf("SELECT CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.COLLATIONS WHERE COLLATION_NAME = \"%s\"", collation), "CHARACTER_SET_NAME")
+}
+
 // GetSchemaEngine get schema default engine.
 func (c *Context) GetSchemaEngine(stmt *ast.TableName, schemaName string) (string, error) {
 	if schemaName == "" {


### PR DESCRIPTION
#2043 
## Problem
when the table creation statement declares the column character set and table character set (both are the same), trigger the rule
## Solution
Support checking column character sets in table creation statements
## Support
Add support for the following scenarios
### If the DDL statement is a table creation statement:

1. If both columns and tables declare a character set. The character set of the column is different from the character set of the table, triggering the rule.
2. If the column declares a character set, the table does not declare a character set and only declares sorting rules. The sorting rule corresponds to a character set that is different from the column character set, triggering the rule.
3. If the column declares a character set, the table does not declare a character set and sorting rule. The column character set and the database default character set are different, triggering rules.

### If the DDL statement is a modify table statement

1. If only the column character set is modified. The character set is different from the original table, triggering rules.
2. If you first modify the character set of the table, then modify the character set of the column. The new column character set is different from the new table character set, triggering rules.
3. If you first modify the character set of the column, then modify the character set of the table. The character sets listed in the table are unified as new character sets and do not trigger rules.