### PR TITLE
接口复审：SQL审核以文件聚合的展示页面

### DIFF
--- a/sqle/api/app.go
+++ b/sqle/api/app.go
@@ -338,6 +338,7 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config *config.SqleOpti
 		v1Router.GET("/tasks/audits/:task_id/", v1.GetTask)
 		v1Router.GET("/tasks/audits/:task_id/sqls", v1.GetTaskSQLs)
 		v2Router.GET("/tasks/audits/:task_id/sqls", v2.GetTaskSQLs)
+		v2Router.GET("/tasks/audits/:task_id/files", v2.GetAuditTaskFileOverview)
 		v1Router.GET("/tasks/audits/:task_id/sql_report", v1.DownloadTaskSQLReportFile)
 		v1Router.GET("/tasks/audits/:task_id/sql_file", v1.DownloadTaskSQLFile)
 		v1Router.GET("/tasks/audits/:task_id/audit_file", v1.DownloadAuditFile)

--- a/sqle/api/controller/v2/task.go
+++ b/sqle/api/controller/v2/task.go
@@ -14,6 +14,7 @@ type GetAuditTaskSQLsReqV2 struct {
 	FilterExecStatus  string `json:"filter_exec_status" query:"filter_exec_status"`
 	FilterAuditStatus string `json:"filter_audit_status" query:"filter_audit_status"`
 	FilterAuditLevel  string `json:"filter_audit_level" query:"filter_audit_level"`
+	FilterAuditFileId uint   `json:"filter_audit_file_id" query:"filter_audit_file_id"`
 	NoDuplicate       bool   `json:"no_duplicate" query:"no_duplicate"`
 	PageIndex         uint32 `json:"page_index" query:"page_index" valid:"required"`
 	PageSize          uint32 `json:"page_size" query:"page_size" valid:"required"`
@@ -57,6 +58,7 @@ type AuditResult struct {
 // @Param filter_audit_status query string false "filter: audit status of task sql" Enums(initialized,doing,finished)
 // @Param filter_audit_level query string false "filter: audit level of task sql" Enums(normal,notice,warn,error)
 // @Param no_duplicate query boolean false "select unique (fingerprint and audit result) for task sql"
+// @Param filter_audit_file_id query uint false "filter: audit file id of task"
 // @Param page_index query string true "page index"
 // @Param page_size query string true "page size"
 // @Success 200 {object} v2.GetAuditTaskSQLsResV2
@@ -83,13 +85,14 @@ func GetTaskSQLs(c echo.Context) error {
 		offset = req.PageSize * (req.PageIndex - 1)
 	}
 	data := map[string]interface{}{
-		"task_id":             taskId,
-		"filter_exec_status":  req.FilterExecStatus,
-		"filter_audit_status": req.FilterAuditStatus,
-		"filter_audit_level":  req.FilterAuditLevel,
-		"no_duplicate":        req.NoDuplicate,
-		"limit":               req.PageSize,
-		"offset":              offset,
+		"task_id":              taskId,
+		"filter_exec_status":   req.FilterExecStatus,
+		"filter_audit_status":  req.FilterAuditStatus,
+		"filter_audit_level":   req.FilterAuditLevel,
+		"filter_audit_file_id": req.FilterAuditFileId,
+		"no_duplicate":         req.NoDuplicate,
+		"limit":                req.PageSize,
+		"offset":               offset,
 	}
 
 	taskSQLs, count, err := s.GetTaskSQLsByReq(data)

--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -1248,3 +1248,38 @@ func convertWorkflowStepToRes(step *model.WorkflowStep) *WorkflowStepResV2 {
 	stepRes.Users = append(stepRes.Users, strings.Split(step.Assignees, ",")...)
 	return stepRes
 }
+
+type GetAuditTaskFileOverviewRes struct {
+	controller.BaseRes
+	Data      []FileOverview `json:"data"`
+	TotalNums uint64         `json:"total_nums"`
+}
+
+type FileOverview struct {
+	FileID           string            `json:"file_id"`
+	FileName         string            `json:"file_name"`
+	ExecOrder        uint              `json:"exec_order"`
+	ExecStatus       string            `json:"exec_status"`
+	AuditResultFlags *AuditResultFlags `json:"audit_result_flags"`
+}
+
+type AuditResultFlags struct {
+	HasError   bool `json:"has_error"`
+	HasWarning bool `json:"has_warning"`
+	HasNormal  bool `json:"has_normal"`
+	HasNotice  bool `json:"has_notice"`
+}
+
+// GetAuditTaskFileOverview
+// @Summary 获取审核任务文件概览
+// @Description get audit task file overview
+// @Tags task
+// @Id getAuditTaskFileOverview
+// @Security ApiKeyAuth
+// @Param task_id path string true "task id"
+// @Success 200 {object} GetAuditTaskFileOverviewRes
+// @router /v2/tasks/audits/{task_id}/files [get]
+func GetAuditTaskFileOverview(c echo.Context) error {
+	// TODO implement this function
+	return nil
+}

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -8082,7 +8082,7 @@ var doc = `{
                 }
             }
         },
-        "/v2/{project_name}/workflows/{workflow_id}/files": {
+        "/v2/{project_name}/workflows/{workflow_id}/tasks/{task_id}/files": {
             "get": {
                 "security": [
                     {

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -8013,6 +8013,12 @@ var doc = `{
                         "in": "query"
                     },
                     {
+                        "type": "integer",
+                        "description": "filter: audit file id of task",
+                        "name": "filter_audit_file_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "description": "page index",
                         "name": "page_index",
@@ -8071,6 +8077,45 @@ var doc = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/v2.GetTaskAnalysisDataResV2"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/{project_name}/workflows/{workflow_id}/files": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get workflow file overview",
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "获取工单文件概览",
+                "operationId": "getWorkflowFileOverview",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "workflow id",
+                        "name": "workflow_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.WorkflowFileOverviewRes"
                         }
                     }
                 }
