### PR TITLE
SQL文件上线：以文件聚合列表页以及单个文件页

### DIFF
--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -1346,6 +1346,7 @@ func GetAuditTaskFileOverview(c echo.Context) error {
 }
 
 func convertToAuditFileOverview(input []*model.AuditResultOverview, filterByFileID bool) (output []FileOverview) {
+	output = make([]FileOverview, 0, len(input))
 	for _, file := range input {
 		output = append(output, FileOverview{
 			FileID:           file.FileID,

--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -1304,7 +1304,7 @@ type ExecResultCount struct {
 // @Param task_id path string true "task id"
 // @Param page_index query string true "page index"
 // @Param page_size query string true "page size"
-// @Param filter_file_id query string true "filter file id"
+// @Param filter_file_id query string false "filter file id"
 // @Success 200 {object} GetAuditTaskFileOverviewRes
 // @router /v2/tasks/audits/{task_id}/files [get]
 func GetAuditTaskFileOverview(c echo.Context) error {

--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -1334,7 +1334,7 @@ func GetAuditTaskFileOverview(c echo.Context) error {
 		"filter_file_id": req.FilterFileID,
 	}
 
-	result, count, err := s.GetAuditOverviewByTaskId(data)
+	result, count, err := s.GetAuditOverviewByTaskId(data, req.PageSize)
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -8080,8 +8080,7 @@ var doc = `{
                         "type": "string",
                         "description": "filter file id",
                         "name": "filter_file_id",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -8064,8 +8064,7 @@
                         "type": "string",
                         "description": "filter file id",
                         "name": "filter_file_id",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -9469,7 +9469,6 @@ paths:
       - description: filter file id
         in: query
         name: filter_file_id
-        required: true
         type: string
       responses:
         "200":

--- a/sqle/driver/mysql/mysql.go
+++ b/sqle/driver/mysql/mysql.go
@@ -183,23 +183,8 @@ func (i *MysqlDriverImpl) Exec(ctx context.Context, query string) (_driver.Resul
 	return conn.Db.Exec(query)
 }
 
-//	func (i *MysqlDriverImpl) ExecBatch(ctx context.Context, queries ...string) ([]_driver.Result, error) {
-//		return nil, fmt.Errorf("unimplement this method")
-//	}
 func (i *MysqlDriverImpl) ExecBatch(ctx context.Context, queries ...string) ([]_driver.Result, error) {
-	var results []_driver.Result
-	var errorSlice []error
-	for _, sql := range queries {
-		result, err := i.Exec(ctx, sql)
-		results = append(results, result)
-		if err != nil {
-			errorSlice = append(errorSlice, err)
-		}
-	}
-	if len(errorSlice) > 0 {
-		return results, fmt.Errorf("encount errors:\n%v", errorSlice)
-	}
-	return results, nil
+	return nil, fmt.Errorf("unimplement this method")
 }
 
 func (i *MysqlDriverImpl) onlineddlWithGhost(query string) (bool, error) {
@@ -282,7 +267,6 @@ func (i *MysqlDriverImpl) Parse(ctx context.Context, sqlText string) ([]driverV2
 		n.Text = nodes[idx].Text()
 		n.StartLine = uint64(nodes[idx].StartLine())
 		n.Type = i.assertSQLType(nodes[idx])
-		n.ExecBatchId = uint64(idx)
 		ns[idx] = n
 	}
 	return ns, nil
@@ -629,7 +613,6 @@ func (p *PluginProcessor) GetDriverMetas() (*driverV2.DriverMetas, error) {
 			driverV2.OptionalModuleExtractTableFromSQL,
 			driverV2.OptionalModuleEstimateSQLAffectRows,
 			driverV2.OptionalModuleKillProcess,
-			driverV2.OptionalExecBatch,
 		},
 	}, nil
 }

--- a/sqle/driver/mysql/mysql.go
+++ b/sqle/driver/mysql/mysql.go
@@ -183,8 +183,23 @@ func (i *MysqlDriverImpl) Exec(ctx context.Context, query string) (_driver.Resul
 	return conn.Db.Exec(query)
 }
 
+//	func (i *MysqlDriverImpl) ExecBatch(ctx context.Context, queries ...string) ([]_driver.Result, error) {
+//		return nil, fmt.Errorf("unimplement this method")
+//	}
 func (i *MysqlDriverImpl) ExecBatch(ctx context.Context, queries ...string) ([]_driver.Result, error) {
-	return nil, fmt.Errorf("unimplement this method")
+	var results []_driver.Result
+	var errorSlice []error
+	for _, sql := range queries {
+		result, err := i.Exec(ctx, sql)
+		results = append(results, result)
+		if err != nil {
+			errorSlice = append(errorSlice, err)
+		}
+	}
+	if len(errorSlice) > 0 {
+		return results, fmt.Errorf("encount errors:\n%v", errorSlice)
+	}
+	return results, nil
 }
 
 func (i *MysqlDriverImpl) onlineddlWithGhost(query string) (bool, error) {
@@ -267,7 +282,7 @@ func (i *MysqlDriverImpl) Parse(ctx context.Context, sqlText string) ([]driverV2
 		n.Text = nodes[idx].Text()
 		n.StartLine = uint64(nodes[idx].StartLine())
 		n.Type = i.assertSQLType(nodes[idx])
-
+		n.ExecBatchId = uint64(idx)
 		ns[idx] = n
 	}
 	return ns, nil
@@ -614,6 +629,7 @@ func (p *PluginProcessor) GetDriverMetas() (*driverV2.DriverMetas, error) {
 			driverV2.OptionalModuleExtractTableFromSQL,
 			driverV2.OptionalModuleEstimateSQLAffectRows,
 			driverV2.OptionalModuleKillProcess,
+			driverV2.OptionalExecBatch,
 		},
 	}, nil
 }

--- a/sqle/model/task.go
+++ b/sqle/model/task.go
@@ -496,6 +496,7 @@ var taskSQLsQueryBodyTpl = `
 FROM execute_sql_detail AS e_sql
 {{- if .filter_audit_file_id }}
 LEFT JOIN audit_files ON audit_files.task_id = e_sql.task_id
+AND audit_files.file_name = e_sql.source_file
 {{- end }}
 LEFT JOIN rollback_sql_detail AS r_sql ON e_sql.id = r_sql.execute_sql_id
 WHERE

--- a/sqle/model/task_files.go
+++ b/sqle/model/task_files.go
@@ -88,3 +88,142 @@ func (s *Storage) BatchCreateFileRecords(records []*AuditFile) error {
 		return nil
 	})
 }
+
+
+type AuditResultOverview struct {
+	FileID    string `json:"file_id"`
+	FileName  string `json:"file_name"`
+	ExecOrder uint   `json:"exec_order"`
+	// 单个文件中触发XX审核等级的SQL的数量统计
+	ErrorCount   uint `json:"error_count"`
+	WarningCount uint `json:"warning_count"`
+	NoticeCount  uint `json:"notice_count"`
+	NormalCount  uint `json:"normal_count"`
+	// 单个文件中SQL执行状态的数量统计
+	FailedCount             uint `json:"failed_count"`
+	SucceededCount          uint `json:"succeeded_count"`
+	InitializedCount        uint `json:"initialized_count"`
+	DoingCount              uint `json:"doing_count"`
+	ManuallyExecutedCount   uint `json:"manually_executed_count"`
+	TerminateSucceededCount uint `json:"terminate_succeeded_count"`
+	TerminateFailedCount    uint `json:"terminate_failed_count"`
+}
+
+func (a AuditResultOverview) FileExecStatus() string {
+	// 手工执行后，手工执行和SQLE执行互斥，因此先判断
+	if a.ManuallyExecutedCount > 0 {
+		return SQLExecuteStatusManuallyExecuted
+	}
+	// 终止上线后，终止上线操作在上线前或者上线中，若有终止失败，则为失败
+	if a.TerminateFailedCount > 0 {
+		return SQLExecuteStatusTerminateFailed
+	}
+	if a.TerminateSucceededCount > 0 {
+		return SQLExecuteStatusTerminateSucc
+	}
+	// 执行上线中
+	if a.InitializedCount > 0 {
+		// 若仅包含初始化的SQL，则状态为初始化
+		if a.DoingCount == 0 && a.FailedCount == 0 && a.SucceededCount == 0 {
+			return SQLExecuteStatusInitialized
+		}
+		// 若有其他状态，则为执行中
+		return SQLExecuteStatusDoing
+	}
+	if a.DoingCount > 0 {
+		// 若不包含初始化的SQL，但存在正在执行的SQL，则文件状态为执行中
+		return SQLExecuteStatusDoing
+	}
+	// 执行完毕后
+	if a.FailedCount > 0 {
+		return SQLExecuteStatusFailed
+	}
+	if a.SucceededCount > 0 {
+		return SQLExecuteStatusSucceeded
+	}
+	// 如果没有执行成功或者失败的SQL，则说明没有SQL，则为初始化
+	return SQLExecuteStatusInitialized
+}
+
+func (s *Storage) GetAuditOverviewByTaskId(data map[string]interface{}) (
+	result []*AuditResultOverview, count uint64, err error) {
+	// add key value because suspension(:) will be considered as input variables
+	data["key_error"] = "{\"level\": \"error\"}"
+	data["key_warn"] = "{\"level\": \"warn\"}"
+	data["key_normal"] = "{\"level\": \"normal\"}"
+	data["key_notice"] = "{\"level\": \"notice\"}"
+	err = s.getListResult(auditFileOverviewQueryBodyTpl, auditFileOverviewQueryTpl, data, &result)
+	if err != nil {
+		return result, 0, err
+	}
+	count, err = s.getCountResult("", auditFileOverviewCountTpl, data)
+	return result, count, err
+}
+
+var auditFileOverviewQueryTpl string = `
+	SELECT 
+		a_file.id AS file_id,
+		a_file.exec_order,
+		a_file.file_name,
+		SUM(CASE WHEN e_sql.exec_status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
+		SUM(CASE WHEN e_sql.exec_status = 'succeeded' THEN 1 ELSE 0 END) AS succeeded_count,
+		SUM(CASE WHEN e_sql.exec_status = 'initialized' THEN 1 ELSE 0 END) AS initialized_count,
+		SUM(CASE WHEN e_sql.exec_status = 'doing' THEN 1 ELSE 0 END) AS doing_count,
+		SUM(CASE WHEN e_sql.exec_status = 'manually_executed' THEN 1 ELSE 0 END) AS manually_executed_count,
+		SUM(CASE WHEN e_sql.exec_status = 'terminate_succeeded' THEN 1 ELSE 0 END) AS terminate_succeeded_count,
+		SUM(CASE WHEN e_sql.exec_status = 'terminate_failed' THEN 1 ELSE 0 END) AS terminate_failed_count,
+		SUM(JSON_CONTAINS(e_sql.audit_results, :key_error)) AS error_count,
+		SUM(JSON_CONTAINS(e_sql.audit_results, :key_warn)) AS warning_count,
+		SUM(JSON_CONTAINS(e_sql.audit_results, :key_notice)) AS notice_count,
+		SUM(JSON_CONTAINS(e_sql.audit_results, :key_normal)) AS normal_count
+	{{- template "body" . -}}
+	{{- if .limit }}
+		LIMIT :limit OFFSET :offset	
+	{{- end -}}
+`
+
+var auditFileOverviewQueryBodyTpl = `
+	{{ define "body" }}
+		FROM 
+			audit_files AS a_file
+		LEFT JOIN
+			execute_sql_detail AS e_sql
+		ON 
+			a_file.task_id = e_sql.task_id
+		AND 
+			a_file.file_name = e_sql.source_file
+		WHERE 
+			a_file.task_id = :task_id
+		AND
+			e_sql.exec_status IS NOT NULL
+
+		{{- if .filter_file_id }}
+			AND a_file.id = :filter_file_id
+		{{- end }}
+
+		GROUP BY 
+			a_file.id,a_file.file_name,a_file.exec_order
+	{{- end }}
+`
+
+var auditFileOverviewCountTpl = `
+	SELECT 
+		COUNT(DISTINCT a_file.id)
+	FROM 
+		audit_files AS a_file
+	LEFT JOIN
+		execute_sql_detail AS e_sql
+	ON 
+		a_file.task_id = e_sql.task_id
+	AND 
+		a_file.file_name = e_sql.source_file
+	WHERE 
+		a_file.task_id = :task_id
+
+	{{- if .filter_file_id }}
+		AND a_file.id = :filter_file_id
+	{{- end }}
+
+	AND
+		e_sql.exec_status IS NOT NULL
+`

--- a/sqle/model/task_files.go
+++ b/sqle/model/task_files.go
@@ -89,7 +89,6 @@ func (s *Storage) BatchCreateFileRecords(records []*AuditFile) error {
 	})
 }
 
-
 type AuditResultOverview struct {
 	FileID    string `json:"file_id"`
 	FileName  string `json:"file_name"`
@@ -145,13 +144,14 @@ func (a AuditResultOverview) FileExecStatus() string {
 	return SQLExecuteStatusInitialized
 }
 
-func (s *Storage) GetAuditOverviewByTaskId(data map[string]interface{}) (
+func (s *Storage) GetAuditOverviewByTaskId(data map[string]interface{}, limit uint32) (
 	result []*AuditResultOverview, count uint64, err error) {
 	// add key value because suspension(:) will be considered as input variables
 	data["key_error"] = "{\"level\": \"error\"}"
 	data["key_warn"] = "{\"level\": \"warn\"}"
 	data["key_normal"] = "{\"level\": \"normal\"}"
 	data["key_notice"] = "{\"level\": \"notice\"}"
+	result = make([]*AuditResultOverview, 0, limit)
 	err = s.getListResult(auditFileOverviewQueryBodyTpl, auditFileOverviewQueryTpl, data, &result)
 	if err != nil {
 		return result, 0, err


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/1468
## 描述你的变更
1. 调整zip文件和单个文件文件初始顺序的赋值
2. 修复单个文件页面会显示task下所有文件sql的bug
3. 实现了获取审核任务文件概览的接口
        1. 概览在单个文件页面不展示审核情况概览
        2. 概览在文件列表页面不展示执行情况概览
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
