### PR TITLE
SQLE00170

### DIFF
--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -145,7 +145,7 @@ func AIMockExecutor(expectations []*AIMockSQLExpectation) (*executor.Executor, e
 	return e, nil
 }
 
-func runAIRuleCase(rule driverV2.Rule, t *testing.T, desc, sql string, mockContext *session.AIMockContext, mockSQLExpectation []*AIMockSQLExpectation ,result *testResult) {
+func runAIRuleCase(rule driverV2.Rule, t *testing.T, desc, sql string, mockContext *session.AIMockContext, mockSQLExpectation []*AIMockSQLExpectation, result *testResult) {
 	e, err := AIMockExecutor(mockSQLExpectation)
 	if err != nil {
 		t.Errorf("%s test failed, mock executor error: %v\n", desc, err)
@@ -159,7 +159,7 @@ func runAIRuleCase(rule driverV2.Rule, t *testing.T, desc, sql string, mockConte
 	inspect := NewMockInspect(e)
 	inspect.Ctx = ctx
 	inspect.rules = []*driverV2.Rule{&rule}
-	inspectCase(t, desc, inspect, sql, result)
+	inspectAICase(t, desc, inspect, sql, result)
 }
 
 func runDefaultRulesInspectCase(t *testing.T, desc string, i *MysqlDriverImpl, sql string, results ...*testResult) {
@@ -252,6 +252,57 @@ func inspectCase(t *testing.T, desc string, i *MysqlDriverImpl, sql string, resu
 				desc, stmt.Text(), results[idx].level(), results[idx].message(), actualResults[idx].Level(), actualResults[idx].Message())
 		} else {
 			t.Logf("\n\ncase:%s\nactual level: %s\nactual result:\n%s\n\n", desc, actualResults[idx].Level(), actualResults[idx].Message())
+		}
+	}
+}
+
+func inspectAICase(t *testing.T, desc string, i *MysqlDriverImpl, sql string, results ...*testResult) {
+	stmts, err := util.ParseSql(sql)
+	if err != nil {
+		t.Errorf("%s test failed, error: %v\n", desc, err)
+		return
+	}
+
+	if len(stmts) != len(results) {
+		t.Errorf("%s test failed, error: result is unknow\n", desc)
+		return
+	}
+	sqls := make([]string, 0, len(stmts))
+	for _, stmt := range stmts {
+		sqls = append(sqls, stmt.Text())
+	}
+	actualResults, err := i.Audit(context.TODO(), sqls)
+	if err != nil {
+		t.Errorf("%s", err)
+		return
+	}
+	if len(stmts) != len(actualResults) {
+		t.Errorf("%s test failed, error: actual result is unknow\n", desc)
+		return
+	}
+
+	for idx, stmt := range stmts {
+		actual := actualResults[idx]
+		expect := results[idx]
+		failed := false
+		// 因为AI生成规则代码时，生成的审核结果的文字内容是规则的message加一些可能的额外文字信息，如额外的列名rulepkg.AddResult(input.Res, input.Rule, SQLE00170, columnName)
+		// 所以这里仅检查规则审核结果的条数和每条的level是否一致(已经能够检查规则是否被正确触发)，不检查文字内容
+		if len(actual.Results) != len(expect.Results.Results) {
+			failed = true
+		} else {
+			for i := range actual.Results {
+				if actual.Results[i].Level != expect.Results.Results[i].Level {
+					failed = true
+					break
+				}
+			}
+		}
+
+		if failed {
+			t.Errorf("%s test failed, \n\nsql:\n %s\n\nexpect level: %s\nexpect result:\n%s\n\nactual level: %s\nactual result:\n%s\n",
+				desc, stmt.Text(), expect.level(), expect.message(), actual.Level(), actual.Message())
+		} else {
+			t.Logf("\n\ncase:%s\nactual level: %s\nactual result:\n%s\n\n", desc, actual.Level(), actual.Message())
 		}
 	}
 }

--- a/sqle/driver/mysql/executor/executor.go
+++ b/sqle/driver/mysql/executor/executor.go
@@ -476,6 +476,25 @@ func (c *Executor) ShowCreateView(tableName string) (string, error) {
 	}
 }
 