@@ -13198,6 +13243,23 @@ var doc = `{
                 }
             }
         },
+        "v2.AuditResultFlags": {
+            "type": "object",
+            "properties": {
+                "has_error": {
+                    "type": "boolean"
+                },
+                "has_normal": {
+                    "type": "boolean"
+                },
+                "has_notice": {
+                    "type": "boolean"
+                },
+                "has_warning": {
+                    "type": "boolean"
+                }
+            }
+        },
         "v2.AuditSQLResV2": {
             "type": "object",
             "properties": {
@@ -13424,6 +13486,27 @@ var doc = `{
                     "type": "string"
                 },
                 "logo_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.FileOverview": {
+            "type": "object",
+            "properties": {
+                "audit_result_flags": {
+                    "type": "object",
+                    "$ref": "#/definitions/v2.AuditResultFlags"
+                },
+                "exec_order": {
+                    "type": "integer"
+                },
+                "exec_status": {
+                    "type": "string"
+                },
+                "file_id": {
+                    "type": "string"
+                },
+                "file_name": {
                     "type": "string"
                 }
             }
@@ -13921,6 +14004,25 @@ var doc = `{
                 },
                 "schedule_time": {
                     "type": "string"
+                }
+            }
+        },
+        "v2.WorkflowFileOverviewRes": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.FileOverview"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
                 }
             }
         },

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -14023,6 +14023,9 @@ var doc = `{
                 "message": {
                     "type": "string",
                     "example": "ok"
+                },
+                "total_nums": {
+                    "type": "integer"
                 }
             }
         },

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -7946,6 +7946,38 @@ var doc = `{
                 }
             }
         },
+        "/v2/tasks/audits/{task_id}/files": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get audit task file overview",
+                "tags": [
+                    "task"
+                ],
+                "summary": "获取审核任务文件概览",
+                "operationId": "getAuditTaskFileOverview",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "task id",
+                        "name": "task_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.GetAuditTaskFileOverviewRes"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/tasks/audits/{task_id}/sqls": {
             "get": {
                 "security": [
@@ -8077,45 +8109,6 @@ var doc = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/v2.GetTaskAnalysisDataResV2"
-                        }
-                    }
-                }
-            }
-        },
-        "/v2/{project_name}/workflows/{workflow_id}/tasks/{task_id}/files": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "get workflow file overview",
-                "tags": [
-                    "workflow"
-                ],
-                "summary": "获取工单文件概览",
-                "operationId": "getWorkflowFileOverview",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "workflow id",
-                        "name": "workflow_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "project name",
-                        "name": "project_name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.WorkflowFileOverviewRes"
                         }
                     }
                 }
@@ -13583,6 +13576,28 @@ var doc = `{
                 }
             }
         },
