### PR TITLE
fix: when SQL file execution fails, no more SQL files will be executed

### DIFF
--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -531,6 +531,9 @@ func (a *action) execSqlFileMode() error {
 		}
 		err = a.executeSqlsGroupByBatchId(sqls)
 		if err != nil {
+			if err == ErrExecuteFileFailed {
+				return nil
+			}
 			return err
 		}
 	}
@@ -558,6 +561,9 @@ func groupSqlsByFile(executeSQLs []*model.ExecuteSQL) map[string][]*model.Execut
 	return fileSqlMap
 }
 
+// 存在SQL文件执行失败，不再执行其他SQL文件
+var ErrExecuteFileFailed error = fmt.Errorf("execute file failed, please stop execute other file")
+
 func (a *action) executeSqlsGroupByBatchId(sqls []*model.ExecuteSQL) error {
 	sqlBatch := make([]*model.ExecuteSQL, 0)
 	for idx, sql := range sqls {
@@ -572,7 +578,7 @@ func (a *action) executeSqlsGroupByBatchId(sqls []*model.ExecuteSQL) error {
 				for _, sqlInBatch := range sqlBatch {
 					if sqlInBatch.ExecStatus == model.SQLExecuteStatusFailed {
 						// 一旦出现执行失败的SQL，则不再执行其他未执行的SQL
-						return nil
+						return ErrExecuteFileFailed
 					}
 				}
 				// clear sql batch


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/1562
## 描述你的变更
1. 修改了执行多个SQL文件当文件执行失败的处理逻辑，修改为当SQL文件执行失败，不再执行剩余SQL文件
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
