### PR TITLE
Compatible with TDSQL database responses with info column 

### DIFF
--- a/sqle/driver/mysql/executor/executor.go
+++ b/sqle/driver/mysql/executor/executor.go
@@ -307,7 +307,7 @@ func (c *Executor) ShowCreateTable(schema, tableName string) (string, error) {
 	+----------+------------------+
 	| Database | info             |
 	+----------+------------------+
-	| sysdb    | set_1700620716_1 |
+	| system   | set_1700620716_1 |
 	| test     | set_1700620716_1 |
 	+----------+------------------+
 */

--- a/sqle/driver/mysql/mysql.go
+++ b/sqle/driver/mysql/mysql.go
@@ -108,6 +108,10 @@ func NewInspect(log *logrus.Entry, cfg *driverV2.Config) (*MysqlDriverImpl, erro
 	return inspect, nil
 }
 
+func (i *MysqlDriverImpl) SetExecutor(dbConn *executor.Executor) {
+	i.dbConn = dbConn
+}
+
 func (i *MysqlDriverImpl) IsOfflineAudit() bool {
 	return i.isOfflineAudit
 }

--- a/sqle/driver/mysql/util/util.go
+++ b/sqle/driver/mysql/util/util.go
@@ -98,8 +98,8 @@ func GetAffectedRowNum(ctx context.Context, originSql string, conn *executor.Exe
 		return 0, nil
 	}
 
-	if len(row) != 1 {
-		return 0, fmt.Errorf("affected row sql(%v) result row count(%v) is not 1", affectRowSql, len(row))
+	if len(row) < 1 {
+		return 0, fmt.Errorf("affected row sql(%v) result row count(%v) less than 1", affectRowSql, len(row))
 	}
 
 	affectCount, err := strconv.ParseInt(row[0][0].String, 10, 64)


### PR DESCRIPTION
#2065 
对函数做了兼容性的修改：
```bash golang
func (c *Executor) ShowDatabases(ignoreSysDatabase bool) ([]string, error)
func (c *Executor) ShowSchemaTables(schema string) ([]string, error)
func (c *Executor) ShowSchemaViews(schema string) ([]string, error)
func (c *Context) getSelectivityByIndex(indexes []index) (map[string] /*index name*/ float64, error)
func (c *Context) getSelectivityByColumn(columns []column) (map[string] /*index name*/ float64, error)
```

对结构体MysqlDriverImpl，增加了修改executor的方法
```bash golang
func (i *MysqlDriverImpl) SetExecutor(dbConn *executor.Executor)
```