+func (c *Executor) ShowCurrentMaxColumnWidth(tableName, columnName string) (int, error) {
+	query := fmt.Sprintf(`SELECT MAX(CHAR_LENGTH(%s)) "max_length" FROM %s`, columnName, tableName)
+	result, err := c.Db.Query(query)
+	if err != nil {
+		return 0, err
+	}
+	if len(result) != 1 {
+		err := fmt.Errorf("show max column width error, result is %v", result)
+		c.Db.Logger().Error(err)
+		return 0, errors.New(errors.ConnectRemoteDatabaseError, err)
+	}
+	if value, ok := result[0]["max_length"]; ok {
+		return strconv.Atoi(value.String)
+	}
+	err = fmt.Errorf("show max column width error, column \"MAX(CHAR_LENGTH(`%s`))\" not found", columnName)
+	c.Db.Logger().Error(err)
+	return 0, errors.New(errors.ConnectRemoteDatabaseError, err)
+}
+
 type ExplainWithWarningsResult struct {
 	Plan     []*ExplainRecord
 	Warnings []*WarningsRecord

--- a/sqle/driver/mysql/rule/ai/rule_00170.go
+++ b/sqle/driver/mysql/rule/ai/rule_00170.go
@@ -1,0 +1,99 @@
+package ai
+
+import (
+	rulepkg "github.com/actiontech/sqle/sqle/driver/mysql/rule"
+	util "github.com/actiontech/sqle/sqle/driver/mysql/rule/ai/util"
+	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
+	"github.com/actiontech/sqle/sqle/log"
+	"github.com/actiontech/sqle/sqle/pkg/params"
+	"github.com/pingcap/parser/ast"
+)
+
+const (
+	SQLE00170 = "SQLE00170"
+)
+
+func init() {
+	rh := rulepkg.RuleHandler{
+		Rule: driverV2.Rule{
+			Name:       SQLE00170,
+			Desc:       "在 MySQL 中, 避免缩短字段长度",
+			Annotation: "修改字段长度值低于现有字段长度值，如果该字段现有数据超出设定后的长度，会造成语句执行报错",
+			Level:      driverV2.RuleLevelWarn,
+			Category:   rulepkg.RuleTypeDMLConvention,
+			Params:     params.Params{},
+		},
+		Message:      "在 MySQL 中, 避免缩短字段长度. 字段 %s 的新长度 %d 小于当前最大长度 %d",
+		AllowOffline: false,
+		Func:         RuleSQLE00170,
+	}
+	rulepkg.RuleHandlers = append(rulepkg.RuleHandlers, rh)
+	rulepkg.RuleHandlerMap[rh.Rule.Name] = rh
+}
+
+/*
+==== Prompt start ====
+在 MySQL 中，您应该检查 SQL 是否违反了规则(SQLE00170): "在 MySQL 中，避免缩短字段长度."
+您应遵循以下逻辑：
+1. 对于 "ALTER TABLE... MODIFY ..." 语句：
+   1. 提取字段名称及其类型和使用辅助函数GetColumnWidth获取其长度。
+   2. 登录数据库。
+   3. 使用SQL(select max(char_length(col_name)) "max_length" from table_name)获取字段当前存储值的最大长度。
+   4. 比较新定义的字段长度与查询结果中的最大长度：
+      - 如果新长度小于最大长度，则报告违反规则。
+
+2. 对于 "ALTER TABLE ... CHANGE ..." 语句，执行与上述相同检查。
+==== Prompt end ====
+*/
+
+// ==== Rule code start ====
+// 规则函数实现开始
+func RuleSQLE00170(input *rulepkg.RuleHandlerInput) error {
+	// 确保输入节点为 ALTER TABLE 语句
+	alterStmt, ok := input.Node.(*ast.AlterTableStmt)
+	if !ok {
+		return nil
+	}
+
+	// 获取所有 MODIFY 和 CHANGE 类型的 AlterTableSpec
+	modifyChangeSpecs := util.GetAlterTableCommandsByTypes(alterStmt, ast.AlterTableModifyColumn, ast.AlterTableChangeColumn)
+	if len(modifyChangeSpecs) == 0 {
+		return nil
+	}
+
+	// 遍历每个 MODIFY 或 CHANGE 规范
+	for _, spec := range modifyChangeSpecs {
+		for _, newCol := range spec.NewColumns {
+			// 提取字段名称
+			columnName := util.GetColumnName(newCol)
+
+			// 提取新字段长度
+			newLength := util.GetColumnWidth(newCol)
+
+			// 检查是否成功提取新字段长度
+			if newLength == 0 {
+				log.NewEntry().Errorf("无法提取字段 %s 的新长度", columnName)
+				continue
+			}
+
+			// 获取当前字段的最大存储长度
+			currentMaxLength, err := util.GetCurrentMaxColumnWidth(input.Ctx, alterStmt.Table, columnName)
+			if err != nil {
+				// 记录日志并继续处理下一个字段
+				log.NewEntry().Errorf("获取字段 %s 当前最大长度失败: %v", columnName, err)
+				continue
+			}
+
+			// 比较新定义的字段长度与当前最大长度
+			if newLength < currentMaxLength {
+				// 报告违反规则
+				rulepkg.AddResult(input.Res, input.Rule, SQLE00170, columnName, newLength, currentMaxLength)
+			}
+		}
+	}
+
+	return nil
+}
+
+// 规则函数实现结束
+// ==== Rule code end ====

--- a/sqle/driver/mysql/rule/ai/util/util.go
+++ b/sqle/driver/mysql/rule/ai/util/util.go
@@ -439,7 +439,7 @@ func GetExecutionPlan(context *session.Context, sql string) (*executor.ExplainWi
 	return context.GetExecutionPlanWithWarnings(sql)
 }
 
-// a helper function to get table row count in MySQL
+// a helper function to get the number of rows in a table in MySQL
 func GetTableRowCount(context *session.Context, table *ast.TableName) (int, error) {
 	return context.GetTableRowCount(table)
 }
@@ -578,14 +578,9 @@ func ScanWhereStmt(fn func(expr ast.ExprNode) (skip bool), exprs ...ast.ExprNode
 	}
 }
 
