### PR TITLE
fix: rule DMLCheckJoinFieldUseIndex not triggered

### DIFF
--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -6536,12 +6536,12 @@ func TestDMLCheckJoinFieldUseIndex(t *testing.T) {
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"left join, with join condition, with index, ignore index on left table",
+		"left join, with join condition, without index",
 		DefaultMysqlInspect(),
 		`update exist_tb_3 t3 left join exist_tb_2 t2 on t3.id = t2.user_id
 		set t3.id = 1
 		where t2.id = 2;`,
-		newTestResult(),
+		newTestResult().addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 	)
 
 	runSingleRuleInspectCase(

--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -876,7 +876,8 @@ func TestDMLCheckHasJoinCondition(t *testing.T) {
 				WHERE exist_tb_3.v3 > 5;
 			`,
 			ExpectResult: newTestResult().
-				addResult(rulepkg.DMLCheckSelectLimit, 1000),
+				addResult(rulepkg.DMLCheckSelectLimit, 1000).
+				addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 		}, {
 			Name: "select mix with where and on condition, does not trigger rule",
 			SQL: `
@@ -887,7 +888,8 @@ func TestDMLCheckHasJoinCondition(t *testing.T) {
 				WHERE exist_tb_1.user_id = t3.v1;
 			`,
 			ExpectResult: newTestResult().
-				addResult(rulepkg.DMLCheckSelectLimit, 1000),
+				addResult(rulepkg.DMLCheckSelectLimit, 1000).
+				addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 		},
 		{
 			Name: "select with where condition match another table, trigger rule",
@@ -899,7 +901,8 @@ func TestDMLCheckHasJoinCondition(t *testing.T) {
 				WHERE exist_tb_2.user_id = t3.v1;
 			`,
 			ExpectResult: newTestResult().
-				addResult(rulepkg.DMLCheckSelectLimit, 1000),
+				addResult(rulepkg.DMLCheckSelectLimit, 1000).
+				addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 		},
 		{
 			Name: "select mix with where on using condition, does not trigger rule",
@@ -1051,39 +1054,42 @@ update exist_db.not_exist_tb set exist_tb_1.v2 = "1" where exist_tb_1.id = exist
 		newTestResult().add(driverV2.RuleLevelError, "", TableNotExistMessage, "exist_db.not_exist_tb"),
 	)
 
-	runDefaultRulesInspectCase(t, "multi-update: column not exist", DefaultMysqlInspect(),
+	runDefaultRulesInspectCase(t, "multi-update: column not exist 1", DefaultMysqlInspect(),
 		`
 update exist_tb_1,exist_tb_2 set exist_tb_1.v3 = "1" where exist_tb_1.id = exist_tb_2.id;
 `,
 		newTestResult().add(driverV2.RuleLevelError, "", ColumnNotExistMessage, "exist_tb_1.v3"),
 	)
 
-	runDefaultRulesInspectCase(t, "multi-update: column not exist", DefaultMysqlInspect(),
+	runDefaultRulesInspectCase(t, "multi-update: column not exist 2", DefaultMysqlInspect(),
 		`
 update exist_tb_1,exist_tb_2 set exist_tb_2.v3 = "1" where exist_tb_1.id = exist_tb_2.id;
 `,
 		newTestResult().add(driverV2.RuleLevelError, "", ColumnNotExistMessage, "exist_tb_2.v3"),
 	)
 
-	runDefaultRulesInspectCase(t, "multi-update: column not exist", DefaultMysqlInspect(),
+	runDefaultRulesInspectCase(t, "multi-update: column not exist 3", DefaultMysqlInspect(),
 		`
 update exist_tb_1,exist_tb_2 set exist_tb_1.v1 = "1" where exist_tb_1.v3 = exist_tb_2.v3;
 `,
-		newTestResult().add(driverV2.RuleLevelError, "", ColumnNotExistMessage, "exist_tb_1.v3,exist_tb_2.v3"),
+		newTestResult().add(driverV2.RuleLevelError, "", ColumnNotExistMessage, "exist_tb_1.v3,exist_tb_2.v3").
+			addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 	)
 
-	runDefaultRulesInspectCase(t, "multi-update: column not exist", DefaultMysqlInspect(),
+	runDefaultRulesInspectCase(t, "multi-update: column not exist 4", DefaultMysqlInspect(),
 		`
 update exist_db.exist_tb_1,exist_db.exist_tb_2 set exist_tb_3.v1 = "1" where exist_tb_1.v1 = exist_tb_2.v1;
 `,
-		newTestResult().add(driverV2.RuleLevelError, "", ColumnNotExistMessage, "exist_tb_3.v1"),
+		newTestResult().add(driverV2.RuleLevelError, "", ColumnNotExistMessage, "exist_tb_3.v1").
+			addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 	)
 
-	runDefaultRulesInspectCase(t, "multi-update: column not exist", DefaultMysqlInspect(),
+	runDefaultRulesInspectCase(t, "multi-update: column not exist 5", DefaultMysqlInspect(),
 		`
 update exist_db.exist_tb_1,exist_db.exist_tb_2 set not_exist_db.exist_tb_1.v1 = "1" where exist_tb_1.v1 = exist_tb_2.v1;
 `,
-		newTestResult().add(driverV2.RuleLevelError, "", ColumnNotExistMessage, "not_exist_db.exist_tb_1.v1"),
+		newTestResult().add(driverV2.RuleLevelError, "", ColumnNotExistMessage, "not_exist_db.exist_tb_1.v1").
+			addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 	)
 
 	runDefaultRulesInspectCase(t, "multi-update: column not ambiguous", DefaultMysqlInspect(),
@@ -6456,13 +6462,14 @@ func TestDMLCheckScanRows(t *testing.T) {
 	runSingleRuleInspectCase(rule, t, "", inspect11, "delete from exist_tb_2 where v1=1", newTestResult())
 }
 
+// TODO
 func TestDMLCheckJoinFieldUseIndex(t *testing.T) {
 	rule := rulepkg.RuleHandlerMap[rulepkg.DMLCheckJoinFieldUseIndex].Rule
 
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"success",
+		"without join conodition",
 		DefaultMysqlInspect(),
 		`select * from exist_tb_2`,
 		newTestResult(),
@@ -6471,7 +6478,7 @@ func TestDMLCheckJoinFieldUseIndex(t *testing.T) {
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"success",
+		"left join, with join condition, without index 1",
 		DefaultMysqlInspect(),
 		`select * from exist_tb_2 left join exist_tb_3 on exist_tb_2.v1=exist_tb_3.v2`,
 		newTestResult().addResult(rulepkg.DMLCheckJoinFieldUseIndex),
@@ -6480,7 +6487,7 @@ func TestDMLCheckJoinFieldUseIndex(t *testing.T) {
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"success",
+		"left join, with join condition, with index",
 		DefaultMysqlInspect(),
 		`select * from exist_tb_1 left join exist_tb_2 on exist_tb_1.v1=exist_tb_2.user_id`,
 		newTestResult(),
@@ -6489,28 +6496,27 @@ func TestDMLCheckJoinFieldUseIndex(t *testing.T) {
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"",
+		"left join, with join condition, without index 2",
 		DefaultMysqlInspect(),
-		`select * from exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = t2.id left join exist_tb_3 t3
-				on t3.v2 = t2.id where exist_tb_2.v2 = 'v1'`,
+		`select * from exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = t2.id left join exist_tb_3 t3 on t3.v2 = t2.id where exist_tb_2.v2 = 'v1'`,
 		newTestResult().addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 	)
 
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"",
+		"left join, with join condition, without index 3",
 		DefaultMysqlInspect(),
-		`select * from exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = id`,
-		newTestResult(),
+		`select * from exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = t2.id left join exist_tb_3 t3 using(id)`,
+		newTestResult().addResult(rulepkg.DMLCheckJoinFieldUseIndex),
 	)
 
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"",
+		"multi-column index, cross join,  with join condition, with index",
 		DefaultMysqlInspect(),
-		`update exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = t2.id
+		`update exist_tb_1 t1 join exist_tb_2 t2 on t1.v2 = t2.id and t1.v1 = t2.id
 		set t1.id = 1
 		where t2.id = 2;`,
 		newTestResult(),
@@ -6519,9 +6525,9 @@ func TestDMLCheckJoinFieldUseIndex(t *testing.T) {
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"",
+		"multi-column index, cross join,  with join condition, with index but not match multi-column index",
 		DefaultMysqlInspect(),
-		`update exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = t2.id left join exist_tb_3 t3 on t2.id=t3.id
+		`update exist_tb_1 t1 join exist_tb_2 t2 on t1.v1 = t2.id and t1.v2 = t2.user_id
 		set t1.id = 1
 		where t2.id = 2;`,
 		newTestResult().addResult(rulepkg.DMLCheckJoinFieldUseIndex),
@@ -6530,28 +6536,28 @@ func TestDMLCheckJoinFieldUseIndex(t *testing.T) {
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"",
+		"left join, with join condition, with index, ignore index on left table",
 		DefaultMysqlInspect(),
-		`update exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = t2.v2
-		set t1.id = 1
+		`update exist_tb_3 t3 left join exist_tb_2 t2 on t3.id = t2.user_id
+		set t3.id = 1
 		where t2.id = 2;`,
-		newTestResult().addResult(rulepkg.DMLCheckJoinFieldUseIndex),
+		newTestResult(),
 	)
 
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"",
+		"right join, with less join condition, with index",
 		DefaultMysqlInspect(),
-		`delete exist_tb_1 , exist_tb_2 , exist_tb_3  from exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = t2.id where t2.v2 = 'v1'`,
+		`delete exist_tb_1 , exist_tb_2 , exist_tb_3  from exist_tb_1 t1 right join exist_tb_2 t2 on t1.id = t2.id where t2.v2 = 'v1'`,
 		newTestResult())
 
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"",
+		"right join, with join condition, not satisfy multi-column index",
 		DefaultMysqlInspect(),
-		`delete exist_tb_1 , exist_tb_2 , exist_tb_3  from exist_tb_1 t1 left join exist_tb_2 t2 on t1.id = t2.v2 where t2.v2 = 'v1'`,
+		`delete exist_tb_1 , exist_tb_2 , exist_tb_3  from exist_tb_1 t1 right join exist_tb_2 t2 on t1.id = t2.v2 where t2.v2 = 'v1'`,
 		newTestResult().addResult(rulepkg.DMLCheckJoinFieldUseIndex))
 }
 

--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -6469,7 +6469,7 @@ func TestDMLCheckJoinFieldUseIndex(t *testing.T) {
 	runSingleRuleInspectCase(
 		rule,
 		t,
-		"without join conodition",
+		"without join condition",
 		DefaultMysqlInspect(),
 		`select * from exist_tb_2`,
 		newTestResult(),

--- a/sqle/driver/mysql/context_test.go
+++ b/sqle/driver/mysql/context_test.go
@@ -3,20 +3,19 @@ package mysql
 import (
 	"testing"
 
-	"github.com/actiontech/sqle/sqle/driver/mysql/rule"
 	rulepkg "github.com/actiontech/sqle/sqle/driver/mysql/rule"
 	"github.com/actiontech/sqle/sqle/driver/mysql/session"
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
 )
 
 func TestContext(t *testing.T) {
-	handler := rule.RuleHandlerMap[rule.DDLCheckAlterTableNeedMerge]
-	handlerNotAllowRenaming := rule.RuleHandlerMap[rule.DDLNotAllowRenaming]
-	delete(rule.RuleHandlerMap, rule.DDLCheckAlterTableNeedMerge)
-	delete(rule.RuleHandlerMap, rule.DDLNotAllowRenaming)
+	handler := rulepkg.RuleHandlerMap[rulepkg.DDLCheckAlterTableNeedMerge]
+	handlerNotAllowRenaming := rulepkg.RuleHandlerMap[rulepkg.DDLNotAllowRenaming]
+	delete(rulepkg.RuleHandlerMap, rulepkg.DDLCheckAlterTableNeedMerge)
+	delete(rulepkg.RuleHandlerMap, rulepkg.DDLNotAllowRenaming)
 	defer func() {
-		rule.RuleHandlerMap[rule.DDLCheckAlterTableNeedMerge] = handler
-		rule.RuleHandlerMap[rule.DDLNotAllowRenaming] = handlerNotAllowRenaming
+		rulepkg.RuleHandlerMap[rulepkg.DDLCheckAlterTableNeedMerge] = handler
+		rulepkg.RuleHandlerMap[rulepkg.DDLNotAllowRenaming] = handlerNotAllowRenaming
 	}()
 
 	runDefaultRulesInspectCase(t, "rename table and drop column: table not exists", DefaultMysqlInspect(),
@@ -116,14 +115,14 @@ alter table not_exist_tb_1 drop column v1;
 }
 
 func TestParentContext(t *testing.T) {
-	handler := rule.RuleHandlerMap[rule.DDLCheckAlterTableNeedMerge]
-	delete(rule.RuleHandlerMap, rule.DDLCheckAlterTableNeedMerge)
+	handler := rulepkg.RuleHandlerMap[rulepkg.DDLCheckAlterTableNeedMerge]
+	delete(rulepkg.RuleHandlerMap, rulepkg.DDLCheckAlterTableNeedMerge)
 	// It's trick :),
 	// elegant method: unit test support MySQL.
-	delete(rule.RuleHandlerMap, rule.DDLCheckTableDBEngine)
-	delete(rule.RuleHandlerMap, rule.DDLCheckTableCharacterSet)
+	delete(rulepkg.RuleHandlerMap, rulepkg.DDLCheckTableDBEngine)
+	delete(rulepkg.RuleHandlerMap, rulepkg.DDLCheckTableCharacterSet)
 	defer func() {
-		rule.RuleHandlerMap[rule.DDLCheckAlterTableNeedMerge] = handler
+		rulepkg.RuleHandlerMap[rulepkg.DDLCheckAlterTableNeedMerge] = handler
 	}()
 
 	inspect1 := DefaultMysqlInspect()

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -7457,18 +7457,18 @@ func checkJoinFieldUseIndex(input *RuleHandlerInput) error {
 		return nil
 	}
 	tableNameCreateTableStmtMap := getTableNameCreateTableStmtMap(input.Ctx, joinNode)
-	tableConstarints := make(map[string][]*ast.Constraint, len(tableNameCreateTableStmtMap))
+	tableIndexes := make(map[string][]*ast.Constraint, len(tableNameCreateTableStmtMap))
 	for table, createTableStmt := range tableNameCreateTableStmtMap {
-		tableConstarints[table] = createTableStmt.Constraints
+		tableIndexes[table] = createTableStmt.Constraints
 	}
 
-	if joinNodes, hasIndex := joinConditionInJoinNodeHasIndex(input.Ctx, joinNode, tableConstarints); joinNodes && !hasIndex {
+	if joinNodes, hasIndex := joinConditionInJoinNodeHasIndex(input.Ctx, joinNode, tableIndexes); joinNodes && !hasIndex {
 		addResult(input.Res, input.Rule, input.Rule.Name)
 		return nil
 	}
 
 	whereStmt := getWhereStmtFromNode(input.Node)
-	if joinNodes, hasIndex := joinConditionInWhereStmtHasIndex(input.Ctx, joinNode, whereStmt, tableConstarints); joinNodes && !hasIndex {
+	if joinNodes, hasIndex := joinConditionInWhereStmtHasIndex(input.Ctx, joinNode, whereStmt, tableIndexes); joinNodes && !hasIndex {
 		addResult(input.Res, input.Rule, input.Rule.Name)
 		return nil
 	}

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -2643,36 +2643,9 @@ func checkJoinFieldType(input *RuleHandlerInput) error {
 }
 
 func checkHasJoinCondition(input *RuleHandlerInput) error {
-	var joinNode *ast.Join
-	var whereStmt ast.ExprNode
-
-	switch stmt := input.Node.(type) {
-	case *ast.SelectStmt:
-		if stmt.From == nil {
-			return nil
-		}
-		joinNode = stmt.From.TableRefs
-		if stmt.Where != nil {
-			whereStmt = stmt.Where
-		}
-	case *ast.UpdateStmt:
-		if stmt.TableRefs == nil {
-			return nil
-		}
-		joinNode = stmt.TableRefs.TableRefs
-		if stmt.Where != nil {
-			whereStmt = stmt.Where
-		}
-	case *ast.DeleteStmt:
-		if stmt.TableRefs == nil {
-			return nil
-		}
-		joinNode = stmt.TableRefs.TableRefs
-		if stmt.Where != nil {
-			whereStmt = stmt.Where
-		}
-	default:
-		// 不检查JOIN不会存在的语句
+	joinNode := getJoinNodeFromNode(input.Node)
+	whereStmt := getWhereExpr(input.Node)
+	if joinNode == nil {
 		return nil
 	}
 	joinTables, hasCondition := checkJoinConditionInJoinNode(input.Ctx, whereStmt, joinNode)
@@ -2683,7 +2656,7 @@ func checkHasJoinCondition(input *RuleHandlerInput) error {
 }
 
 func doesNotJoinTables(tableRefs *ast.Join) bool {
-	return tableRefs.Left == nil || tableRefs.Right == nil
+	return tableRefs == nil || tableRefs.Left == nil || tableRefs.Right == nil
 }
 
 func checkJoinConditionInJoinNode(ctx *session.Context, whereStmt ast.ExprNode, joinNode *ast.Join) (joinTables, hasCondition bool) {
@@ -7459,57 +7432,264 @@ func isColumnUseLeftMostPrefix(allCols []string, constraints []*ast.Constraint) 
 	return true
 }
 
-func judgeColumnIsIndex(columnNameExpr *ast.ColumnNameExpr, columnNames []*ast.ColumnName) bool {
-	for _, column := range columnNames {
-		if column.Name.L == columnNameExpr.Name.Name.L {
+/*
+checkJoinFieldUseIndex 判断Join语句中被驱动表中作为连接条件的列是否属于索引
+
+	触发条件：
+		A. CrossJoin和RightJoin (选择驱动表的情况复杂：随着数据变化而变化，因此都判断)
+			1. 分别判断ON USING WHERE中的连接条件是否有索引
+		B. LeftJoin (选择驱动表的情况固定：Join右侧的表为被驱动表)
+			1. ON和USING，判断LeftJoin的被驱动表 (右侧的表) 的连接条件是否有索引
+			2. 判断WHERE中的连接条件是否有索引
+	连接条件：等值条件两侧为不同表的列
+	支持情况：
+		支持：
+			1. 多表JOIN
+			2. 判断单列索引和复合索引
+		不支持：
+			1. 子查询中JOIN多表的判断
+*/
+func checkJoinFieldUseIndex(input *RuleHandlerInput) error {
+
+	joinNode := getJoinNodeFromNode(input.Node)
+	if doesNotJoinTables(joinNode) {
+		// 如果SQL没有JOIN多表，则不需要审核
+		return nil
+	}
+	tableNameCreateTableStmtMap := getTableNameCreateTableStmtMap(input.Ctx, joinNode)
+	tableConstarints := make(map[string][]*ast.Constraint, len(tableNameCreateTableStmtMap))
+	for table, createTableStmt := range tableNameCreateTableStmtMap {
+		tableConstarints[table] = createTableStmt.Constraints
+	}
+
+	if joinNodes, hasIndex := joinConditionInJoinNodeHasIndex(input.Ctx, joinNode, tableConstarints); joinNodes && !hasIndex {
+		addResult(input.Res, input.Rule, input.Rule.Name)
+		return nil
+	}
+
+	whereStmt := getWhereStmtFromNode(input.Node)
+	if joinNodes, hasIndex := joinConditionInWhereStmtHasIndex(input.Ctx, joinNode, whereStmt, tableConstarints); joinNodes && !hasIndex {
+		addResult(input.Res, input.Rule, input.Rule.Name)
+		return nil
+	}
+	return nil
+}
+
+func joinConditionInWhereStmtHasIndex(ctx *session.Context, joinNode *ast.Join, whereStmt ast.ExprNode, tableIndex map[string][]*ast.Constraint) (joinTables, hasIndex bool) {
+	if doesNotJoinTables(joinNode) {
+		return false, false
+	}
+	if whereStmt == nil {
+		return false, false
+	}
+
+	visitor := util.EqualConditionVisitor{}
+	whereStmt.Accept(&visitor)
+	tableColumn := make(map[string] /*table name*/ map[string] /*column name*/ struct{})
+	for _, condition := range visitor.ConditionList {
+		if tableColumn[condition.Left.Table.L] == nil {
+			tableColumn[condition.Left.Table.L] = make(map[string]struct{})
+		}
+		if tableColumn[condition.Right.Table.L] == nil {
+			tableColumn[condition.Right.Table.L] = make(map[string]struct{})
+		}
+		tableColumn[condition.Left.Table.L][condition.Left.Name.L] = struct{}{}
+		tableColumn[condition.Right.Table.L][condition.Right.Name.L] = struct{}{}
+	}
+	for tableName, columnMap := range tableColumn {
+		if constraints, ok := tableIndex[tableName]; ok {
+			if !IsIndex(columnMap, constraints) {
+				return true, false
+			}
+		}
+	}
+
+	return true, true
+}
+
+func joinConditionInJoinNodeHasIndex(ctx *session.Context, joinNode *ast.Join, tableIndex map[string] /*table name*/ []*ast.Constraint) (joinTables, hasIndex bool) {
+	if doesNotJoinTables(joinNode) {
+		return false, false
+	}
+	// 深度遍历左子树类型为ast.Join的节点
+	if l, ok := joinNode.Left.(*ast.Join); ok {
+		joinTables, hasIndex = joinConditionInJoinNodeHasIndex(ctx, l, tableIndex)
+		if joinTables && !hasIndex {
+			return joinTables, hasIndex
+		}
+	}
+
+	tableColumn := make(map[string] /*table name*/ map[string] /*column name*/ struct{})
+
+	if isJoinConditionInOnClause(joinNode) {
+		visitor := util.EqualConditionVisitor{}
+		joinNode.On.Accept(&visitor)
+		for _, condition := range visitor.ConditionList {
+			if tableColumn[condition.Left.Table.L] == nil {
+				tableColumn[condition.Left.Table.L] = make(map[string]struct{})
+			}
+			if tableColumn[condition.Right.Table.L] == nil {
+				tableColumn[condition.Right.Table.L] = make(map[string]struct{})
+			}
+			tableColumn[condition.Left.Table.L][condition.Left.Name.L] = struct{}{}
+			tableColumn[condition.Right.Table.L][condition.Right.Name.L] = struct{}{}
+		}
+	}
+	if isJoinConditionInUsingClause(joinNode) {
+		leftTableSource, rightTableSource := getTableSourcesBesideJoin(joinNode)
+		if leftTableSource != nil {
+			tableName := getTableName(leftTableSource)
+			for _, columnName := range joinNode.Using {
+				if tableColumn[tableName] == nil {
+					tableColumn[tableName] = make(map[string]struct{})
+				}
+				tableColumn[tableName][columnName.Name.L] = struct{}{}
+			}
+		}
+		if rightTableSource != nil {
+			tableName := getTableName(rightTableSource)
+			for _, columnName := range joinNode.Using {
+				if tableColumn[tableName] == nil {
+					tableColumn[tableName] = make(map[string]struct{})
+				}
+				tableColumn[tableName][columnName.Name.L] = struct{}{}
+			}
+		}
+	}
+	var isLeftJoin bool = (joinNode.Tp == ast.LeftJoin)
+	var rightTableName string
+	if isLeftJoin {
+		if tableSource, ok := joinNode.Right.(*ast.TableSource); ok {
+			rightTableName = getTableName(tableSource)
+		}
+	}
+	for tableName, columnMap := range tableColumn {
+		if isLeftJoin && tableName != rightTableName {
+			continue
+		}
+		if constraints, ok := tableIndex[tableName]; ok {
+			if !IsIndex(columnMap, constraints) {
+				return true, false
+			}
+		}
+	}
+	return true, true
+}
+
+/*
+IsIndex
+
+	判断单列或多列是否属于索引切片中的索引：
+		1. 单列：满足单列索引或多列索引的第一列，则返回true
+		2. 多列：满足N列是M列索引的前N列（M>=N），则返回true
+		3. 否则返回false
+*/
+func IsIndex(columnMap map[string] /*column name*/ struct{}, constraints []*ast.Constraint) bool {
+	for _, constraint := range constraints {
+		if len(columnMap) > len(constraint.Keys) {
+			// 若符合索引的列数小于关联列的列数 一定不满足多列索引
+			continue
+		}
+		var matchCount int
+		for _, key := range constraint.Keys {
+			if _, ok := columnMap[key.Column.Name.L]; ok {
+				matchCount++
+			} else {
+				break
+			}
+		}
+		if matchCount == len(columnMap) {
 			return true
 		}
 	}
 	return false
 }
 
-func checkJoinFieldUseIndex(input *RuleHandlerInput) error {
-	tableNameCreateTableStmtMap, onConditions := getCreateTableAndOnCondition(input)
-	if tableNameCreateTableStmtMap == nil || onConditions == nil {
+/*
+示例SQL:
+
+	select * from a join b join c join d;
+						   ↑
+	如果*ast.Join节点是↑所指的join，拿到的是b和c两张表的tableSource
+
+	select * from a join b join c join d;
+								  ↑
+	如果*ast.Join节点是↑所指的join，拿到的是c和d两张表的tableSource
+
+	SQL: select * from a join(1) b join(2) c join(3) d;中join的抽象语法树如下:
+
+		 join(3)
+		 /     \
+	   join(2)  d
+	   /     \
+	 join(1)  c
+	 /    \
+	a      b
+*/
+func getTableSourcesBesideJoin(joinNode *ast.Join) (left *ast.TableSource, right *ast.TableSource) {
+	if tableSource, ok := joinNode.Right.(*ast.TableSource); ok {
+		right = tableSource
+	}
+	if tableSource, ok := joinNode.Left.(*ast.TableSource); ok {
+		left = tableSource
+	}
+	if join, ok := joinNode.Left.(*ast.Join); ok {
+		if tableSource, ok := join.Right.(*ast.TableSource); ok {
+			left = tableSource
+		}
+	}
+	return
+}
+
+func getTableName(tableSource *ast.TableSource) string {
+	if tableNameStmt, ok := tableSource.Source.(*ast.TableName); ok {
+		if tableSource.AsName.L != "" {
+			return tableSource.AsName.L
+		}
+		return tableNameStmt.Name.L
+	}
+	return ""
+}
+
+func getJoinNodeFromNode(node ast.Node) *ast.Join {
+	switch stmt := node.(type) {
+	case *ast.SelectStmt:
+		if stmt.From == nil {
+			return nil
+		}
+		return stmt.From.TableRefs
+	case *ast.UpdateStmt:
+		if stmt.TableRefs == nil {
+			return nil
+		}
+		return stmt.TableRefs.TableRefs
+	case *ast.DeleteStmt:
+		if stmt.TableRefs == nil {
+			return nil
+		}
+		return stmt.TableRefs.TableRefs
+	default:
 		return nil
 	}
-	tableNameIndexMap := make(map[string][]*ast.ColumnName)
+}
 
-	for table, createTableStmt := range tableNameCreateTableStmtMap {
-		indexes := []*ast.ColumnName{}
-		for _, constraint := range createTableStmt.Constraints {
-			// 联合索引只取第一个字段
-			if len(constraint.Keys) > 0 {
-				indexes = append(indexes, constraint.Keys[0].Column)
-			}
+func getWhereStmtFromNode(node ast.Node) ast.ExprNode {
+	switch stmt := node.(type) {
+	case *ast.SelectStmt:
+		if stmt.Where != nil {
+			return stmt.Where
 		}
-		tableNameIndexMap[table] = indexes
-	}
-	for _, onCondition := range onConditions {
-		var isUseIndex bool
-		binaryOperation, ok := onCondition.Expr.(*ast.BinaryOperationExpr)
-		if !ok {
-			continue
+	case *ast.UpdateStmt:
+		if stmt.Where != nil {
+			return stmt.Where
 		}
-		if columnNameExpr, ok := binaryOperation.L.(*ast.ColumnNameExpr); ok {
-			if columnNames, ok := tableNameIndexMap[columnNameExpr.Name.Table.L]; ok {
-				isUseIndex = judgeColumnIsIndex(columnNameExpr, columnNames)
-				if !isUseIndex {
-					addResult(input.Res, input.Rule, input.Rule.Name)
-					return nil
-				}
-			}
+	case *ast.DeleteStmt:
+		if stmt.Where != nil {
+			return stmt.Where
 		}
-
-		if columnNameExpr, ok := binaryOperation.R.(*ast.ColumnNameExpr); ok {
-			if columnNames, ok := tableNameIndexMap[columnNameExpr.Name.Table.L]; ok {
-				isUseIndex = judgeColumnIsIndex(columnNameExpr, columnNames)
-				if !isUseIndex {
-					addResult(input.Res, input.Rule, input.Rule.Name)
-					return nil
-				}
-			}
-		}
+	default:
+		// 不检查JOIN不会存在的语句
+		return nil
 	}
 	return nil
 }

--- a/sqle/driver/mysql/session/context_test.go
+++ b/sqle/driver/mysql/session/context_test.go
@@ -1,9 +1,10 @@
 package session
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"unicode"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_LoadSchemaLowerCaseTableNamesOpen(t *testing.T) {
@@ -26,7 +27,7 @@ func Test_LoadSchemaLowerCaseTableNamesOpen(t *testing.T) {
 func Test_LoadTablesLowerCaseTableNamesOpen(t *testing.T) {
 	context := &Context{
 		schemas: map[string]*SchemaInfo{
-			"exist_db": &SchemaInfo{},
+			"exist_db": {},
 		},
 		schemaHasLoad: true,
 		sysVars: map[string]string{


### PR DESCRIPTION
#2089 
1. fix: rule not triggered by the SQL below, in this SQL, table2.column_1 do not have index.
``` sql
select * from table_1 left join table_2 on table_1.column_1 = table_2.column_1 and table_1.column_2 = 'some_value';
select * from table_1 cross join table_2 where table_1.column_1 = table_2.column_1 and table_1.column_2 = 'some_value';
```
3. support check multi-column index
4. support check USING and WHERE clause
5. support check multi-join SQL