### PR TITLE
导出工单时在cvs文件头写入UTF-8 BOM，防止中文乱码

### DIFF
--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -409,7 +409,7 @@ func DownloadTaskSQLReportFile(c echo.Context) error {
 	buff := &bytes.Buffer{}
 	buff.WriteString("\xEF\xBB\xBF") // 写入UTF-8 BOM
 	cw := csv.NewWriter(buff)
-	err = cw.Write([]string{"序号", "SQL", "SQL审核状态", "SQL审核结果", "SQL执行状态", "SQL执行结果", "SQL对应的回滚语句", "SQL描述"})
+	err = cw.Write([]string{"\xEF\xBB\xBF序号", "SQL", "SQL审核状态", "SQL审核结果", "SQL执行状态", "SQL执行结果", "SQL对应的回滚语句", "SQL描述"})
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, errors.New(errors.WriteDataToTheFileError, err))
 	}


### PR DESCRIPTION
issue：github.com/actiontech/sqle-ee/issues/1404
描述：导出工单时在cvs文件头写入UTF-8 BOM，防止Microsoft Office excel打开时出现中文乱码