### PR TITLE
use util.Fingerprint to fix panic ce

### DIFF
--- a/sqle/driver/mysql/util/parser_helper_test.go
+++ b/sqle/driver/mysql/util/parser_helper_test.go
@@ -189,6 +189,20 @@ func TestFingerprint(t *testing.T) {
 			input:  "select * from tb1 where a='my_db' and b='test1'# this is a comment",
 			expect: "SELECT * FROM `tb1` WHERE `a`=? AND `b`=?",
 		},
+		// not sql
+		{
+			input:  "SELECT*FROM (SELECT * FROM tb values(1));",
+			expect: "SELECT*FROM (SELECT * FROM tb values(1));",
+		},
+		{
+			input:  "not sql",
+			expect: "not sql",
+		},
+		// https://github.com/actiontech/sqle/issues/2603
+		{
+			input:  "insert into tb values(1)",
+			expect: "INSERT INTO `tb` VALUES (?)",
+		},
 	}
 	for _, c := range cases {
 		testFingerprint(t, c.input, c.expect)

--- a/sqle/pkg/driver/impl.go
+++ b/sqle/pkg/driver/impl.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/actiontech/sqle/sqle/driver/mysql/util"
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
 	"github.com/actiontech/sqle/sqle/pkg/params"
 	"github.com/actiontech/sqle/sqle/utils"
 	hclog "github.com/hashicorp/go-hclog"
 
-	"github.com/percona/go-mysql/query"
 	"github.com/pkg/errors"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
@@ -200,10 +200,14 @@ func (p *DriverImpl) Parse(ctx context.Context, sql string) ([]driverV2.Node, er
 
 	nodes := make([]driverV2.Node, 0, len(sqls))
 	for _, sql := range sqls {
+		fp, err := util.Fingerprint(sql, true)
+		if err != nil {
+			return nil, errors.Wrapf(err, "fingerprint of sql: %s", sql)
+		}
 		n := driverV2.Node{
 			Text:        sql,
 			Type:        classifySQL(sql),
-			Fingerprint: query.Fingerprint(sql),
+			Fingerprint: fp,
 		}
 		nodes = append(nodes, n)
 	}


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2603

## 描述你的变更
github.com/percona/go-mysql/query中生成指纹的函数Fingerprint特殊情况会panic，使用github.com/actiontech/sqle/sqle/driver/mysql/util中的指纹函数替换

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------

assign in @winfredLIN 