### PR TITLE
fix: parse empty tags when get SQL audit records

### DIFF
--- a/sqle/api/controller/v1/sql_audit_record.go
+++ b/sqle/api/controller/v1/sql_audit_record.go
@@ -610,8 +610,10 @@ func GetSQLAuditRecordsV1(c echo.Context) error {
 			status = SQLAuditRecordStatusSuccessfully
 		}
 		var tags []string
-		if err := json.Unmarshal([]byte(record.Tags.String), &tags); err != nil {
-			log.NewEntry().Errorf("parse tags failed,tags:%v , err: %v", record.Tags, err)
+		if record.Tags.Valid {
+			if err := json.Unmarshal([]byte(record.Tags.String), &tags); err != nil {
+				log.NewEntry().Errorf("parse tags failed,tags:%v , err: %v", record.Tags, err)
+			}
 		}
 		resData[i] = SQLAuditRecord{
 			Creator:          record.CreatorName,


### PR DESCRIPTION
In fact, the program should not parse empty tags, but first determine whether the structure of the tag is valid.

