### PR TITLE
truncate audit plan sql when exporting for Excel view

### DIFF
--- a/sqle/api/controller/v1/instance_audit_plan.go
+++ b/sqle/api/controller/v1/instance_audit_plan.go
@@ -1173,7 +1173,7 @@ func GetInstanceAuditPlanSQLExport(c echo.Context) error {
 	}
 	for _, rowMap := range rows {
 		for col, h := range head {
-			toWrite[col] = rowMap[h.Name]
+			toWrite[col] = utils.TruncateAndMarkForExcelCell(rowMap[h.Name])
 		}
 		if err = csvWriter.Write(toWrite); err != nil {
 			return controller.JSONBaseErrorReq(c, err)

--- a/sqle/utils/util.go
+++ b/sqle/utils/util.go
@@ -365,35 +365,42 @@ func GenerateRandomString(halfLength int) string {
 	return fmt.Sprintf("%x", bytes)
 }
 
-// TruncateStringByChars 按字符数截取字符串
-func TruncateStringByChars(s string, maxChars uint) string {
-	// 字节数不大于 maxChars ，那字符数肯定不大于 maxChars
-	if uint(len(s)) <= maxChars {
+// TruncateStringByRunes 按字符数截取字符串
+func TruncateStringByRunes(s string, maxRunes uint) string {
+	// 字节数不大于 maxRunes ，那字符数肯定不大于 maxRunes
+	if uint(len(s)) <= maxRunes {
 		return s
 	}
 
-	// 逐个rune遍历s，i为每个rune起始的字节索引
-	// 如: s="a一b二c"，汉字为多字节字符，len(s)=9
-	//     i依次为　0　　1　　4　　5　　8
-	//           　^ａ　^一　^ｂ　^二　^ｃ
-	var charsCount uint
+	// UTF-8一个字符的字节数是不确定的，如：s="a一b二c"，汉字为多字节字符，len(s)=9
+	//    s的hexdump结果：
+	//    00000000  61 e4 b8 80 62 e4 ba 8c 63                       |a...b...c|
+	//
+	//    当想截取头两个字符：“a一”，即 maxRunes 为2时，
+	//    直接返回s[:maxRunes]的话得到是：“61 e4”这两个字节组成的字符串，并非“a一”，“a一”是“61 e4 b8 80”这四个字节，此时应取s[:4]
+	//
+	//    为得到s[:4]中4这个索引，可以“range s”：逐个rune遍历s，i为每个rune起始的字节索引
+	//    i依次为　0　　1　　4　　5　　8
+	//          　^ａ　^一　^ｂ　^二　^ｃ
+	//    遍历 maxRunes (2)次后，i为下一个字符(b)的起始索引，即4，此时s[:i]就是要截取的头两个字符“a一”
+	var runesCount uint
 	for i := range s {
-		if charsCount == maxChars {
+		if runesCount == maxRunes {
 			// 达到截取的字符数了，将字符截取至此时rune的字节索引
 			return s[:i]
 		}
 		// 未达到要截取的字符数，继续获取下一个rune
-		charsCount++
+		runesCount++
 	}
-	// 字符串字符数不足 maxChars
+	// 字符串字符数不足 maxRunes
 	return s
 }
 
-const excelCellMaxChars = 32766
+const excelCellMaxRunes = 32766
 
 // TruncateAndMarkForExcelCell 对超长字符串进行截取，以符合Excel类工具对单元格字符数上限的限制
 func TruncateAndMarkForExcelCell(s string) string {
-	truncated := TruncateStringByChars(s, excelCellMaxChars-4)
+	truncated := TruncateStringByRunes(s, excelCellMaxRunes-4)
 	if truncated != s {
 		// 截取了的话，做标记
 		return truncated + " ..."

--- a/sqle/utils/util.go
+++ b/sqle/utils/util.go
@@ -364,3 +364,39 @@ func GenerateRandomString(halfLength int) string {
 	rand.Read(bytes)
 	return fmt.Sprintf("%x", bytes)
 }
+
+// TruncateStringByChars 按字符数截取字符串
+func TruncateStringByChars(s string, maxChars uint) string {
+	// 字节数不大于 maxChars ，那字符数肯定不大于 maxChars
+	if uint(len(s)) <= maxChars {
+		return s
+	}
+
+	// 逐个rune遍历s，i为每个rune起始的字节索引
+	// 如: s="a一b二c"，汉字为多字节字符，len(s)=9
+	//     i依次为　0　　1　　4　　5　　8
+	//           　^ａ　^一　^ｂ　^二　^ｃ
+	var charsCount uint
+	for i := range s {
+		if charsCount == maxChars {
+			// 达到截取的字符数了，将字符截取至此时rune的字节索引
+			return s[:i]
+		}
+		// 未达到要截取的字符数，继续获取下一个rune
+		charsCount++
+	}
+	// 字符串字符数不足 maxChars
+	return s
+}
+
+const excelCellMaxChars = 32766
+
+// TruncateAndMarkForExcelCell 对超长字符串进行截取，以符合Excel类工具对单元格字符数上限的限制
+func TruncateAndMarkForExcelCell(s string) string {
+	truncated := TruncateStringByChars(s, excelCellMaxChars-4)
+	if truncated != s {
+		// 截取了的话，做标记
+		return truncated + " ..."
+	}
+	return s
+}


### PR DESCRIPTION
## 关联的 issue
close https://github.com/actiontech/sqle/issues/2530

## 描述你的变更
智能扫描任务sql导出时，对超长的列进行截取，避免超出Excel类工具单元格字符数上限

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
