### PR TITLE
fix: increase rule coverage and cover subqueries 

### DIFF
--- a/sqle/driver/mysql/audit_offline_test.go
+++ b/sqle/driver/mysql/audit_offline_test.go
@@ -2867,6 +2867,18 @@ func TestDMLHintCountFuncWithCol(t *testing.T) {
 			ON t1.a = t2.c AND t1.b = t2.d;`,
 			newTestResult().addResult(rulepkg.DMLHintCountFuncWithCol))
 	})
+	t.Run(`select fields contain different count(4) `, func(t *testing.T) {
+		runSingleRuleInspectCase(
+			rule,
+			t,
+			``,
+			DefaultMysqlInspectOffline(),
+			`SELECT t1.a, t1.b, t2.col_count   
+			FROM test_table AS t1   
+			LEFT JOIN (SELECT c, COUNT(distinct col_1) AS distinct_count FROM test_table_1) AS t2   
+			ON t1.a = t2.c AND t1.b = t2.d;`,
+			newTestResult())
+	})
 }
 
 func TestDDLCheckAutoIncrementFieldNum(t *testing.T) {

--- a/sqle/driver/mysql/audit_offline_test.go
+++ b/sqle/driver/mysql/audit_offline_test.go
@@ -2855,6 +2855,18 @@ func TestDMLHintCountFuncWithCol(t *testing.T) {
 			`SELECT a, b,COUNT(distinct col), COUNT(distinct(col)) AS t FROM test_table GROUP BY a,b ORDER BY a,t DESC;`,
 			newTestResult())
 	})
+	t.Run(`select fields contain different count(3) `, func(t *testing.T) {
+		runSingleRuleInspectCase(
+			rule,
+			t,
+			``,
+			DefaultMysqlInspectOffline(),
+			`SELECT t1.a, t1.b, COUNT(distinct t1.col) AS distinct_count, t2.col_count   
+			FROM test_table AS t1   
+			LEFT JOIN (SELECT c, d, COUNT(col_1) AS col_count FROM test_table_1) AS t2   
+			ON t1.a = t2.c AND t1.b = t2.d;`,
+			newTestResult().addResult(rulepkg.DMLHintCountFuncWithCol))
+	})
 }
 
 func TestDDLCheckAutoIncrementFieldNum(t *testing.T) {

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -6215,8 +6215,9 @@ func hintSumFuncTips(input *RuleHandlerInput) error {
 }
 
 func hintCountFuncWithCol(input *RuleHandlerInput) error {
-	switch stmt := input.Node.(type) {
-	case *ast.SelectStmt:
+	extractor := util.SelectStmtExtractor{}
+	input.Node.Accept(&extractor)
+	for _, stmt := range extractor.SelectStmts {
 		for _, f := range stmt.Fields.Fields {
 			if fu, ok := f.Expr.(*ast.AggregateFuncExpr); ok && strings.ToLower(fu.F) == "count" {
 				if fu.Distinct {
@@ -6230,10 +6231,7 @@ func hintCountFuncWithCol(input *RuleHandlerInput) error {
 				}
 			}
 		}
-	default:
-		return nil
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
#2062 
## Solution
Scan SQL to get all select statement, then scan every select fields of every select statement, if find a field using `COUNT` but not using `DISTINCT`, rule triggere.