-func utilGetTableName(tableName *ast.TableName) string {
-	// 假设这是一个简单的实现
-	return tableName.Name.String()
-}
-
-func utilGetTargetObjectType(cmd *ast.AlterTableSpec) string {
-	// 假设这是一个简单的实现
-	return "TEMPORARY_TABLE"
+// a helper function to return the maximum character length of a specified column in a specified table.
+func GetCurrentMaxColumnWidth(ctx *session.Context, table *ast.TableName, columnName string) (int, error) {
+	return ctx.GetExecutor().ShowCurrentMaxColumnWidth(table.Name.O, columnName)
 }
 
 // end helper function file. this line which used for ai scanner should be at the end of the file, please do not delete it

--- a/sqle/driver/mysql/rule_00170_test.go
+++ b/sqle/driver/mysql/rule_00170_test.go
@@ -1,0 +1,150 @@
+package mysql
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	rulepkg "github.com/actiontech/sqle/sqle/driver/mysql/rule"
+	"github.com/actiontech/sqle/sqle/driver/mysql/rule/ai"
+	"github.com/actiontech/sqle/sqle/driver/mysql/session"
+)
+
+// ==== Rule test code start ====
+func TestRuleSQLE00170(t *testing.T) {
+	ruleName := ai.SQLE00170
+	rule := rulepkg.RuleHandlerMap[ruleName].Rule
+
+	// case 1
+	runAIRuleCase(rule, t, "case 1: 使用 ALTER TABLE ... MODIFY ... 语句缩短 VARCHAR 字段长度，且当前数据长度超过新长度",
+		"ALTER TABLE test_table MODIFY name VARCHAR(50);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE test_table (id INT, name VARCHAR(100));").WithSQL("INSERT INTO test_table (id, name) VALUES (1, 'This is a very long name exceeding fifty characters.');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(name)) "max_length" FROM test_table`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(60),
+			},
+		}, newTestResult().addResult(ruleName))
+
+	// case 2
+	runAIRuleCase(rule, t, "case 2: 使用 ALTER TABLE ... MODIFY ... 语句不缩短 VARCHAR 字段长度，保持或增加长度",
+		"ALTER TABLE test_table MODIFY name VARCHAR(100);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE test_table (id INT, name VARCHAR(50));").WithSQL("INSERT INTO test_table (id, name) VALUES (1, 'Short name');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(name)) "max_length" FROM test_table`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(10),
+			},
+		}, newTestResult())
+
+	// case 3
+	runAIRuleCase(rule, t, "case 3: 使用 ALTER TABLE ... CHANGE ... 语句缩短 VARCHAR 字段长度，且当前数据长度超过新长度",
+		"ALTER TABLE test_table CHANGE name name VARCHAR(30);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE test_table (id INT, name VARCHAR(100));").WithSQL("INSERT INTO test_table (id, name) VALUES (1, 'This name is definitely longer than thirty characters.');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(name)) "max_length" FROM test_table`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(45),
+			},
+		}, newTestResult().addResult(ruleName))
+
+	// case 4
+	runAIRuleCase(rule, t, "case 4: 使用 ALTER TABLE ... CHANGE ... 语句不缩短 VARCHAR 字段长度，保持或增加长度",
+		"ALTER TABLE test_table CHANGE name name VARCHAR(100);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE test_table (id INT, name VARCHAR(50));").WithSQL("INSERT INTO test_table (id, name) VALUES (1, 'Short name');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(name)) "max_length" FROM test_table`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(10),
+			},
+		}, newTestResult())
+
+	// case 5
+	runAIRuleCase(rule, t, "case 5: 使用 ALTER TABLE ... MODIFY ... 语句缩短 CHAR 字段长度，且当前数据长度超过新长度",
+		"ALTER TABLE test_table MODIFY code CHAR(5);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE test_table (id INT, code CHAR(10));").WithSQL("INSERT INTO test_table (id, code) VALUES (1, '1234567890');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(code)) "max_length" FROM test_table`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(10),
+			},
+		}, newTestResult().addResult(ruleName))
+
+	// case 6
+	runAIRuleCase(rule, t, "case 6: 使用 ALTER TABLE ... MODIFY ... 语句不缩短 CHAR 字段长度，保持或增加长度",
+		"ALTER TABLE test_table MODIFY code CHAR(10);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE test_table (id INT, code CHAR(5));").WithSQL("INSERT INTO test_table (id, code) VALUES (1, '12345');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(code)) "max_length" FROM test_table`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(5),
+			},
+		}, newTestResult())
+
+	// case 7
+	runAIRuleCase(rule, t, "case 7: 使用 ALTER TABLE ... CHANGE ... 语句缩短 CHAR 字段长度，且当前数据长度超过新长度",
+		"ALTER TABLE test_table CHANGE code code CHAR(4);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE test_table (id INT, code CHAR(10));").WithSQL("INSERT INTO test_table (id, code) VALUES (1, '1234567890');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(code)) "max_length" FROM test_table`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(10),
+			},
+		}, newTestResult().addResult(ruleName))
+
+	// case 8
+	runAIRuleCase(rule, t, "case 8: 使用 ALTER TABLE ... CHANGE ... 语句不缩短 CHAR 字段长度，保持或增加长度",
+		"ALTER TABLE test_table CHANGE code code CHAR(10);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE test_table (id INT, code CHAR(5));").WithSQL("INSERT INTO test_table (id, code) VALUES (1, '1234');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(code)) "max_length" FROM test_table`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(4),
+			},
+		}, newTestResult())
+
+	// case 9
+	runAIRuleCase(rule, t, "case 9: 使用 ALTER TABLE ... MODIFY ... 语句缩短 VARCHAR 字段长度，且当前数据长度超过新长度 (从xml中补充)",
+		"ALTER TABLE customers MODIFY city VARCHAR(4);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE customers (id INT, city VARCHAR(10));").WithSQL("INSERT INTO customers (id, city) VALUES (1, 'New York');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(city)) "max_length" FROM customers`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(8),
+			},
+		}, newTestResult().addResult(ruleName))
+
+	// case 10
+	runAIRuleCase(rule, t, "case 10: 使用 ALTER TABLE ... MODIFY ... 语句不缩短 VARCHAR 字段长度，保持或增加长度 (从xml中补充)",
+		"ALTER TABLE customers MODIFY city VARCHAR(10);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE customers (id INT, city VARCHAR(5));").WithSQL("INSERT INTO customers (id, city) VALUES (1, 'LA');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(city)) "max_length" FROM customers`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(2),
+			},
+		}, newTestResult())
+
+	// case 11
+	runAIRuleCase(rule, t, "case 11: 使用 ALTER TABLE ... CHANGE ... 语句缩短 VARCHAR 字段长度，且当前数据长度超过新长度 (从xml中补充)",
+		"ALTER TABLE customers CHANGE city city VARCHAR(4);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE customers (id INT, city VARCHAR(10));").WithSQL("INSERT INTO customers (id, city) VALUES (1, 'Chicago');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(city)) "max_length" FROM customers`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(7),
+			},
+		}, newTestResult().addResult(ruleName))
+
+	// case 12
+	runAIRuleCase(rule, t, "case 12: 使用 ALTER TABLE ... CHANGE ... 语句不缩短 VARCHAR 字段长度，保持或增加长度 (从xml中补充)",
+		"ALTER TABLE customers CHANGE city city VARCHAR(10);",
+		session.NewAIMockContext().WithSQL("CREATE TABLE customers (id INT, city VARCHAR(5));").WithSQL("INSERT INTO customers (id, city) VALUES (1, 'SF');"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: `SELECT MAX(CHAR_LENGTH(city)) "max_length" FROM customers`,
+				Rows:  sqlmock.NewRows([]string{"max_length"}).AddRow(2),
+			},
+		}, newTestResult())
+}
+
+// ==== Rule test code end ====


### PR DESCRIPTION
1. 实现规则00170    
2. 变更单测结果检查逻辑
由于AI生成的规则代码中审核结果文本并不固定，所以不希望单测中检查审核结果文本完全相同，只检查结果的条数和级别，已经能保证检查出结果是否触发规则