### PR TITLE
fix: expired token causes scannerd to be unable to access SQLite normally

### DIFF
--- a/sqle/api/app.go
+++ b/sqle/api/app.go
@@ -111,6 +111,10 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config config.SqleConfi
 	e.GET("/v1/oauth2/link", v1.Oauth2Link)
 	e.GET("/v1/oauth2/callback", v1.Oauth2Callback)
 	e.POST("/v1/oauth2/user/bind", v1.BindOauth2User)
+	e.POST("/v1/projects/:project_name/audit_plans/:audit_plan_name/sqls/full", v1.FullSyncAuditPlanSQLs, sqleMiddleware.ScannerVerifier())
+	e.POST("/v2/projects/:project_name/audit_plans/:audit_plan_name/sqls/full", v2.FullSyncAuditPlanSQLs, sqleMiddleware.ScannerVerifier())
+	e.POST("/v1/projects/:project_name/audit_plans/:audit_plan_name/sqls/partial", v1.PartialSyncAuditPlanSQLs, sqleMiddleware.ScannerVerifier())
+	e.POST("/v2/projects/:project_name/audit_plans/:audit_plan_name/sqls/partial", v2.PartialSyncAuditPlanSQLs, sqleMiddleware.ScannerVerifier())
 
 	v1Router := e.Group(apiV1)
 	v1Router.Use(sqleMiddleware.JWTTokenAdapter(), sqleMiddleware.JWTWithConfig(utils.JWTSecretKey), sqleMiddleware.VerifyUserIsDisabled(), sqleMiddleware.LicenseAdapter(), sqleMiddleware.OperationLogRecord())
@@ -392,10 +396,6 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config config.SqleConfi
 	v1Router.GET("/projects/:project_name/audit_plans/:audit_plan_name/reports/:audit_plan_report_id/", v1.GetAuditPlanReport)
 
 	v1Router.GET("/projects/:project_name/audit_plans/:audit_plan_name/sqls", v1.GetAuditPlanSQLs)
-	v1Router.POST("/projects/:project_name/audit_plans/:audit_plan_name/sqls/full", v1.FullSyncAuditPlanSQLs, sqleMiddleware.ScannerVerifier())
-	v2Router.POST("/projects/:project_name/audit_plans/:audit_plan_name/sqls/full", v2.FullSyncAuditPlanSQLs, sqleMiddleware.ScannerVerifier())
-	v1Router.POST("/projects/:project_name/audit_plans/:audit_plan_name/sqls/partial", v1.PartialSyncAuditPlanSQLs, sqleMiddleware.ScannerVerifier())
-	v2Router.POST("/projects/:project_name/audit_plans/:audit_plan_name/sqls/partial", v2.PartialSyncAuditPlanSQLs, sqleMiddleware.ScannerVerifier())
 	v1Router.POST("/projects/:project_name/audit_plans/:audit_plan_name/trigger", v1.TriggerAuditPlan)
 	v1Router.PATCH("/projects/:project_name/audit_plans/:audit_plan_name/notify_config", v1.UpdateAuditPlanNotifyConfig)
 	v1Router.GET("/projects/:project_name/audit_plans/:audit_plan_name/notify_config", v1.GetAuditPlanNotifyConfig)

--- a/sqle/utils/jwt.go
+++ b/sqle/utils/jwt.go
@@ -63,8 +63,8 @@ func WithAuditPlanName(name string) CustomClaimOption {
 	})
 }
 
-// ParseAuditPlanName used by echo middleware which only verify api request to audit plan related.
-func ParseAuditPlanName(tokenString string) (string, error) {
+// ParseAuditPlanToken used by echo middleware which only verify api request to audit plan related.
+func ParseAuditPlanToken(tokenString string) (string, string, error) {
 	keyFunc := func(t *jwt.Token) (interface{}, error) {
 		return JWTSecretKey, nil
 	}
@@ -72,7 +72,7 @@ func ParseAuditPlanName(tokenString string) (string, error) {
 	if err != nil {
 		if e, ok := err.(*jwt.ValidationError); ok {
 			if e.Errors != jwt.ValidationErrorExpired {
-				return "", err
+				return "", "", err
 			}
 		}
 	}
@@ -81,9 +81,13 @@ func ParseAuditPlanName(tokenString string) (string, error) {
 	claims := token.Claims.(jwt.MapClaims)
 	apn, ok := claims["apn"]
 	if !ok {
-		return "", jwt.NewValidationError("unknown token", jwt.ValidationErrorClaimsInvalid)
+		return "", "", jwt.NewValidationError("unknown token", jwt.ValidationErrorClaimsInvalid)
 	}
-	return apn.(string), nil
+	userName, ok := claims["name"]
+	if !ok {
+		return "", "", jwt.NewValidationError("unknown token", jwt.ValidationErrorClaimsInvalid)
+	}
+	return apn.(string), userName.(string), nil
 }
 
 func GetUserNameFromJWTToken(token string) (string, error) {

--- a/sqle/utils/jwt.go
+++ b/sqle/utils/jwt.go
@@ -70,7 +70,11 @@ func ParseAuditPlanName(tokenString string) (string, error) {
 	}
 	token, err := jwt.Parse(tokenString, keyFunc)
 	if err != nil {
-		return "", err
+		if e, ok := err.(*jwt.ValidationError); ok {
+			if e.Errors != jwt.ValidationErrorExpired {
+				return "", err
+			}
+		}
 	}
 	// claims can only be jwt.MapClaims
 	//nolint:forcetypeassert


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2602
## 描述你的变更

1. 对于慢日志扫描，将慢日志扫描的接口组移动到v1路由组外，该接口的权限校验全由ScannerVerifier来鉴权
2. 在ScannerVerifier中，针对token过期的错误，放行包含该错误的token

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
