### PR TITLE
fix: 修复sql工作台最高审核等级参数不生效的问题

### DIFF
--- a/sqle/driver/v1/driver.go
+++ b/sqle/driver/v1/driver.go
@@ -205,12 +205,12 @@ func RegisterDrivers(c *goPlugin.Client, clientCfg func(cmdBase string, cmdArgs 
 
 // DSN provide necessary information to connect to database.
 type DSN struct {
-	Host             string
-	Port             string
-	User             string
-	Password         string
-	AdditionalParams params.Params
-
+	Host                    string
+	Port                    string
+	User                    string
+	Password                string
+	AdditionalParams        params.Params
+	SQLAllowQueryAuditLevel string
 	// DatabaseName is the default database to connect.
 	DatabaseName string
 }

--- a/sqle/driver/v1/driver.go
+++ b/sqle/driver/v1/driver.go
@@ -205,12 +205,12 @@ func RegisterDrivers(c *goPlugin.Client, clientCfg func(cmdBase string, cmdArgs 
 
 // DSN provide necessary information to connect to database.
 type DSN struct {
-	Host                    string
-	Port                    string
-	User                    string
-	Password                string
-	AdditionalParams        params.Params
-	SQLAllowQueryAuditLevel string
+	Host             string
+	Port             string
+	User             string
+	Password         string
+	AdditionalParams params.Params
+
 	// DatabaseName is the default database to connect.
 	DatabaseName string
 }

--- a/sqle/driver/v2/util.go
+++ b/sqle/driver/v2/util.go
@@ -117,6 +117,14 @@ func ConvertI18nAuditResultsFromProtoToDriver(pars []*protoV2.AuditResult, isI18
 	return ars, nil
 }
 
+// IsAllowAuditPass 判断运行查询的最高审核等级，如果审核等级低于或等于这个等级将会放行
+func IsAllowAuditPass(sqlAllowQueryAuditLevel RuleLevel, auditResultLevel RuleLevel) bool {
+	if sqlAllowQueryAuditLevel == "" {
+		return false
+	}
+	return auditResultLevel.LessOrEqual(sqlAllowQueryAuditLevel)
+}
+
 func ConvertI18nAuditResultFromProtoToDriver(par *protoV2.AuditResult, isI18n bool) (*AuditResult, error) {
 	ar := &AuditResult{
 		RuleName:            par.RuleName,

--- a/sqle/driver/v2/util.go
+++ b/sqle/driver/v2/util.go
@@ -119,9 +119,6 @@ func ConvertI18nAuditResultsFromProtoToDriver(pars []*protoV2.AuditResult, isI18
 
 // IsAllowAuditPass 判断运行查询的最高审核等级，如果审核等级低于或等于这个等级将会放行
 func IsAllowAuditPass(sqlAllowQueryAuditLevel RuleLevel, auditResultLevel RuleLevel) bool {
-	if sqlAllowQueryAuditLevel == "" {
-		return false
-	}
 	return auditResultLevel.LessOrEqual(sqlAllowQueryAuditLevel)
 }
 

--- a/sqle/server/audit.go
+++ b/sqle/server/audit.go
@@ -45,7 +45,7 @@ func HookAudit(l *logrus.Entry, task *model.Task, hook AuditHook, projectId *mod
 	if task.Instance == nil {
 		task.Instance = &model.Instance{ProjectId: string(*projectId)}
 	}
-	return hookAudit(l, task, plugin, hook, string(*projectId), customRules)
+	return hookAudit(l, task, plugin, hook, string(*projectId), "", customRules)
 }
 
 const AuditSchema = "AuditSchema"
@@ -67,8 +67,7 @@ func DirectAuditByInstance(l *logrus.Entry, sql, schemaName string, instance *mo
 		return nil, err
 	}
 	task.Instance = instance
-
-	return task, audit(instance.ProjectId, l, task, plugin, customRules)
+	return task, audit(instance.ProjectId, instance.SqlQueryConfig.AllowQueryWhenLessThanAuditLevel, l, task, plugin, customRules)
 }
 
 func AuditSQLByDBType(l *logrus.Entry, sql string, dbType string, projectId string, ruleTemplateName string) (*model.Task, error) {
@@ -91,7 +90,7 @@ func AuditSQLByDriver(projectId string, l *logrus.Entry, sql string, p driver.Pl
 	if err != nil {
 		return nil, err
 	}
-	return task, audit(projectId, l, task, p, customRules)
+	return task, audit(projectId, "", l, task, p, customRules)
 }
 
 func convertSQLsToTask(sql string, p driver.Plugin) (*model.Task, error) {
@@ -111,8 +110,8 @@ func convertSQLsToTask(sql string, p driver.Plugin) (*model.Task, error) {
 	return task, nil
 }
 
-func audit(projectId string, l *logrus.Entry, task *model.Task, p driver.Plugin, customRules []*model.CustomRule) (err error) {
-	return hookAudit(l, task, p, &EmptyAuditHook{}, projectId, customRules)
+func audit(projectId string, allowQueryWhenLessThanAuditLevel string, l *logrus.Entry, task *model.Task, p driver.Plugin, customRules []*model.CustomRule) (err error) {
+	return hookAudit(l, task, p, &EmptyAuditHook{}, projectId, allowQueryWhenLessThanAuditLevel, customRules)
 }
 
 type AuditHook interface {
@@ -126,7 +125,7 @@ func (e *EmptyAuditHook) BeforeAudit(sql *model.ExecuteSQL) {}
 
 func (e *EmptyAuditHook) AfterAudit(sql *model.ExecuteSQL) {}
 
-func hookAudit(l *logrus.Entry, task *model.Task, p driver.Plugin, hook AuditHook, projectId string, customRules []*model.CustomRule) (err error) {
+func hookAudit(l *logrus.Entry, task *model.Task, p driver.Plugin, hook AuditHook, projectId string, allowQueryWhenLessThanAuditLevel string, customRules []*model.CustomRule) (err error) {
 	defer func() {
 		if errRecover := recover(); errRecover != nil {
 			debug.PrintStack()
@@ -210,14 +209,28 @@ func hookAudit(l *logrus.Entry, task *model.Task, p driver.Plugin, hook AuditHoo
 		for i, sql := range auditSqls {
 			hook.AfterAudit(sql)
 			sql.AuditStatus = model.SQLAuditStatusFinished
-			sql.AuditLevel = string(results[i].Level())
-			sql.AuditFingerprint = utils.Md5String(string(append([]byte(results[i].Message()), []byte(nodes[i].Fingerprint)...)))
-			appendExecuteSqlResults(sql, results[i])
+			filteredResults := filterAuditResults(allowQueryWhenLessThanAuditLevel, results[i])
+			sql.AuditLevel = string(filteredResults.Level())
+			sql.AuditFingerprint = utils.Md5String(string(append([]byte(filteredResults.Message()), []byte(nodes[i].Fingerprint)...)))
+			appendExecuteSqlResults(sql, filteredResults)
 		}
 	}
 
 	ReplenishTaskStatistics(task)
 	return nil
+}
+
+func filterAuditResults(allowQueryWhenLessThanAuditLevel string, auditResult *driverV2.AuditResults) *driverV2.AuditResults {
+	var filteredAuditResult = make([]*driverV2.AuditResult, 0)
+	for _, auditResult := range auditResult.Results {
+		if driverV2.IsAllowAuditPass(driverV2.RuleLevel(allowQueryWhenLessThanAuditLevel), auditResult.Level) {
+			continue
+		}
+		filteredAuditResult = append(filteredAuditResult, auditResult)
+	}
+	filteredAuditResults := &driverV2.AuditResults{}
+	filteredAuditResults.Results = filteredAuditResult
+	return filteredAuditResults
 }
 
 func ReplenishTaskStatistics(task *model.Task) {

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -294,7 +294,7 @@ func (a *action) validation(task *model.Task) error {
 func (a *action) audit() (err error) {
 	st := model.GetStorage()
 
-	err = audit(a.projectId, a.entry, a.task, a.plugin, a.customRules)
+	err = audit(a.projectId, "", a.entry, a.task, a.plugin, a.customRules)
 	if err != nil {
 		return err
 	}
@@ -812,8 +812,7 @@ func newDriverManagerWithAudit(l *logrus.Entry, inst *model.Instance, database s
 			User:             inst.User,
 			Password:         inst.Password,
 			AdditionalParams: inst.AdditionalParams,
-
-			DatabaseName: database,
+			DatabaseName:     database,
 		}
 	}
 

--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -294,7 +294,7 @@ func (a *action) validation(task *model.Task) error {
 func (a *action) audit() (err error) {
 	st := model.GetStorage()
 
-	err = audit(a.projectId, "", a.entry, a.task, a.plugin, a.customRules)
+	err = audit(a.projectId, a.entry, a.task, a.plugin, a.customRules)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2011
## 描述你的变更
- 直接审核接口增加`dbservicename`参数使得最高审核等级参数生效
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
