### PR TITLE
Only use the version number to name the rpm package when publishing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ ifeq ($(GOARCH), arm64)
     RPMBUILD_TARGET = aarch64
 endif
 
-# Two cases:
+ifeq ($(IS_PRODUCTION_RELEASE),true)
+# When performing a publishing operation, two cases:
 # 1. if there is tag on current commit, means that
 # 	 we release new version on current branch just now.
 #    Set rpm name with tag name(v1.2109.0 -> 1.2109.0).
@@ -25,7 +26,11 @@ endif
 # 2. if there is no tag on current commit, means that
 #    current branch is on process.
 #    Set rpm name with current branch name(release-1.2109.x-ee or release-1.2109.x -> 1.2109.x).
-PROJECT_VERSION = $(shell if [ "$$(git tag --points-at HEAD | tail -n1)" ]; then git tag --points-at HEAD | tail -n1 | sed 's/v\(.*\)/\1/'; else git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1; fi)
+    PROJECT_VERSION = $(shell if [ "$$(git tag --points-at HEAD | tail -n1)" ]; then git tag --points-at HEAD | tail -n1 | sed 's/v\(.*\)/\1/'; else git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1; fi)
+else
+#    When performing daily packaging, set rpm name with current branch name(release-1.2109.x-ee or release-1.2109.x -> 1.2109.x).
+    PROJECT_VERSION = $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1)
+endif
 
 EDITION ?= ce
 GO_BUILD_TAGS = dummyhead
@@ -71,7 +76,7 @@ vet: swagger
 	GOOS=$(GOOS) GOARCH=amd64 go vet $$(GOOS=${GOOS} GOARCH=${GOARCH} go list ./...)
 
 ## Unit Test
-test: 
+test:
 	cd $(PROJECT_NAME) && GOOS=$(GOOS) GOARCH=amd64 go test -v ./... -count 1
 
 clean:


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/1687

## 描述你的变更
修改Makefile，新增标志变量IS_PRODUCTION_RELEASE，用于指定当前打包是否是发版

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
