### PR TITLE
feat: it is not allowed to execute workflow that have pre-workflow was not executed correctly

### DIFF
--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -1101,6 +1101,8 @@ type WorkflowRecordResV2 struct {
 	Tasks             []*WorkflowTaskItem  `json:"tasks"`
 	CurrentStepNumber uint                 `json:"current_step_number,omitempty"`
 	Status            string               `json:"status" enums:"wait_for_audit,wait_for_execution,rejected,canceled,exec_failed,executing,finished"`
+	Executable        bool                 `json:"executable"`
+	ExecutableReason  string               `json:"executable_reason"`
 	Steps             []*WorkflowStepResV2 `json:"workflow_step_list,omitempty"`
 }
 

--- a/sqle/api/controller/v3/workflow.go
+++ b/sqle/api/controller/v3/workflow.go
@@ -10,6 +10,7 @@ import (
 	"github.com/actiontech/sqle/sqle/dms"
 	"github.com/actiontech/sqle/sqle/errors"
 	"github.com/actiontech/sqle/sqle/model"
+	"github.com/actiontech/sqle/sqle/server/sqlversion"
 	"github.com/labstack/echo/v4"
 )
 
@@ -54,6 +55,13 @@ func BatchCompleteWorkflowsV3(c echo.Context) error {
 	s := model.GetStorage()
 	workflows := make([]*model.Workflow, len(req.WorkflowList))
 	for i, completeWorkflow := range req.WorkflowList {
+		executable, reason, err := sqlversion.CheckWorkflowExecutable(projectUid, completeWorkflow.WorkflowID)
+		if err != nil {
+			return controller.JSONBaseErrorReq(c, err)
+		}
+		if !executable {
+			return controller.JSONBaseErrorReq(c, fmt.Errorf(reason))
+		}
 		workflow, err := v2.CheckCanCompleteWorkflow(projectUid, completeWorkflow.WorkflowID)
 		if err != nil {
 			return controller.JSONBaseErrorReq(c, err)

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -18323,6 +18323,12 @@ var doc = `{
                 "current_step_number": {
                     "type": "integer"
                 },
+                "executable": {
+                    "type": "boolean"
+                },
+                "executable_reason": {
+                    "type": "string"
+                },
                 "status": {
                     "type": "string",
                     "enum": [

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -18307,6 +18307,12 @@
                 "current_step_number": {
                     "type": "integer"
                 },
+                "executable": {
+                    "type": "boolean"
+                },
+                "executable_reason": {
+                    "type": "string"
+                },
                 "status": {
                     "type": "string",
                     "enum": [

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -5379,6 +5379,10 @@ definitions:
     properties:
       current_step_number:
         type: integer
+      executable:
+        type: boolean
+      executable_reason:
+        type: string
       status:
         enum:
         - wait_for_audit

--- a/sqle/model/workflow.go
+++ b/sqle/model/workflow.go
@@ -921,6 +921,20 @@ func (s *Storage) GetWorkflowByProjectAndWorkflowId(projectId, workflowId string
 	return workflow, true, errors.New(errors.ConnectStorageError, err)
 }
 
+func (s *Storage) GetWorkflowByWorkflowId(workflowId string) (workflow *Workflow, exist bool, err error) {
+	err = s.db.
+		Preload("Record").
+		Where("workflow_id = ?", workflowId).
+		First(&workflow).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return workflow, false, nil
+		}
+		return workflow, false, errors.New(errors.ConnectStorageError, err)
+	}
+	return workflow, true, nil
+}
+
 func (s *Storage) GetWorkflowExportById(workflowId string) (*Workflow, bool, error) {
 	w := new(Workflow)
 	err := s.db.Preload("Record").Where("workflow_id = ?", workflowId).First(&w).Error

--- a/sqle/server/sqlversion/sql_version_ce.go
+++ b/sqle/server/sqlversion/sql_version_ce.go
@@ -12,3 +12,7 @@ import (
 func CheckInstanceInWorkflowCanAssociateToTheFirstStageOfVersion(versionID uint, instanceId []uint64) error {
 	return errors.New(errors.EnterpriseEditionFeatures, e.New("sql version is enterprise version feature"))
 }
+
+func CheckWorkflowExecutable(projectUid, workflowId string) (executable bool, reason string, err error) {
+	return true, "", nil
+}


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/1807
https://github.com/actiontech/sqle-ee/issues/1807#issuecomment-2401551908
link: https://github.com/actiontech/sqle-ee/pull/1875
## 描述你的变更
1. 修改工单详情接口，增加2个字段，标记工单能否执行，前端根据能否执行置灰或者正常显示按钮
2. 在执行工单的相应接口，增加对工单是否能执行的前置条件校验

功能特性：页面上将用户不能执行的工单的执行按钮颜色变成灰色的特性
限制条件：当工单状态为等待执行时，且工单绑定了SQL版本的某个阶段，且该工单在该阶段中，位于工单前面的工单存在状态不是已关闭或者成功执行的两种状态之一，则不允许执行该工单的sql

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
assign in @ColdWaterLW 