### PR TITLE
optimize: unified management of scanner commands

### DIFF
--- a/sqle/api/controller/v1/instance_audit_plan.go
+++ b/sqle/api/controller/v1/instance_audit_plan.go
@@ -831,7 +831,7 @@ func GetAuditPlanExecCmd(projectName string, iap *model.InstanceAuditPlan, ap *m
 		scannerCmd.FlagPort:        port,
 		scannerCmd.FlagProject:     projectName,
 		scannerCmd.FlagToken:       iap.Token,
-		scannerCmd.FlagAuditPlanID: string(ap.ID),
+		scannerCmd.FlagAuditPlanID: fmt.Sprint(ap.ID),
 	})
 	if err != nil {
 		logger.Infof("generate scannerd %s command failed %s", ap.Type, err)

--- a/sqle/api/controller/v1/instance_audit_plan.go
+++ b/sqle/api/controller/v1/instance_audit_plan.go
@@ -17,6 +17,7 @@ import (
 	v1 "github.com/actiontech/dms/pkg/dms-common/api/dms/v1"
 	dmsCommonJwt "github.com/actiontech/dms/pkg/dms-common/api/jwt"
 	"github.com/actiontech/sqle/sqle/api/controller"
+	scannerCmd "github.com/actiontech/sqle/sqle/cmd/scannerd/command"
 	"github.com/actiontech/sqle/sqle/config"
 	dms "github.com/actiontech/sqle/sqle/dms"
 	"github.com/actiontech/sqle/sqle/driver"
@@ -820,8 +821,23 @@ func GetAuditPlanExecCmd(projectName string, iap *model.InstanceAuditPlan, ap *m
 		return ""
 	}
 
-	cmd := `./scannerd %s --project=%s --host=%s --port=%s  --audit_plan_id=%d  --token=%s`
-	return fmt.Sprintf(cmd, ap.Type, projectName, ip, port, ap.ID, iap.Token)
+	scannerd, err := scannerCmd.GetScannerdCmd(ap.Type)
+	if err != nil {
+		logger.Infof("get scannerd %s failed %s", ap.Type, err)
+		return ""
+	}
+	cmd, err := scannerd.GenCommand("./scannerd", map[string]string{
+		scannerCmd.FlagHost:        ip,
+		scannerCmd.FlagPort:        port,
+		scannerCmd.FlagProject:     projectName,
+		scannerCmd.FlagToken:       iap.Token,
+		scannerCmd.FlagAuditPlanID: string(ap.ID),
+	})
+	if err != nil {
+		logger.Infof("generate scannerd %s command failed %s", ap.Type, err)
+		return ""
+	}
+	return cmd
 }
 
 type UpdateInstanceAuditPlanStatusReqV1 struct {

--- a/sqle/api/controller/v1/pipeline.go
+++ b/sqle/api/controller/v1/pipeline.go
@@ -52,6 +52,10 @@ func (p *pipelineNodeDetail) fillWith(node *pipeline.PipelineNode) {
 	if node == nil {
 		return
 	}
+	integrationInfo, err := node.IntegrationInfo()
+	if err != nil {
+		integrationInfo = err.Error()
+	}
 	p.ID = node.ID
 	p.Name = node.Name
 	p.Type = node.NodeType
@@ -61,7 +65,7 @@ func (p *pipelineNodeDetail) fillWith(node *pipeline.PipelineNode) {
 	p.ObjectType = node.ObjectType
 	p.AuditMethod = node.AuditMethod
 	p.RuleTemplateName = node.RuleTemplateName
-	p.IntegrationInfo = node.IntegrationInfo()
+	p.IntegrationInfo = integrationInfo
 }
 
 // pipelineNodeBase 流水线节点基础信息
@@ -332,7 +336,7 @@ func UpdatePipeline(c echo.Context) error {
 
 	var pipelineSvc pipeline.PipelineSvc
 	svcPipeline := req.convertToSvcPipeline(projectUid, uint(pipelineID))
-	
+
 	err = pipelineSvc.CheckRuleTemplate(svcPipeline)
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)

--- a/sqle/cmd/scannerd/cmd/root.go
+++ b/sqle/cmd/scannerd/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	pkgScanner "github.com/actiontech/sqle/sqle/pkg/scanner"
+	scannerCmd "github.com/actiontech/sqle/sqle/cmd/scannerd/command"
 
 	"github.com/spf13/cobra"
 )
@@ -27,13 +27,20 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&rootCmdFlags.host, "host", "H", "127.0.0.1", "sqle host")
-	rootCmd.PersistentFlags().StringVarP(&rootCmdFlags.port, "port", "P", "10000", "sqle port")
-	rootCmd.PersistentFlags().StringVarP(&rootCmdFlags.auditPlanID, "audit_plan_id", "", "", "audit plan id")
-	rootCmd.PersistentFlags().StringVarP(&rootCmdFlags.token, "token", "A", "", "sqle token")
-	rootCmd.PersistentFlags().IntVarP(&rootCmdFlags.timeout, "timeout", "T", pkgScanner.DefaultTimeoutNum, "request sqle timeout in seconds")
-	rootCmd.PersistentFlags().StringVarP(&rootCmdFlags.project, "project", "J", "default", "project name")
-	_ = rootCmd.MarkPersistentFlagRequired("token")
+	root, err := scannerCmd.GetScannerdCmd(scannerCmd.TypeRootScannerd)
+	if err != nil {
+		panic(err)
+	}
+	rootCmd.PersistentFlags().StringVarP(root.StringFlagFn[scannerCmd.FlagHost](&rootCmdFlags.host))
+	rootCmd.PersistentFlags().StringVarP(root.StringFlagFn[scannerCmd.FlagPort](&rootCmdFlags.port))
+	rootCmd.PersistentFlags().StringVarP(root.StringFlagFn[scannerCmd.FlagAuditPlanID](&rootCmdFlags.auditPlanID))
+	rootCmd.PersistentFlags().StringVarP(root.StringFlagFn[scannerCmd.FlagToken](&rootCmdFlags.token))
+	rootCmd.PersistentFlags().IntVarP(root.IntFlagFn[scannerCmd.FlagTimeout](&rootCmdFlags.timeout))
+	rootCmd.PersistentFlags().StringVarP(root.StringFlagFn[scannerCmd.FlagProject](&rootCmdFlags.project))
+
+	for _, requiredFlag := range root.RequiredFlags {
+		_ = rootCmd.MarkPersistentFlagRequired(requiredFlag)
+	}
 }
 
 func Execute(ctx context.Context) error {

--- a/sqle/cmd/scannerd/command/base.go
+++ b/sqle/cmd/scannerd/command/base.go
@@ -1,0 +1,184 @@
+package command
+
+import (
+	"fmt"
+
+	"strconv"
+)
+
+const (
+	FlagDirectory        string = "dir"
+	FlagDirectorySort    string = "D"
+	FlagFile             string = "file"
+	FlagFileSort         string = "f"
+	FlagInstanceName     string = "instance-name"
+	FlagInstanceNameSort string = "I"
+	FlagDbType           string = "db-type"
+	FlagDbTypeSort       string = "B"
+	FlagSchemaName       string = "schema-name"
+	FlagSchemaNameSort   string = "C"
+	// empty
+	EmptyDefaultValue string = ""
+	EmptyFlagSort     string = ""
+	// root
+	FlagHost        string = "host"
+	FlagHostSort    string = "H"
+	FlagPort        string = "port"
+	FlagPortSort    string = "P"
+	FlagAuditPlanID string = "audit_plan_id"
+	FlagToken       string = "token"
+	FlagTokenSort   string = "A"
+	FlagTimeout     string = "timeout"
+	FlagTimeoutSort string = "T"
+	FlagProject     string = "project"
+	FlagProjectSort string = "J"
+	// mybatis
+	FlagSkipErrorQuery     string = "skip-error-query"
+	FlagSkipErrorQuerySort string = "S"
+	FlagSkipErrorXml       string = "skip-error-xml"
+	FlagSkipErrorXmlSort   string = "X"
+	// sqlfile
+	FlagSkipErrorSqlFile     string = "skip-error-sql-file"
+	FlagSkipErrorSqlFileSort string = "S"
+	// slow log
+	FlagLogFile           string = "log-file"
+	FlagIncludeUserList   string = "include-user-list"
+	FlagExcludeUserList   string = "exclude-user-list"
+	FlagIncludeSchemaList string = "include-schema-list"
+	FlagExcludeSchemaList string = "exclude-schema-list"
+	// tbase
+	FlagFileFormat     string = "format"
+	FlagFileFormatSort string = "F"
+)
+
+func newScannerCmd(scannerType string) scannerCmd {
+	return scannerCmd{
+		ScannerType:  scannerType,
+		StringFlagFn: make(map[string]func(variable *string) (p *string, name string, shorthand string, value string, usage string)),
+		BoolFlagFn:   make(map[string]func(variable *bool) (p *bool, name string, shorthand string, value bool, usage string)),
+		IntFlagFn:    make(map[string]func(variable *int) (p *int, name string, shorthand string, value int, usage string)),
+	}
+}
+
+type scannerCmd struct {
+	ScannerType   string
+	FatherCmds    []*scannerCmd
+	StringFlagFn  map[string]func(variable *string) (p *string, name string, shorthand string, value string, usage string)
+	BoolFlagFn    map[string]func(variable *bool) (p *bool, name string, shorthand string, value bool, usage string)
+	IntFlagFn     map[string]func(variable *int) (p *int, name string, shorthand string, value int, usage string)
+	RequiredFlags []string
+}
+
+func GetScannerdCmd(scannerType string) (*scannerCmd, error) {
+	switch scannerType {
+	case TypeRootScannerd:
+		return &rootCmd, nil
+	case TypeMySQLMybatis:
+		return &myBatis, nil
+	case TypeMySQLSlowLog:
+		return &slowLog, nil
+	case TypeTiDBAuditLog:
+		return &tidbAuditLog, nil
+	case TypeSQLFile:
+		return &sqlFile, nil
+	case TypeTBaseSlowLog:
+		return &tbaseLog, nil
+	default:
+		return nil, fmt.Errorf("unsupport scannerd type %s", scannerType)
+	}
+}
+
+func (newCmd *scannerCmd) addFather(cmd *scannerCmd) {
+	newCmd.FatherCmds = append(newCmd.FatherCmds, cmd)
+}
+
+func (cmd *scannerCmd) addStringFlag(name string, shorthand string, value string, usage string) {
+	cmd.StringFlagFn[name] = func(variable *string) (*string, string, string, string, string) {
+		return variable, name, shorthand, value, usage
+	}
+}
+
+func (cmd *scannerCmd) addIntFlag(name string, shorthand string, value int, usage string) {
+	cmd.IntFlagFn[name] = func(variable *int) (*int, string, string, int, string) {
+		return variable, name, shorthand, value, usage
+	}
+}
+
+func (cmd *scannerCmd) addBoolFlag(name string, shorthand string, value bool, usage string) {
+	cmd.BoolFlagFn[name] = func(variable *bool) (*bool, string, string, bool, string) {
+		return variable, name, shorthand, value, usage
+	}
+}
+
+func (cmd *scannerCmd) addRequiredFlag(name string) {
+	cmd.RequiredFlags = append(cmd.RequiredFlags, name)
+}
+
+func (cmd scannerCmd) Type() string {
+	return cmd.ScannerType
+}
+
+// path can be relative path or absolute path. params is flagName:flagValue map, bool type input true or false string.
+func (cmd scannerCmd) GenCommand(path string, params map[string] /* flag name */ string /* flag value */) (string, error) {
+	// check required flag exist
+	for _, father := range cmd.FatherCmds {
+		for _, requiredFlag := range father.RequiredFlags {
+			if value, exist := params[requiredFlag]; !exist || value == "" {
+				return "", fmt.Errorf("required flag: %s value: %s", requiredFlag, value)
+			}
+		}
+	}
+	for _, requiredFlag := range cmd.RequiredFlags {
+		if value, exist := params[requiredFlag]; !exist || value == "" {
+			return "", fmt.Errorf("required flag: %s value: %s", requiredFlag, value)
+		}
+	}
+	var command string = fmt.Sprintf("%s %s", path, cmd.Type())
+	var addParamTpl string = "%s --%s %s"
+	// check is flag valid and add flag
+	for flagName, flagValue := range params {
+		var err error
+		var exist bool
+		for _, father := range cmd.FatherCmds {
+			exist, err = father.checkFlag(flagName, flagValue)
+			if err != nil {
+				return "", fmt.Errorf("when checking flag: %s,error %w", flagName, err)
+			}
+			if exist {
+				break
+			}
+		}
+
+		if !exist {
+			exist, err = cmd.checkFlag(flagName, flagValue)
+			if err != nil {
+				return "", fmt.Errorf("when checking flag: %s,error %w", flagName, err)
+			}
+		}
+		if exist {
+			if flagValue == "" {
+				continue
+			}
+			command = fmt.Sprintf(addParamTpl, command, flagName, flagValue)
+			continue
+		}
+		return "", fmt.Errorf("unsupport flag %s", flagName)
+	}
+	return command, nil
+}
+
+func (cmd scannerCmd) checkFlag(flagName string, flagValue string) (exist bool, err error) {
+	if _, exist = cmd.StringFlagFn[flagName]; exist {
+		return true, nil
+	}
+	if _, exist = cmd.BoolFlagFn[flagName]; exist {
+		if flagValue != "false" && flagValue != "true" {
+			return true, fmt.Errorf("flage %s is bool type, should input false or true", flagName)
+		}
+	}
+	if _, exist = cmd.IntFlagFn[flagName]; exist {
+		_, err = strconv.Atoi(flagValue)
+		return true, err
+	}
+	return false, nil
+}

--- a/sqle/cmd/scannerd/command/command.go
+++ b/sqle/cmd/scannerd/command/command.go
@@ -1,0 +1,61 @@
+package command
+
+const (
+	TypeMySQLMybatis = "mysql_mybatis"
+	TypeMySQLSlowLog = "mysql_slow_log"
+	TypeSQLFile      = "sql_file"
+	TypeTBaseSlowLog = "TBase_slow_log"
+	TypeTiDBAuditLog = "tidb_audit_log"
+	TypeRootScannerd = "root"
+)
+
+var (
+	rootCmd      scannerCmd = newScannerCmd(TypeRootScannerd)
+	myBatis      scannerCmd = newScannerCmd(TypeMySQLMybatis)
+	slowLog      scannerCmd = newScannerCmd(TypeMySQLSlowLog)
+	sqlFile      scannerCmd = newScannerCmd(TypeSQLFile)
+	tbaseLog     scannerCmd = newScannerCmd(TypeTBaseSlowLog)
+	tidbAuditLog scannerCmd = newScannerCmd(TypeTiDBAuditLog)
+)
+
+func init() {
+	rootCmd.addStringFlag(FlagHost, FlagHostSort, "127.0.0.1", "sqle host")
+	rootCmd.addStringFlag(FlagPort, FlagPortSort, "10000", "sqle port")
+	rootCmd.addStringFlag(FlagAuditPlanID, EmptyFlagSort, "", "audit plan id")
+	rootCmd.addStringFlag(FlagToken, FlagTokenSort, "", "sqle token")
+	rootCmd.addIntFlag(FlagTimeout, FlagTimeoutSort, 10, "request sqle timeout in seconds")
+	rootCmd.addStringFlag(FlagProject, FlagProjectSort, "default", "project name")
+	rootCmd.addRequiredFlag(FlagToken)
+}
+
+func init() {
+	myBatis.addFather(&rootCmd)
+	myBatis.addStringFlag(FlagDirectory, FlagDirectorySort, EmptyDefaultValue, "xml directory")
+	myBatis.addStringFlag(FlagDbType, FlagDbTypeSort, EmptyDefaultValue, "database type")
+	myBatis.addStringFlag(FlagInstanceName, FlagInstanceNameSort, EmptyDefaultValue, "instance name")
+	myBatis.addStringFlag(FlagSchemaName, FlagSchemaNameSort, EmptyDefaultValue, "schema name")
+	myBatis.addBoolFlag(FlagSkipErrorQuery, FlagSkipErrorQuerySort, false,
+		"skip the statement that the scanner failed to parse from within the xml file")
+	myBatis.addBoolFlag(FlagSkipErrorXml, FlagSkipErrorXmlSort, false, "skip the xml file that failed to parse")
+	myBatis.addRequiredFlag(FlagDirectory)
+}
+
+func init() {
+	slowLog.addFather(&rootCmd)
+	slowLog.addStringFlag(FlagLogFile, EmptyFlagSort, EmptyDefaultValue, "log file absolute path")
+	slowLog.addStringFlag(FlagIncludeUserList, EmptyFlagSort, EmptyDefaultValue, "include mysql user list, split by \",\"")
+	slowLog.addStringFlag(FlagExcludeUserList, EmptyFlagSort, EmptyDefaultValue, "exclude mysql user list, split by \",\"")
+	slowLog.addStringFlag(FlagIncludeSchemaList, EmptyFlagSort, EmptyDefaultValue, "include mysql schema list, split by \",\"")
+	slowLog.addStringFlag(FlagExcludeSchemaList, EmptyFlagSort, EmptyDefaultValue, "exclude mysql schema list, split by \",\"")
+	slowLog.addRequiredFlag(FlagLogFile)
+}
+
+func init() {
+	sqlFile.addFather(&rootCmd)
+	sqlFile.addStringFlag(FlagDirectory, FlagDirectorySort, EmptyDefaultValue, "sql file directory")
+	sqlFile.addBoolFlag(FlagSkipErrorSqlFile, FlagSkipErrorSqlFileSort, false, "skip the sql file that failed to parse")
+	sqlFile.addStringFlag(FlagDbType, FlagDbTypeSort, EmptyDefaultValue, "database type")
+	sqlFile.addStringFlag(FlagInstanceName, FlagInstanceNameSort, EmptyDefaultValue, "instance name")
+	sqlFile.addStringFlag(FlagSchemaName, FlagSchemaNameSort, EmptyDefaultValue, "schema name")
+	sqlFile.addRequiredFlag(FlagDirectory)
+}

--- a/sqle/server/auditplan/meta.go
+++ b/sqle/server/auditplan/meta.go
@@ -2,7 +2,7 @@ package auditplan
 
 import (
 	"fmt"
-
+	scannerCmd "github.com/actiontech/sqle/sqle/cmd/scannerd/command"
 	"github.com/actiontech/sqle/sqle/pkg/params"
 
 	"github.com/sirupsen/logrus"
@@ -28,18 +28,18 @@ type MetaBuilder struct {
 
 const (
 	TypeDefault               = "default"
-	TypeMySQLSlowLog          = "mysql_slow_log"
-	TypeMySQLMybatis          = "mysql_mybatis"
+	TypeMySQLSlowLog          = scannerCmd.TypeMySQLSlowLog
+	TypeMySQLMybatis          = scannerCmd.TypeMySQLMybatis
 	TypeMySQLSchemaMeta       = "mysql_schema_meta"
 	TypeMySQLProcesslist      = "mysql_processlist"
 	TypeAliRdsMySQLSlowLog    = "ali_rds_mysql_slow_log"
 	TypeAliRdsMySQLAuditLog   = "ali_rds_mysql_audit_log"
 	TypeHuaweiRdsMySQLSlowLog = "huawei_rds_mysql_slow_log"
 	TypeOracleTopSQL          = "oracle_top_sql"
-	TypeTiDBAuditLog          = "tidb_audit_log"
+	TypeTiDBAuditLog          = scannerCmd.TypeTiDBAuditLog
 	TypeAllAppExtract         = "all_app_extract"
 	TypeBaiduRdsMySQLSlowLog  = "baidu_rds_mysql_slow_log"
-	TypeSQLFile               = "sql_file"
+	TypeSQLFile               = scannerCmd.TypeSQLFile
 )
 
 const (


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2579
方案page_id：169738586
## 描述你的变更

1. 定义scannerd/command，将scannerd的命令集中在此处定义

> 在package cmd中，引用scannerd/command，对cmd进行初始化，对变量和标志名称关联
> 若在cmd中初始化时调用了一个未在scannerd/command定义的标志，能够在初始化阶段引发panic，能够在dev阶段发现问题
> 定义了生成command的方法，会检查：必须的flag是否存在，值是否为空。传入的标志位是否存在，类型是否正确。

2. 解除 scannerd/cmd 到 auditplan/meta 的直接依赖，为二者添加依赖scannerd/command。避免了循环依赖和传递循环依赖
3. auditplan和pipeline生成command方法都使用了scannerd/command中的command生成方法，能够在scannerd的定义发生变化时，保持一致性。

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