+        "v2.GetAuditTaskFileOverviewRes": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.FileOverview"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                },
+                "total_nums": {
+                    "type": "integer"
+                }
+            }
+        },
         "v2.GetAuditTaskSQLsResV2": {
             "type": "object",
             "properties": {
@@ -14004,28 +14019,6 @@ var doc = `{
                 },
                 "schedule_time": {
                     "type": "string"
-                }
-            }
-        },
-        "v2.WorkflowFileOverviewRes": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer",
-                    "example": 0
-                },
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/v2.FileOverview"
-                    }
-                },
-                "message": {
-                    "type": "string",
-                    "example": "ok"
-                },
-                "total_nums": {
-                    "type": "integer"
                 }
             }
         },

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -8066,7 +8066,7 @@
                 }
             }
         },
-        "/v2/{project_name}/workflows/{workflow_id}/files": {
+        "/v2/{project_name}/workflows/{workflow_id}/tasks/{task_id}/files": {
             "get": {
                 "security": [
                     {

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -7997,6 +7997,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "integer",
+                        "description": "filter: audit file id of task",
+                        "name": "filter_audit_file_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "description": "page index",
                         "name": "page_index",
@@ -8055,6 +8061,45 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/v2.GetTaskAnalysisDataResV2"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/{project_name}/workflows/{workflow_id}/files": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get workflow file overview",
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "获取工单文件概览",
+                "operationId": "getWorkflowFileOverview",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "workflow id",
+                        "name": "workflow_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.WorkflowFileOverviewRes"
                         }
                     }
                 }
@@ -13182,6 +13227,23 @@
                 }
             }
         },
+        "v2.AuditResultFlags": {
+            "type": "object",
+            "properties": {
+                "has_error": {
+                    "type": "boolean"
+                },
+                "has_normal": {
+                    "type": "boolean"
+                },
+                "has_notice": {
+                    "type": "boolean"
+                },
+                "has_warning": {
+                    "type": "boolean"
+                }
+            }
+        },
         "v2.AuditSQLResV2": {
             "type": "object",
             "properties": {
@@ -13408,6 +13470,27 @@
                     "type": "string"
                 },
                 "logo_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.FileOverview": {
+            "type": "object",
+            "properties": {
+                "audit_result_flags": {
+                    "type": "object",
+                    "$ref": "#/definitions/v2.AuditResultFlags"
+                },
+                "exec_order": {
+                    "type": "integer"
+                },
+                "exec_status": {
+                    "type": "string"
+                },
+                "file_id": {
+                    "type": "string"
+                },
+                "file_name": {
                     "type": "string"
                 }
             }
@@ -13905,6 +13988,25 @@
                 },
                 "schedule_time": {
                     "type": "string"
+                }
+            }
+        },
+        "v2.WorkflowFileOverviewRes": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.FileOverview"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
                 }
             }
         },

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -14007,6 +14007,9 @@
                 "message": {
                     "type": "string",
                     "example": "ok"
+                },
+                "total_nums": {
+                    "type": "integer"
                 }
             }
         },

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -7930,6 +7930,38 @@
                 }
             }
         },
+        "/v2/tasks/audits/{task_id}/files": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get audit task file overview",
+                "tags": [
+                    "task"
+                ],
+                "summary": "获取审核任务文件概览",
+                "operationId": "getAuditTaskFileOverview",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "task id",
+                        "name": "task_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.GetAuditTaskFileOverviewRes"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/tasks/audits/{task_id}/sqls": {
             "get": {
                 "security": [
@@ -8061,45 +8093,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/v2.GetTaskAnalysisDataResV2"
-                        }
-                    }
-                }
-            }
-        },
-        "/v2/{project_name}/workflows/{workflow_id}/tasks/{task_id}/files": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "get workflow file overview",
-                "tags": [
-                    "workflow"
-                ],
-                "summary": "获取工单文件概览",
-                "operationId": "getWorkflowFileOverview",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "workflow id",
-                        "name": "workflow_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "project name",
-                        "name": "project_name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.WorkflowFileOverviewRes"
                         }
                     }
                 }
@@ -13567,6 +13560,28 @@
                 }
             }
         },
+        "v2.GetAuditTaskFileOverviewRes": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.FileOverview"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                },
+                "total_nums": {
+                    "type": "integer"
+                }
+            }
+        },
         "v2.GetAuditTaskSQLsResV2": {
             "type": "object",
             "properties": {
@@ -13988,28 +14003,6 @@
                 },
                 "schedule_time": {
                     "type": "string"
-                }
-            }
-        },
-        "v2.WorkflowFileOverviewRes": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer",
-                    "example": 0
-                },
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/v2.FileOverview"
-                    }
-                },
-                "message": {
-                    "type": "string",
-                    "example": "ok"
-                },
-                "total_nums": {
-                    "type": "integer"
                 }
             }
         },

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -8547,7 +8547,7 @@ paths:
       summary: 获取全局工单列表
       tags:
       - workflow
-  /v2/{project_name}/workflows/{workflow_id}/files:
+  /v2/{project_name}/workflows/{workflow_id}/tasks/{task_id}/files:
     get:
       description: get workflow file overview
       operationId: getWorkflowFileOverview

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -3492,6 +3492,17 @@ definitions:
       rule_name:
         type: string
     type: object
+  v2.AuditResultFlags:
+    properties:
+      has_error:
+        type: boolean
+      has_normal:
+        type: boolean
+      has_notice:
+        type: boolean
+      has_warning:
+        type: boolean
+    type: object
   v2.AuditSQLResV2:
     properties:
       audit_level:
@@ -3649,6 +3660,20 @@ definitions:
       driver_name:
         type: string
       logo_url:
+        type: string
+    type: object
+  v2.FileOverview:
+    properties:
+      audit_result_flags:
+        $ref: '#/definitions/v2.AuditResultFlags'
+        type: object
+      exec_order:
+        type: integer
+      exec_status:
+        type: string
+      file_id:
+        type: string
+      file_name:
         type: string
     type: object
   v2.FullSyncAuditPlanSQLsReqV2:
@@ -3989,6 +4014,19 @@ definitions:
         - feishu
         type: string
       schedule_time:
+        type: string
+    type: object
+  v2.WorkflowFileOverviewRes:
+    properties:
+      code:
+        example: 0
+        type: integer
+      data:
+        items:
+          $ref: '#/definitions/v2.FileOverview'
+        type: array
+      message:
+        example: ok
         type: string
     type: object
   v2.WorkflowRecordResV2:
@@ -8507,6 +8545,31 @@ paths:
       summary: 获取全局工单列表
       tags:
       - workflow
+  /v2/{project_name}/workflows/{workflow_id}/files:
+    get:
+      description: get workflow file overview
+      operationId: getWorkflowFileOverview
+      parameters:
+      - description: workflow id
+        in: path
+        name: workflow_id
+        required: true
+        type: string
+      - description: project name
+        in: path
+        name: project_name
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.WorkflowFileOverviewRes'
+      security:
+      - ApiKeyAuth: []
+      summary: 获取工单文件概览
+      tags:
+      - workflow
   /v2/audit_files:
     post:
       description: Direct audit sql from SQL files and MyBatis files
@@ -9274,6 +9337,10 @@ paths:
         in: query
         name: no_duplicate
         type: boolean
+      - description: 'filter: audit file id of task'
+        in: query
+        name: filter_audit_file_id
+        type: integer
       - description: page index
         in: query
         name: page_index

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -4028,6 +4028,8 @@ definitions:
       message:
         example: ok
         type: string
+      total_nums:
+        type: integer
     type: object
   v2.WorkflowRecordResV2:
     properties:

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -3725,6 +3725,21 @@ definitions:
       total_nums:
         type: integer
     type: object
+  v2.GetAuditTaskFileOverviewRes:
+    properties:
+      code:
+        example: 0
+        type: integer
+      data:
+        items:
+          $ref: '#/definitions/v2.FileOverview'
+        type: array
+      message:
+        example: ok
+        type: string
+      total_nums:
+        type: integer
+    type: object
   v2.GetAuditTaskSQLsResV2:
     properties:
       code:
@@ -4015,21 +4030,6 @@ definitions:
         type: string
       schedule_time:
         type: string
-    type: object
-  v2.WorkflowFileOverviewRes:
-    properties:
-      code:
-        example: 0
-        type: integer
-      data:
-        items:
-          $ref: '#/definitions/v2.FileOverview'
-        type: array
-      message:
-        example: ok
-        type: string
-      total_nums:
-        type: integer
     type: object
   v2.WorkflowRecordResV2:
     properties:
@@ -8547,31 +8547,6 @@ paths:
       summary: 获取全局工单列表
       tags:
       - workflow
-  /v2/{project_name}/workflows/{workflow_id}/tasks/{task_id}/files:
-    get:
-      description: get workflow file overview
-      operationId: getWorkflowFileOverview
-      parameters:
-      - description: workflow id
-        in: path
-        name: workflow_id
-        required: true
-        type: string
-      - description: project name
-        in: path
-        name: project_name
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/v2.WorkflowFileOverviewRes'
-      security:
-      - ApiKeyAuth: []
-      summary: 获取工单文件概览
-      tags:
-      - workflow
   /v2/audit_files:
     post:
       description: Direct audit sql from SQL files and MyBatis files
@@ -9295,6 +9270,26 @@ paths:
       summary: 直接审核SQL
       tags:
       - sql_audit
+  /v2/tasks/audits/{task_id}/files:
+    get:
+      description: get audit task file overview
+      operationId: getAuditTaskFileOverview
+      parameters:
+      - description: task id
+        in: path
+        name: task_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.GetAuditTaskFileOverviewRes'
+      security:
+      - ApiKeyAuth: []
+      summary: 获取审核任务文件概览
+      tags:
+      - task
   /v2/tasks/audits/{task_id}/sqls:
     get:
       description: get information of all SQLs belong to the specified audit task

--- a/sqle/model/task.go
+++ b/sqle/model/task.go
@@ -478,6 +478,9 @@ var taskSQLsCountTpl = `SELECT COUNT(*)
 var taskSQLsQueryBodyTpl = `
 {{ define "body" }}
 FROM execute_sql_detail AS e_sql
+{{- if .filter_audit_file_id }}
+LEFT JOIN audit_files ON audit_files.task_id = e_sql.task_id
+{{- end }}
 LEFT JOIN rollback_sql_detail AS r_sql ON e_sql.id = r_sql.execute_sql_id
 WHERE
 e_sql.deleted_at IS NULL
@@ -493,6 +496,10 @@ AND e_sql.audit_status = :filter_audit_status
 
 {{- if .filter_audit_level }}
 AND e_sql.audit_level = :filter_audit_level
+{{- end }}
+
+{{- if .filter_audit_file_id }}
+AND audit_files.id = :filter_audit_file_id
 {{- end }}
 
 {{- if .no_duplicate }}


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/1468
## 描述你的变更
### 调用逻辑
**调用逻辑中，与原有的调用流程相比，原来的流程是1->3，新增流程2，当工单上线模式是文件模式时，流程变为1->2->3，并且3根据文件id进行筛选。其他无变化。**
1. 用户点击SQL工单列表的某一个工单时，前端调用接口：`/projects/:project_name/workflows/:workflow_id/`接口获取工单的信息：
![image](https://github.com/actiontech/sqle/assets/31072467/46817548-f490-4fd3-999b-681364082dfb)
2. 根据exec_mode判断工单的执行模式，若执行模式是文件模式，则根据工单所有的审核任务id调用新增的接口`GET /tasks/audits/{task_id}/files`，获取当前SQL审核任务的所有文件信息及其SQL的概览列表：
![image](https://github.com/actiontech/sqle/assets/31072467/2169dbce-d21b-461e-995e-5e40ed21f28f)
![image](https://github.com/actiontech/sqle/assets/31072467/8ebaeb80-8fb0-44f7-9368-b7a78b4b7505)
3. 用户点击单个文件，调用`/tasks/audits/:task_id/sqls`，进入文件的详情页面，页面根据文件，呈现文件中的sql及其审核结果、执行状态的列表
![image](https://github.com/actiontech/sqle/assets/31072467/99ba3efc-94b7-4e09-93dc-80df4aee35c6)



### 新增一个接口
`GET /tasks/audits/{task_id}/files`
用途：获取当前项目、当前SQL工单下的文件及其SQL概览信息列表。
![image](https://github.com/actiontech/sqle/assets/31072467/2169dbce-d21b-461e-995e-5e40ed21f28f)
![image](https://github.com/actiontech/sqle/assets/31072467/8ebaeb80-8fb0-44f7-9368-b7a78b4b7505)

**详情信息包括：**
1. 文件执行顺序
4. 文件名称
5. SQL审核的结果标志（各等级规则是否存在触发）
6. 上线情况
7. 文件ID（用于调用获取审核任务sql列表的接口，根据文件id筛选sql）

**各等级规则包括：**
- normal 
- notice
- warnning
- error

**上线情况包括：**
- 上线成功
- 上线失败
- 等待上线
- 上线中

### 修改一个接口
`GET /tasks/audits/:task_id/sqls`
新增Query Parameter：`filter_audit_file_id`，用于根据文件id筛选，审核任务的sql列表，用于呈现单个文件中审核任务的sql的审核结果、执行结果。
![image](https://github.com/actiontech/sqle/assets/31072467/41e1b30a-8fe4-498e-87df-0ecb6fa272b5)


## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [ ] 我已完成自测（接口复审无需测试）
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
