### PR TITLE
fix: non equivalent conditions do not exclude columns with inappropriate types

### DIFF
--- a/sqle/driver/mysql/advisor.go
+++ b/sqle/driver/mysql/advisor.go
@@ -616,6 +616,7 @@ func (a *threeStarIndexAdvisor) giveAdvice() {
 				continue
 			}
 			a.adviceColumns.add(column)
+			break
 		}
 	}
 }

--- a/sqle/driver/mysql/advisor.go
+++ b/sqle/driver/mysql/advisor.go
@@ -611,8 +611,11 @@ func (a *threeStarIndexAdvisor) giveAdvice() {
 	}
 	// 最后添加一列WHERE中的非等值列
 	if a.canAddUnequalColumn() {
-		if a.drivingTableColumn.unequalColumnInWhere.len() > 0 {
-			a.adviceColumns.add(a.drivingTableColumn.unequalColumnInWhere.columns[0])
+		for _, column := range a.drivingTableColumn.unequalColumnInWhere.columns {
+			if !isColumnTypeRecommended(column.columnDefine) {
+				continue
+			}
+			a.adviceColumns.add(column)
 		}
 	}
 }
@@ -660,9 +663,7 @@ func (a threeStarIndexAdvisor) shouldSkipColumn(column *column) bool {
 		// 跳过选择性小于最低阈值的列
 		return true
 	}
-	switch column.columnDefine.Tp.Tp {
-	case mysql.TypeBlob, mysql.TypeLongBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeJSON:
-		// 跳过列类型不适合作为索引的列
+	if !isColumnTypeRecommended(column.columnDefine) {
 		return true
 	}
 	return false
@@ -715,13 +716,20 @@ func (a threeStarIndexAdvisor) canGiveCoverIndex() bool {
 	}
 	// 如果备选列中存在列类型是不合适作为索引的列的，不添加覆盖索引
 	for _, column := range a.possibleColumns.columns {
-		switch column.columnDefine.Tp.Tp {
-		case mysql.TypeBlob, mysql.TypeLongBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeJSON:
+		if !isColumnTypeRecommended(column.columnDefine) {
 			return false
 		}
 	}
 	// 当备选列大于索引列的上限时，覆盖索引不满足该限制，不添加覆盖索引
 	return a.possibleColumns.len() <= a.maxColumns
+}
+
+func isColumnTypeRecommended(columnDefine *ast.ColumnDef) bool {
+	switch columnDefine.Tp.Tp {
+	case mysql.TypeBlob, mysql.TypeLongBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeJSON:
+		return false
+	}
+	return true
 }
 
 /*

--- a/sqle/driver/mysql/advisor_test.go
+++ b/sqle/driver/mysql/advisor_test.go
@@ -494,6 +494,19 @@ func TestThreeStarOptimize(t *testing.T) {
 		},
 		maxColumn: 3,
 	}
+	testCases["test13-exclude unsuitable types in unequal columns"] = optimizerTestContent{
+		sql: `SELECT * FROM exist_tb_10 t10 WHERE t10.v3 in ("1","2")`,
+		queryResults: []*queryResult{
+			{
+				query:  regexp.QuoteMeta(fmt.Sprintf(explainFormat, `SELECT * FROM exist_tb_10 t10 WHERE t10.v3 in ("1","2")`)),
+				result: sqlmock.NewRows(explainColumns).AddRow(explainTypeAll, "exist_tb_10"),
+			}, {
+				query:  regexp.QuoteMeta(`SELECT COUNT`),
+				result: sqlmock.NewRows([]string{"id", "v1", "v2", "v3", "v4", "v5"}).AddRow(100.00, 23.56, 70.12, 22, 23.4, 30.1),
+			},
+		},
+		maxColumn: 3,
+	}
 	testCases.testAll(mockThreeStarOptimizeResult, t)
 }
 


### PR DESCRIPTION
https://github.com/actiontech/sqle/issues/2190
add the judgment of column types when adding non equivalent columns