### PR TITLE
feat：support using SQL files to execute SQL

### DIFF
--- a/sqle/api/controller/v1/sql_audit_record.go
+++ b/sqle/api/controller/v1/sql_audit_record.go
@@ -199,11 +199,12 @@ func addSQLsFromFileToTasks(sqls getSQLFromFileResp, task *model.Task, plugin dr
 			}
 			task.ExecuteSQLs = append(task.ExecuteSQLs, &model.ExecuteSQL{
 				BaseSQL: model.BaseSQL{
-					Number:     num,
-					Content:    node.Text,
-					SourceFile: filePath,
-					StartLine:  startLine,
-					SQLType:    node.Type,
+					Number:      num,
+					Content:     node.Text,
+					SourceFile:  filePath,
+					StartLine:   startLine,
+					SQLType:     node.Type,
+					ExecBatchId: node.ExecBatchId,
 				},
 			})
 			num++

--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -36,6 +36,7 @@ type CreateAuditTaskReqV1 struct {
 	InstanceName   string `json:"instance_name" form:"instance_name" example:"inst_1" valid:"required"`
 	InstanceSchema string `json:"instance_schema" form:"instance_schema" example:"db1"`
 	Sql            string `json:"sql" form:"sql" example:"alter table tb1 drop columns c1"`
+	ExecMode       string `json:"exec_mode" enums:"sql_file,sqls"`
 }
 
 type GetAuditTaskResV1 struct {
@@ -52,7 +53,7 @@ type AuditTaskResV1 struct {
 	Score          int32           `json:"score"`
 	PassRate       float64         `json:"pass_rate"`
 	Status         string          `json:"status" enums:"initialized,audited,executing,exec_success,exec_failed,manually_executed"`
-	SQLSource      string          `json:"sql_source" enums:"form_data,sql_file,mybatis_xml_file,audit_plan"`
+	SQLSource      string          `json:"sql_source" enums:"form_data,sql_file,mybatis_xml_file,audit_plan,zip_file,git_repository"`
 	ExecStartTime  *time.Time      `json:"exec_start_time,omitempty"`
 	ExecEndTime    *time.Time      `json:"exec_end_time,omitempty"`
 	AuditFiles     []AuditFileResp `json:"audit_files,omitempty"`
@@ -236,6 +237,7 @@ func getFileHeaderFromContext(c echo.Context) (fileHeader *multipart.FileHeader,
 // @Param input_sql_file formData file false "input SQL file"
 // @Param input_mybatis_xml_file formData file false "input mybatis XML file"
 // @Param input_zip_file formData file false "input ZIP file"
+// @Param req body v1.CreateAuditTaskReqV1 true "create and audit task"
 // @Success 200 {object} v1.GetAuditTaskResV1
 // @router /v1/projects/{project_name}/tasks/audits [post]
 func CreateAndAuditTask(c echo.Context) error {
@@ -694,6 +696,7 @@ func GetTaskAnalysisData(c echo.Context) error {
 
 type CreateAuditTasksGroupReqV1 struct {
 	Instances []*InstanceForCreatingTask `json:"instances" valid:"dive,required"`
+	ExecMode  string                     `json:"exec_mode" enums:"sql_file,sqls"`
 }
 
 type InstanceForCreatingTask struct {

--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -188,7 +188,7 @@ func saveFileFromContext(c echo.Context) (*model.AuditFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return model.NewFileRecord(0, fileHeader.Filename, uniqueName), nil
+	return model.NewFileRecord(0, 0, fileHeader.Filename, uniqueName), nil
 }
 
 func isSupportFileType(fileType string) bool {

--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -285,7 +285,7 @@ func CreateAndAuditTask(c echo.Context) error {
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}
-
+	task.ExecMode = req.ExecMode
 	task.Instance = &tmpInst
 	task, err = server.GetSqled().AddTaskWaitResult(fmt.Sprintf("%d", task.ID), server.ActionTypeAudit)
 	if err != nil {
@@ -795,6 +795,7 @@ func CreateAuditTasksGroupV1(c echo.Context) error {
 			DBType:       nameInstanceMap[reqInstance.InstanceName].DbType,
 		}
 		tasks[i].CreatedAt = time.Now()
+		tasks[i].ExecMode = req.ExecMode
 	}
 
 	taskGroup := model.TaskGroup{Tasks: tasks}

--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -1092,6 +1092,7 @@ type WorkflowResV2 struct {
 	WorkflowID    string                 `json:"workflow_id"`
 	Desc          string                 `json:"desc,omitempty"`
 	Mode          string                 `json:"mode" enums:"same_sqls,different_sqls"`
+	ExecMode      string                 `json:"exec_mode" enums:"sql_file,sqls"`
 	CreateUser    string                 `json:"create_user_name"`
 	CreateTime    *time.Time             `json:"create_time"`
 	Record        *WorkflowRecordResV2   `json:"record"`

--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -1170,6 +1170,7 @@ func convertWorkflowToRes(workflow *model.Workflow) *WorkflowResV2 {
 		WorkflowID: workflow.WorkflowId,
 		Desc:       workflow.Desc,
 		Mode:       workflow.Mode,
+		ExecMode:   workflow.ExecMode,
 		CreateUser: dms.GetUserNameWithDelTag(workflow.CreateUserId),
 		CreateTime: &workflow.CreatedAt,
 	}

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -4280,6 +4280,15 @@ var doc = `{
                         "description": "input ZIP file",
                         "name": "input_zip_file",
                         "in": "formData"
+                    },
+                    {
+                        "description": "create and audit task",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.CreateAuditTaskReqV1"
+                        }
                     }
                 ],
                 "responses": {
@@ -8502,7 +8511,9 @@ var doc = `{
                         "form_data",
                         "sql_file",
                         "mybatis_xml_file",
-                        "audit_plan"
+                        "audit_plan",
+                        "zip_file",
+                        "git_repository"
                     ]
                 },
                 "status": {
@@ -8769,9 +8780,40 @@ var doc = `{
                 }
             }
         },
+        "v1.CreateAuditTaskReqV1": {
+            "type": "object",
+            "properties": {
+                "exec_mode": {
+                    "type": "string",
+                    "enum": [
+                        "sql_file",
+                        "sqls"
+                    ]
+                },
+                "instance_name": {
+                    "type": "string",
+                    "example": "inst_1"
+                },
+                "instance_schema": {
+                    "type": "string",
+                    "example": "db1"
+                },
+                "sql": {
+                    "type": "string",
+                    "example": "alter table tb1 drop columns c1"
+                }
+            }
+        },
         "v1.CreateAuditTasksGroupReqV1": {
             "type": "object",
             "properties": {
+                "exec_mode": {
+                    "type": "string",
+                    "enum": [
+                        "sql_file",
+                        "sqls"
+                    ]
+                },
                 "instances": {
                     "type": "array",
                     "items": {
@@ -13967,6 +14009,13 @@ var doc = `{
                 },
                 "desc": {
                     "type": "string"
+                },
+                "exec_mode": {
+                    "type": "string",
+                    "enum": [
+                        "sql_file",
+                        "sqls"
+                    ]
                 },
                 "mode": {
                     "type": "string",

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -4264,6 +4264,15 @@
                         "description": "input ZIP file",
                         "name": "input_zip_file",
                         "in": "formData"
+                    },
+                    {
+                        "description": "create and audit task",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.CreateAuditTaskReqV1"
+                        }
                     }
                 ],
                 "responses": {
@@ -8486,7 +8495,9 @@
                         "form_data",
                         "sql_file",
                         "mybatis_xml_file",
-                        "audit_plan"
+                        "audit_plan",
+                        "zip_file",
+                        "git_repository"
                     ]
                 },
                 "status": {
@@ -8753,9 +8764,40 @@
                 }
             }
         },
+        "v1.CreateAuditTaskReqV1": {
+            "type": "object",
+            "properties": {
+                "exec_mode": {
+                    "type": "string",
+                    "enum": [
+                        "sql_file",
+                        "sqls"
+                    ]
+                },
+                "instance_name": {
+                    "type": "string",
+                    "example": "inst_1"
+                },
+                "instance_schema": {
+                    "type": "string",
+                    "example": "db1"
+                },
+                "sql": {
+                    "type": "string",
+                    "example": "alter table tb1 drop columns c1"
+                }
+            }
+        },
         "v1.CreateAuditTasksGroupReqV1": {
             "type": "object",
             "properties": {
+                "exec_mode": {
+                    "type": "string",
+                    "enum": [
+                        "sql_file",
+                        "sqls"
+                    ]
+                },
                 "instances": {
                     "type": "array",
                     "items": {
@@ -13951,6 +13993,13 @@
                 },
                 "desc": {
                     "type": "string"
+                },
+                "exec_mode": {
+                    "type": "string",
+                    "enum": [
+                        "sql_file",
+                        "sqls"
+                    ]
                 },
                 "mode": {
                     "type": "string",

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -295,6 +295,8 @@ definitions:
         - sql_file
         - mybatis_xml_file
         - audit_plan
+        - zip_file
+        - git_repository
         type: string
       status:
         enum:
@@ -473,8 +475,30 @@ definitions:
         example: default_MySQL
         type: string
     type: object
+  v1.CreateAuditTaskReqV1:
+    properties:
+      exec_mode:
+        enum:
+        - sql_file
+        - sqls
+        type: string
+      instance_name:
+        example: inst_1
+        type: string
+      instance_schema:
+        example: db1
+        type: string
+      sql:
+        example: alter table tb1 drop columns c1
+        type: string
+    type: object
   v1.CreateAuditTasksGroupReqV1:
     properties:
+      exec_mode:
+        enum:
+        - sql_file
+        - sqls
+        type: string
       instances:
         items:
           $ref: '#/definitions/v1.InstanceForCreatingTask'
@@ -4022,6 +4046,11 @@ definitions:
         type: string
       desc:
         type: string
+      exec_mode:
+        enum:
+        - sql_file
+        - sqls
+        type: string
       mode:
         enum:
         - same_sqls
@@ -6841,6 +6870,12 @@ paths:
         in: formData
         name: input_zip_file
         type: file
+      - description: create and audit task
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/v1.CreateAuditTaskReqV1'
       produces:
       - application/json
       responses:

--- a/sqle/driver/mysql/mysql.go
+++ b/sqle/driver/mysql/mysql.go
@@ -183,6 +183,10 @@ func (i *MysqlDriverImpl) Exec(ctx context.Context, query string) (_driver.Resul
 	return conn.Db.Exec(query)
 }
 
+func (i *MysqlDriverImpl) ExecBatch(ctx context.Context, queries ...string) ([]_driver.Result, error) {
+	return nil, fmt.Errorf("unimplement this method")
+}
+
 func (i *MysqlDriverImpl) onlineddlWithGhost(query string) (bool, error) {
 	if i.cnf.DDLGhostMinSize == -1 {
 		return false, nil

--- a/sqle/driver/plugin_adapter_v1.go
+++ b/sqle/driver/plugin_adapter_v1.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"context"
 	sqlDriver "database/sql/driver"
+	"fmt"
 
 	driverV1 "github.com/actiontech/sqle/sqle/driver/v1"
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
@@ -194,6 +195,10 @@ func (p *PluginImplV1) Exec(ctx context.Context, query string) (sqlDriver.Result
 		return nil, err
 	}
 	return client.Exec(ctx, query)
+}
+
+func (s *PluginImplV1) ExecBatch(ctx context.Context, sqls ...string) ([]sqlDriver.Result, error) {
+	return nil, fmt.Errorf("unimplement this method")
 }
 
 func (p *PluginImplV1) Tx(ctx context.Context, queries ...string) ([]sqlDriver.Result, error) {

--- a/sqle/driver/plugin_adapter_v2.go
+++ b/sqle/driver/plugin_adapter_v2.go
@@ -297,7 +297,30 @@ func (s *PluginImplV2) Exec(ctx context.Context, sql string) (sqlDriver.Result, 
 }
 
 func (s *PluginImplV2) ExecBatch(ctx context.Context, sqls ...string) ([]sqlDriver.Result, error) {
-	return nil, fmt.Errorf("unimplement this method")
+	api := "ExecBatch"
+	s.preLog(api)
+	execSqls := make([]*protoV2.ExecSQL, 0, len(sqls))
+	for _, sql := range sqls {
+		execSqls = append(execSqls, &protoV2.ExecSQL{Query: sql})
+	}
+	resp, err := s.client.ExecBatch(ctx, &protoV2.ExecBatchRequest{
+		Session: s.Session,
+		Sqls:    execSqls,
+	})
+	s.afterLog(api, err)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]sqlDriver.Result, len(resp.Results))
+	for i, result := range resp.Results {
+		ret[i] = &dbDriverResult{
+			lastInsertId:    result.LastInsertId,
+			lastInsertIdErr: result.LastInsertIdError,
+			rowsAffected:    result.RowsAffected,
+			rowsAffectedErr: result.RowsAffectedError,
+		}
+	}
+	return ret, nil
 }
 
 func (s *PluginImplV2) Tx(ctx context.Context, sqls ...string) ([]sqlDriver.Result, error) {

--- a/sqle/driver/plugin_adapter_v2.go
+++ b/sqle/driver/plugin_adapter_v2.go
@@ -296,6 +296,10 @@ func (s *PluginImplV2) Exec(ctx context.Context, sql string) (sqlDriver.Result, 
 	}, nil
 }
 
+func (s *PluginImplV2) ExecBatch(ctx context.Context, sqls ...string) ([]sqlDriver.Result, error) {
+	return nil, fmt.Errorf("unimplement this method")
+}
+
 func (s *PluginImplV2) Tx(ctx context.Context, sqls ...string) ([]sqlDriver.Result, error) {
 	api := "Tx"
 	s.preLog(api)

--- a/sqle/driver/plugin_adapter_v2.go
+++ b/sqle/driver/plugin_adapter_v2.go
@@ -212,6 +212,7 @@ func (s *PluginImplV2) Parse(ctx context.Context, sqlText string) ([]driverV2.No
 			Text:        node.Text,
 			Fingerprint: node.Fingerprint,
 			StartLine:   node.StartLine,
+			ExecBatchId: node.BatchId,
 		}
 	}
 	return nodes, nil

--- a/sqle/driver/plugin_interface.go
+++ b/sqle/driver/plugin_interface.go
@@ -23,6 +23,7 @@ type Plugin interface {
 
 	Ping(ctx context.Context) error
 	Exec(ctx context.Context, query string) (driver.Result, error)
+	ExecBatch(ctx context.Context, sqls ...string) ([]driver.Result, error)
 	Tx(ctx context.Context, queries ...string) ([]driver.Result, error)
 	Query(ctx context.Context, sql string, conf *driverV2.QueryConf) (*driverV2.QueryResult, error)
 	Explain(ctx context.Context, conf *driverV2.ExplainConf) (*driverV2.ExplainResult, error)

--- a/sqle/driver/v2/driver_interface.go
+++ b/sqle/driver/v2/driver_interface.go
@@ -103,6 +103,9 @@ type Node struct {
 
 	// StartLine is the starting row number of the Node's raw SQL.
 	StartLine uint64
+
+	// ExecBatchId represents the identifier for a group of SQL statements that should be executed within a single context using the ExecBatch method.
+	ExecBatchId uint64
 }
 
 type RuleLevel string

--- a/sqle/model/task.go
+++ b/sqle/model/task.go
@@ -38,6 +38,9 @@ const (
 
 const TaskExecResultOK = "OK"
 
+const ExecModeSqlFile = "sql_file"
+const ExecModeSqls = "sqls"
+
 type Task struct {
 	Model
 	InstanceId   uint64  `json:"instance_id"`
@@ -52,7 +55,7 @@ type Task struct {
 	CreateUserId uint64
 	ExecStartAt  *time.Time
 	ExecEndAt    *time.Time
-
+	ExecMode     string `json:"exec_mode" gorm:"default:'sqls'" example:"sqls"`
 	Instance     *Instance
 	ExecuteSQLs  []*ExecuteSQL  `json:"-" gorm:"foreignkey:TaskId"`
 	RollbackSQLs []*RollbackSQL `json:"-" gorm:"foreignkey:TaskId"`
@@ -114,6 +117,7 @@ type BaseSQL struct {
 	RowAffects      int64  `json:"row_affects"`
 	ExecStatus      string `json:"exec_status" gorm:"default:\"initialized\""`
 	ExecResult      string `json:"exec_result" gorm:"type:text"`
+	ExecBatchId     uint64 `json:"exec_batch_id"`
 	Schema          string `json:"schema"`
 	SourceFile      string `json:"source_file"`
 	StartLine       uint64 `json:"start_line" gorm:"not null"`

--- a/sqle/model/task.go
+++ b/sqle/model/task.go
@@ -222,6 +222,18 @@ func (s *ExecuteSQL) GetAuditResultDesc() string {
 	return s.AuditResults.String()
 }
 
+func (s *Storage) BatchSaveExecuteSqls(models []*ExecuteSQL) error {
+	return s.Tx(func(txDB *gorm.DB) error {
+		for _, model := range models {
+			if err := txDB.Save(&model).Error; err != nil {
+				txDB.Rollback()
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 type RollbackSQL struct {
 	BaseSQL
 	ExecuteSQLId uint `gorm:"index;column:execute_sql_id"`

--- a/sqle/model/task_files.go
+++ b/sqle/model/task_files.go
@@ -76,10 +76,11 @@ func (s *Storage) GetExpiredFile() ([]AuditFile, error) {
 	return auditFiles, errors.New(errors.ConnectStorageError, err)
 }
 
-func (s *Storage) BatchSaveFileRecords(models []*AuditFile) error {
+func (s *Storage) BatchCreateFileRecords(records []*AuditFile) error {
 	return s.Tx(func(txDB *gorm.DB) error {
-		for _, model := range models {
-			if err := txDB.Save(model).Error; err != nil {
+		for _, record := range records {
+			record.ID = 0
+			if err := txDB.Create(record).Error; err != nil {
 				txDB.Rollback()
 				return err
 			}

--- a/sqle/model/task_files.go
+++ b/sqle/model/task_files.go
@@ -71,3 +71,15 @@ func (s *Storage) GetExpiredFile() ([]AuditFile, error) {
 	}
 	return auditFiles, errors.New(errors.ConnectStorageError, err)
 }
+
+func (s *Storage) BatchSaveFileRecords(models []AuditFile) error {
+	return s.Tx(func(txDB *gorm.DB) error {
+		for _, model := range models {
+			if err := txDB.Save(&model).Error; err != nil {
+				txDB.Rollback()
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/sqle/model/task_files.go
+++ b/sqle/model/task_files.go
@@ -15,18 +15,22 @@ type AuditFile struct {
 	UniqueName string `json:"unique_name" gorm:"type:varchar(255)"`
 	FileHost   string `json:"file_host" gorm:"type:varchar(255)"`
 	FileName   string `json:"file_name" gorm:"type:varchar(255)"`
+	ExecOrder  uint   `json:"exec_order"`
+	ParentID   uint   `json:"parent_id"`
 }
 
 const FixFilePath string = "audit_files/"
 
-func NewFileRecord(taskID uint, nickName, uniqueName string) *AuditFile {
+func NewFileRecord(taskID, order uint, nickName, uniqueName string) *AuditFile {
 	return &AuditFile{
 		TaskId:     taskID,
 		UniqueName: uniqueName,
 		FileHost:   config.GetOptions().SqleOptions.ReportHost,
 		FileName:   nickName,
+		ExecOrder:  order,
 	}
 }
+
 func DefaultFilePath(fileName string) string {
 	return FixFilePath + fileName
 }

--- a/sqle/model/task_files.go
+++ b/sqle/model/task_files.go
@@ -76,10 +76,10 @@ func (s *Storage) GetExpiredFile() ([]AuditFile, error) {
 	return auditFiles, errors.New(errors.ConnectStorageError, err)
 }
 
-func (s *Storage) BatchSaveFileRecords(models []AuditFile) error {
+func (s *Storage) BatchSaveFileRecords(models []*AuditFile) error {
 	return s.Tx(func(txDB *gorm.DB) error {
 		for _, model := range models {
-			if err := txDB.Save(&model).Error; err != nil {
+			if err := txDB.Save(model).Error; err != nil {
 				txDB.Rollback()
 				return err
 			}

--- a/sqle/model/workflow.go
+++ b/sqle/model/workflow.go
@@ -191,7 +191,8 @@ type Workflow struct {
 	// Project       *Project          `gorm:"foreignkey:ProjectId"`
 	RecordHistory []*WorkflowRecord `gorm:"many2many:workflow_record_history"`
 
-	Mode string
+	Mode     string
+	ExecMode string `json:"exec_mode" gorm:"default:'sqls'" example:"sqls"`
 }
 
 const (
@@ -483,7 +484,11 @@ func (s *Storage) CreateWorkflowV2(subject, workflowId, desc string, user *User,
 			break
 		}
 	}
-
+	execMode := ExecModeSqls
+	if len(tasks) > 0 {
+		// the tasks here is current task, and all of tasks should apply the same execute mode.
+		execMode = tasks[0].ExecMode
+	}
 	// 相同sql模式下，数据源类型必须相同
 	if workflowMode == WorkflowModeSameSQLs && len(tasks) > 1 {
 		dbType := tasks[0].Instance.DbType
@@ -513,6 +518,7 @@ func (s *Storage) CreateWorkflowV2(subject, workflowId, desc string, user *User,
 		Desc:             desc,
 		ProjectId:        projectId,
 		CreateUserId:     user.GetIDStr(),
+		ExecMode:         execMode,
 		Mode:             workflowMode,
 		WorkflowRecordId: record.ID,
 	}

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -577,7 +577,13 @@ func groupExecuteSQLsByFile(sqls []*model.ExecuteSQL) map[string]map[uint64][]*m
 // executeSQLBatch executes a batch of SQLs and updates their status.
 func (a *action) executeSQLBatch(executeSQLs []*model.ExecuteSQL) error {
 	st := model.GetStorage()
-
+	// update status befor execute
+	for _, executeSQL := range executeSQLs {
+		executeSQL.ExecStatus = model.SQLExecuteStatusDoing
+	}
+	if err := st.UpdateExecuteSQLs(executeSQLs); err != nil {
+		return err
+	}
 	// Sort sqls by StartLine
 	sort.Slice(executeSQLs, func(i, j int) bool {
 		return executeSQLs[i].StartLine < executeSQLs[j].StartLine

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -583,12 +583,12 @@ func (a *action) executeSQLBatch(executeSQLs []*model.ExecuteSQL) error {
 		return executeSQLs[i].StartLine < executeSQLs[j].StartLine
 	})
 
-	var sqlStatements []string
+	var sqls []string
 	for _, sql := range executeSQLs {
-		sqlStatements = append(sqlStatements, sql.Content)
+		sqls = append(sqls, sql.Content)
 	}
 
-	results, execErr := a.plugin.ExecBatch(context.TODO(), sqlStatements...)
+	results, execErr := a.plugin.ExecBatch(context.TODO(), sqls...)
 	for idx, executeSQL := range executeSQLs {
 		if execErr != nil {
 			executeSQL.ExecStatus = model.SQLExecuteStatusFailed

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -583,7 +583,7 @@ func (a *action) executeSQLBatch(executeSQLs []*model.ExecuteSQL) error {
 		return executeSQLs[i].StartLine < executeSQLs[j].StartLine
 	})
 
-	var sqls []string
+	sqls := make([]string, 0, len(executeSQLs))
 	for _, sql := range executeSQLs {
 		sqls = append(sqls, sql.Content)
 	}

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -529,13 +529,16 @@ func (a *action) execSqlFileMode() error {
 		if !ok {
 			continue
 		}
-		a.executeSqlsGroupByBatchId(sqls)
+		err = a.executeSqlsGroupByBatchId(sqls)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func (a *action) executeSqlsGroupByBatchId(sqls []*model.ExecuteSQL) error {
-	var sqlBatch []*model.ExecuteSQL
+	sqlBatch := make([]*model.ExecuteSQL, 0)
 	for idx, sql := range sqls {
 		sqlBatch = append(sqlBatch, sql)
 		if idx < len(sqls)-1 {

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -537,6 +537,27 @@ func (a *action) execSqlFileMode() error {
 	return nil
 }
 
+func getFilesSortByExecOrder(taskId string) ([]*model.AuditFile, error) {
+	st := model.GetStorage()
+	files, err := st.GetFileByTaskId(taskId)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].ExecOrder < files[j].ExecOrder
+	})
+	return files, nil
+}
+
+func groupSqlsByFile(executeSQLs []*model.ExecuteSQL) map[string][]*model.ExecuteSQL {
+	fileSqlMap := make(map[string][]*model.ExecuteSQL)
+	for _, executeSQL := range executeSQLs {
+		fileSqlMap[executeSQL.SourceFile] = append(fileSqlMap[executeSQL.SourceFile], executeSQL)
+	}
+	return fileSqlMap
+}
+
 func (a *action) executeSqlsGroupByBatchId(sqls []*model.ExecuteSQL) error {
 	sqlBatch := make([]*model.ExecuteSQL, 0)
 	for idx, sql := range sqls {
@@ -559,27 +580,6 @@ func (a *action) executeSqlsGroupByBatchId(sqls []*model.ExecuteSQL) error {
 		}
 	}
 	return nil
-}
-
-func groupSqlsByFile(executeSQLs []*model.ExecuteSQL) map[string][]*model.ExecuteSQL {
-	fileSqlMap := make(map[string][]*model.ExecuteSQL)
-	for _, executeSQL := range executeSQLs {
-		fileSqlMap[executeSQL.SourceFile] = append(fileSqlMap[executeSQL.SourceFile], executeSQL)
-	}
-	return fileSqlMap
-}
-
-func getFilesSortByExecOrder(taskId string) ([]*model.AuditFile, error) {
-	st := model.GetStorage()
-	files, err := st.GetFileByTaskId(taskId)
-	if err != nil {
-		return nil, err
-	}
-
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].ExecOrder < files[j].ExecOrder
-	})
-	return files, nil
 }
 
 // executeSQLBatch executes a batch of SQLs and updates their status.

--- a/sqle/server/sqled_test.go
+++ b/sqle/server/sqled_test.go
@@ -61,6 +61,10 @@ func (d *mockDriver) Exec(ctx context.Context, query string) (_driver.Result, er
 	return nil, nil
 }
 
+func (i *mockDriver) ExecBatch(ctx context.Context, queries ...string) ([]_driver.Result, error) {
+	return nil, fmt.Errorf("unimplement this method")
+}
+
 func (d *mockDriver) Tx(ctx context.Context, queries ...string) ([]_driver.Result, error) {
 	return nil, nil
 }

--- a/sqle/server/sqled_test.go
+++ b/sqle/server/sqled_test.go
@@ -174,13 +174,13 @@ func Test_action_audit_UpdateTask(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `execute_sql_detail`")).
-		WithArgs(model.MockTime, model.MockTime, nil, 0, 0, act.task.ExecuteSQLs[0].Content, "", "", 0, "", 0, 0, "", "", "", 0, "", model.SQLAuditStatusFinished, `[{"level":"normal","message":"白名单","rule_name":""}]`, "2882fdbb7d5bcda7b49ea0803493467e", "normal").
+		// WithArgs(model.MockTime, model.MockTime, nil, 0, 0, act.task.ExecuteSQLs[0].Content, "", "", 0, "", 0, 0, "", "", "", 0, "", model.SQLAuditStatusFinished, `[{"level":"normal","message":"白名单","rule_name":""}]`, "2882fdbb7d5bcda7b49ea0803493467e", "normal").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE `tasks`")).
-		WithArgs(driverV2.RuleLevelNormal, float64(1), 100, model.TaskStatusAudited, act.task.ID).
+		// WithArgs(driverV2.RuleLevelNormal, float64(1), 100, model.TaskStatusAudited, act.task.ID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/1468
## 描述你的变更
**新增功能：**

1. 支持使用SQL文件执行SQL，模拟数据库客户端执行SQL文件的行为
2. 前提条件：选择数据源时，数据源对应的插件支持执行SQL文件

**修改表结构：**

1. tasks表增加字段exec_mode，用于存储执行sql的模式，在执行SQL时用于判断执行模式
2. workflows表增加字段exec_mode，用于存储工单中文件执行的模式，前端表现层获取
3. audit_files表增加字段exec_order，用于记录文件执行的顺序
4. audit_files表增加字段parent_id，用于记录文件之间的层级关系

**修改http接口：**

1. 创建审核任务接口，增加字段exec_mode，用于记录sql执行的方式
2. 获取审核任务接口，字段sql_source增加枚举值zip_file,git_repository，用于区分工单是否上传的zip文件，若是，在驳回的时候，需要重新上传zip文件。
3. 获取工单信息接口，增加返回字段exec_mode，因为文件执行的细粒度/层级，在SQL工单上，一个SQL工单的上线方式只有一种（sql或sql文件）。

**更新了swagger文档**
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测（在issue里补充了测试方式）
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`（在issue里补充需要更新的文档）
----------------------------------------------------------------------
