### PR TITLE
Prohibit commits from actions-user.

### DIFF
--- a/.github/workflows/check-pr-files.yml
+++ b/.github/workflows/check-pr-files.yml
@@ -14,3 +14,23 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           pattern: ^(?!.*_ee\/.*$)(?!.*_ee\.go$)(?!.*_ee_test\.go$)(?!.*_rel\.go$)(?!.*_rel_test\.go$)(?!go\.mod$)(?!go\.sum$)(?!\.github\/workflows\/check-pr-files\.yml$)(?!vendor\/.*)(?!.*_qa\.go$).*
           trustedAuthors: xalvarez
+
+  # 禁止actions自动提交commit
+  check-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # 检出完整历史
+
+      - name: Check commit authors
+        run: |
+          # 获取所有提交的作者
+          authors=$(git log --pretty=format:"%an" origin/main..HEAD)
+
+          # 检查是否包含不允许的用户
+          if echo "$authors" | grep -q "actions-user"; then
+            echo "Error: actions-user has made a commit in this PR."
+            exit 1
+          fi


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/1838

## 描述你的变更
触发pr时增加commit检查，如果包含actions-user提交的commit，就不允许合并
ce代码不会有这个问题，所以只要ee代码检查就可以

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
