### PR TITLE
工单提交，若需审批成员过多时会报错数据超长

### DIFF
--- a/sqle/model/instance_audit_plan.go
+++ b/sqle/model/instance_audit_plan.go
@@ -278,7 +278,7 @@ type SQLManageRecordProcess struct {
 
 	SQLManageRecordID *uint `json:"sql_manage_record_id" gorm:"unique;not null"`
 	// 任务属性字段
-	Assignees string `json:"assignees" gorm:"type:varchar(255)"`
+	Assignees string `json:"assignees" gorm:"type:varchar(2000)"`
 	Status    string `json:"status" gorm:"default:\"unhandled\""`
 	Remark    string `json:"remark" gorm:"type:varchar(4000)"`
 }

--- a/sqle/model/sql_manage.go
+++ b/sqle/model/sql_manage.go
@@ -20,7 +20,7 @@ type SqlManage struct {
 	InstanceName              string       `json:"instance_name" gorm:"type:varchar(255)"`
 	SchemaName                string       `json:"schema_name" gorm:"type:varchar(255)"`
 
-	Assignees string `json:"assignees" gorm:"type:varchar(255)"`
+	Assignees string `json:"assignees" gorm:"type:varchar(2000)"`
 	Status    string `json:"status" gorm:"default:\"unhandled\"; type:varchar(255)"`
 	Remark    string `json:"remark" gorm:"type:varchar(4000)"`
 

--- a/sqle/model/workflow.go
+++ b/sqle/model/workflow.go
@@ -254,7 +254,7 @@ type WorkflowInstanceRecord struct {
 	Instance *Instance `gorm:"foreignkey:InstanceId"`
 	Task     *Task     `gorm:"foreignkey:TaskId"`
 	// User     *User     `gorm:"foreignkey:ExecutionUserId"`
-	ExecutionAssignees string `gorm:"type:varchar(255)"`
+	ExecutionAssignees string `gorm:"type:varchar(2000)"`
 }
 
 func (s *Storage) UpdateWorkflowInstanceRecordById(id uint, m map[string]interface{}) error {
@@ -312,7 +312,7 @@ type WorkflowStep struct {
 	State                  string `gorm:"default:\"initialized\"; type:varchar(255)"`
 	Reason                 string `gorm:"type:varchar(255)"`
 
-	Assignees string                `gorm:"type:varchar(255)"` // `gorm:"many2many:workflow_step_user"`
+	Assignees string                `gorm:"type:varchar(2000)"` // `gorm:"many2many:workflow_step_user"`
 	Template  *WorkflowStepTemplate `gorm:"foreignkey:WorkflowStepTemplateId"`
 	// OperationUser string                // `gorm:"foreignkey:OperationUserId"`
 }


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2601
## 描述你的变更
背景:工单提交，若需审批成员过多时会报错数据超长
修复:修改审批成员的数据类型长度为2000
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
