### PR TITLE
the latest v1 can not prevent files which matches the rule pattern

### DIFF
--- a/.github/workflows/check-pr-files.yml
+++ b/.github/workflows/check-pr-files.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.head_ref != 'main' && !startsWith(github.head_ref, 'release')
     runs-on: ubuntu-latest
     steps:
-      - uses: xalvarez/prevent-file-change-action@v1
+      - uses: xalvarez/prevent-file-change-action@68e23e206c9680e3a4f13d3b10b9d7f506c90d2b
         name: Prevent file change
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 关联的 issue
和功能无关，不建issue
#### 问题
修复github actions中“prevent-file-change”失效的问题
“prevent-file-change”是为了防止把应该提交到ce仓库的公共代码提交到ee仓库的一个job，但是最近发现它失效了，当有错误提交的时候也不会报错

#### 原因
通过回退actions版本可以解决问题，原因可能是中间某次更新导致了主逻辑发生变化。变更繁多，没有具体去定位，因为回退版本就可以达到目的

## 描述你的变更
不再使用标签指定指定版本，改用最初使用的commit号，这样就不会有更新了

#### 影响面
只是github actions的变更，不会影响任何产品功能

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
