### PR TITLE
Add schema parameter to convertRawSQLToModelSQLs function

### DIFF
--- a/sqle/server/auditplan/task.go
+++ b/sqle/server/auditplan/task.go
@@ -282,12 +282,13 @@ func convertSQLsToModelSQLs(sqls []*SQL) []*model.AuditPlanSQLV2 {
 	return as
 }
 
-func convertRawSQLToModelSQLs(sqls []string) []*model.AuditPlanSQLV2 {
+func convertRawSQLToModelSQLs(sqls []string, schema string) []*model.AuditPlanSQLV2 {
 	as := make([]*model.AuditPlanSQLV2, len(sqls))
 	for i, sql := range sqls {
 		as[i] = &model.AuditPlanSQLV2{
 			Fingerprint: sql,
 			SQLContent:  sql,
+			Schema:      schema,
 		}
 	}
 	return as
@@ -442,7 +443,7 @@ func (at *SchemaMetaTask) collectorDo() {
 		sqls = append(sqls, sql)
 	}
 	if len(sqls) > 0 {
-		err = at.persist.OverrideAuditPlanSQLs(at.ap.ID, convertRawSQLToModelSQLs(sqls))
+		err = at.persist.OverrideAuditPlanSQLs(at.ap.ID, convertRawSQLToModelSQLs(sqls, at.ap.InstanceDatabase))
 		if err != nil {
 			at.logger.Errorf("save schema meta to storage fail, error: %v", err)
 		}


### PR DESCRIPTION
https://github.com/actiontech/sqle-ee/issues/1230
The convertRawSQLToModelSQLs function was updated to include a 'schema' parameter for handling SQL schema identification. This change improves the system's search capability, allowing users to perform more flexible and precise schema searches. The calling function and related documentation have been updated accordingly.