### PR TITLE
fix: up pidfile dir permission

### DIFF
--- a/sqle/driver/plugin_manager.go
+++ b/sqle/driver/plugin_manager.go
@@ -183,7 +183,7 @@ func (pm *pluginManager) Start(pluginDir string, pluginConfigList []config.Plugi
 	// kill plugins process residual and remove pidfile
 	var wg sync.WaitGroup
 	dir := GetPluginPidDirPath(pluginDir)
-	if err := os.MkdirAll(dir, 0644); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
 	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -369,7 +369,7 @@ func GetPluginPidFilePath(pluginDir string, pluginName string) string {
 }
 
 func WritePidFile(pidFilePath string, pid int64) error {
-	if err := os.MkdirAll(filepath.Dir(pidFilePath), 0644); err != nil {
+	if err := os.MkdirAll(filepath.Dir(pidFilePath), 0755); err != nil {
 		return err
 	}
 	file, err := os.OpenFile(pidFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2465
## 描述你的变更
提升插件pid文件夹的权限，修复创建pid文件时权限不足问题
问题原因：
插件pid文件夹为0644，没有执行权限，导致无法open该文件夹创建pid文件
解决：提升pid文件夹权限至0755
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
