### PR TITLE
Sql rewriting fix

### DIFF
--- a/build/sqled.spec
+++ b/build/sqled.spec
@@ -129,6 +129,8 @@ sqle:
       mysql_user: 'root'
       mysql_password: 'pass'
       mysql_schema: 'sqle'
+  sql_rewriting_config:
+    rewriting_url: '127.0.0.1:5891'
 EOF
 
 cat > $RPM_INSTALL_PREFIX/etc/gh-ost.ini<<EOF

--- a/build/sqled_with_dms.spec
+++ b/build/sqled_with_dms.spec
@@ -140,6 +140,8 @@ sqle:
       mysql_user: 'root'
       mysql_password: 'pass'
       mysql_schema: 'sqle'
+  sql_rewriting_config:
+    rewriting_url: '127.0.0.1:5891'
 EOF
 fi
 

--- a/sqle/api/app.go
+++ b/sqle/api/app.go
@@ -469,7 +469,7 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config *config.SqleOpti
 		v1Router.POST("/projects/:project_name/task_groups", v1.CreateAuditTasksGroupV1)
 		v1Router.POST("/task_groups/audit", v1.AuditTaskGroupV1)
 		v1Router.GET("/tasks/file_order_methods", v1.GetSqlFileOrderMethodV1)
-		v1Router.GET("/tasks/audits/:task_id/sqls/:number/rewrite", v1.GetTaskRewrittenSQL)
+		v1Router.POST("/tasks/audits/:task_id/sqls/:number/rewrite", v1.RewriteSQL)
 
 		// dashboard
 		v1Router.GET("/dashboard", v1.Dashboard)

--- a/sqle/api/controller/v1/sql_rewriting.go
+++ b/sqle/api/controller/v1/sql_rewriting.go
@@ -12,7 +12,7 @@ type RewriteSQLReq struct {
 
 type RewriteSQLData struct {
 	// @Description 重写前的SQL业务描述
-	BussinessDesc string `json:"bussiness_desc"`
+	BusinessDesc string `json:"business_desc"`
 	// @Description 重写建议列表
 	Suggestions []*RewriteSuggestion `json:"suggestions"`
 	// @Description 重写后的SQL

--- a/sqle/api/controller/v1/sql_rewriting.go
+++ b/sqle/api/controller/v1/sql_rewriting.go
@@ -11,11 +11,13 @@ type RewriteSQLReq struct {
 }
 
 type RewriteSQLData struct {
+	// @Description 重写前的SQL业务描述
+	BussinessDesc string `json:"bussiness_desc"`
 	// @Description 重写建议列表
 	Suggestions []*RewriteSuggestion `json:"suggestions"`
 	// @Description 重写后的SQL
 	RewrittenSQL string `json:"rewritten_sql"`
-	// @Description 业务不等价性描述，为空表示等价
+	// @Description 重写前后的业务不等价性描述，为空表示等价
 	BusinessNonEquivalentDesc string `json:"business_non_equivalent_desc"`
 
 	// TODO: 重写SQL的审核结果

--- a/sqle/api/controller/v1/sql_rewriting.go
+++ b/sqle/api/controller/v1/sql_rewriting.go
@@ -5,9 +5,12 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+type GetTaskRewrittenSQLReq struct {
+	// @Description 是否启用结构化类型的重写
+	EnableStructureType bool `json:"enable_structure_type" example:"false" default:"false"`
+}
+
 type TaskRewrittenSQLData struct {
-	// @Description 表结构
-	TableMetas *TableMetas `json:"table_metas"`
 	// @Description 重写建议列表
 	Suggestions []*SQLRewrittenSuggestion `json:"suggestions"`
 	// @Description 重写后的SQL
@@ -48,12 +51,15 @@ type GetTaskRewrittenSQLRes struct {
 // @Summary 获取任务中指定SQL的重写结果和建议
 // @Description 获取特定任务中某条SQL语句的重写后的SQL及相关建议
 // @Id getTaskRewrittenSQL
+// @Accept json
+// @Produce json
 // @Tags task
 // @Param task_id path string true "task id"
 // @Param number path uint true "sql number"
+// @Param req body v1.GetTaskRewrittenSQLReq true "request body"
 // @Security ApiKeyAuth
 // @Success 200 {object} v1.GetTaskRewrittenSQLRes "成功返回重写结果"
-// @router /v1/tasks/audits/{task_id}/sqls/{number}/rewrite [get]
+// @router /v1/tasks/audits/{task_id}/sqls/{number}/rewrite [post]
 func GetTaskRewrittenSQL(c echo.Context) error {
 	return getTaskRewrittenSQLData(c)
 }

--- a/sqle/api/controller/v1/sql_rewriting.go
+++ b/sqle/api/controller/v1/sql_rewriting.go
@@ -5,14 +5,14 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type GetTaskRewrittenSQLReq struct {
+type RewriteSQLReq struct {
 	// @Description 是否启用结构化类型的重写
 	EnableStructureType bool `json:"enable_structure_type" example:"false" default:"false"`
 }
 
-type TaskRewrittenSQLData struct {
+type RewriteSQLData struct {
 	// @Description 重写建议列表
-	Suggestions []*SQLRewrittenSuggestion `json:"suggestions"`
+	Suggestions []*RewriteSuggestion `json:"suggestions"`
 	// @Description 重写后的SQL
 	RewrittenSQL string `json:"rewritten_sql"`
 	// @Description 业务不等价性描述，为空表示等价
@@ -21,7 +21,7 @@ type TaskRewrittenSQLData struct {
 	// TODO: 重写SQL的审核结果
 }
 
-type SQLRewrittenSuggestion struct {
+type RewriteSuggestion struct {
 	// @Description 审核规则名称
 	// @Required
 	RuleName string `json:"rule_name"`
@@ -42,24 +42,24 @@ type SQLRewrittenSuggestion struct {
 	DDL_DCL string `json:"ddl_dcl"`
 }
 
-type GetTaskRewrittenSQLRes struct {
+type RewriteSQLRes struct {
 	controller.BaseRes
-	Data *TaskRewrittenSQLData `json:"data"`
+	Data *RewriteSQLData `json:"data"`
 }
 
-// GetTaskRewrittenSQL retrieves the rewritten SQL and associated suggestions for a specific SQL statement within a task.
+// RewriteSQL retrieves the rewritten SQL and associated suggestions for a specific SQL statement within a task.
 // @Summary 获取任务中指定SQL的重写结果和建议
 // @Description 获取特定任务中某条SQL语句的重写后的SQL及相关建议
-// @Id getTaskRewrittenSQL
+// @Id RewriteSQL
 // @Accept json
 // @Produce json
 // @Tags task
 // @Param task_id path string true "task id"
 // @Param number path uint true "sql number"
-// @Param req body v1.GetTaskRewrittenSQLReq true "request body"
+// @Param req body v1.RewriteSQLReq true "request body"
 // @Security ApiKeyAuth
-// @Success 200 {object} v1.GetTaskRewrittenSQLRes "成功返回重写结果"
+// @Success 200 {object} v1.RewriteSQLRes "成功返回重写结果"
 // @router /v1/tasks/audits/{task_id}/sqls/{number}/rewrite [post]
-func GetTaskRewrittenSQL(c echo.Context) error {
-	return getTaskRewrittenSQLData(c)
+func RewriteSQL(c echo.Context) error {
+	return getRewriteSQLData(c)
 }

--- a/sqle/api/controller/v1/sql_rewriting_ce.go
+++ b/sqle/api/controller/v1/sql_rewriting_ce.go
@@ -10,6 +10,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func getTaskRewrittenSQLData(c echo.Context) error {
+func getRewriteSQLData(c echo.Context) error {
 	return errors.New(errors.EnterpriseEditionFeatures, e.New("sql rewriting is enterprise version feature"))
 }

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -9636,13 +9636,19 @@ var doc = `{
             }
         },
         "/v1/tasks/audits/{task_id}/sqls/{number}/rewrite": {
-            "get": {
+            "post": {
                 "security": [
                     {
                         "ApiKeyAuth": []
                     }
                 ],
                 "description": "获取特定任务中某条SQL语句的重写后的SQL及相关建议",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "task"
                 ],
@@ -9662,6 +9668,15 @@ var doc = `{
                         "name": "number",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "request body",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.GetTaskRewrittenSQLReq"
+                        }
                     }
                 ],
                 "responses": {
@@ -14974,6 +14989,17 @@ var doc = `{
                 }
             }
         },
+        "v1.GetTaskRewrittenSQLReq": {
+            "type": "object",
+            "properties": {
+                "enable_structure_type": {
+                    "description": "@Description 是否启用结构化类型的重写",
+                    "type": "boolean",
+                    "default": false,
+                    "example": false
+                }
+            }
+        },
         "v1.GetTaskRewrittenSQLRes": {
             "type": "object",
             "properties": {
@@ -17487,11 +17513,6 @@ var doc = `{
                     "items": {
                         "$ref": "#/definitions/v1.SQLRewrittenSuggestion"
                     }
-                },
-                "table_metas": {
-                    "description": "@Description 表结构",
-                    "type": "object",
-                    "$ref": "#/definitions/v1.TableMetas"
                 }
             }
         },

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -16428,12 +16428,12 @@ var doc = `{
         "v1.RewriteSQLData": {
             "type": "object",
             "properties": {
-                "business_non_equivalent_desc": {
-                    "description": "@Description 重写前后的业务不等价性描述，为空表示等价",
+                "business_desc": {
+                    "description": "@Description 重写前的SQL业务描述",
                     "type": "string"
                 },
-                "bussiness_desc": {
-                    "description": "@Description 重写前的SQL业务描述",
+                "business_non_equivalent_desc": {
+                    "description": "@Description 重写前后的业务不等价性描述，为空表示等价",
                     "type": "string"
                 },
                 "rewritten_sql": {

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -16429,7 +16429,11 @@ var doc = `{
             "type": "object",
             "properties": {
                 "business_non_equivalent_desc": {
-                    "description": "@Description 业务不等价性描述，为空表示等价",
+                    "description": "@Description 重写前后的业务不等价性描述，为空表示等价",
+                    "type": "string"
+                },
+                "bussiness_desc": {
+                    "description": "@Description 重写前的SQL业务描述",
                     "type": "string"
                 },
                 "rewritten_sql": {

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -9653,7 +9653,7 @@ var doc = `{
                     "task"
                 ],
                 "summary": "获取任务中指定SQL的重写结果和建议",
-                "operationId": "getTaskRewrittenSQL",
+                "operationId": "RewriteSQL",
                 "parameters": [
                     {
                         "type": "string",
@@ -9675,7 +9675,7 @@ var doc = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/v1.GetTaskRewrittenSQLReq"
+                            "$ref": "#/definitions/v1.RewriteSQLReq"
                         }
                     }
                 ],
@@ -9683,7 +9683,7 @@ var doc = `{
                     "200": {
                         "description": "成功返回重写结果",
                         "schema": {
-                            "$ref": "#/definitions/v1.GetTaskRewrittenSQLRes"
+                            "$ref": "#/definitions/v1.RewriteSQLRes"
                         }
                     }
                 }
@@ -14989,34 +14989,6 @@ var doc = `{
                 }
             }
         },
-        "v1.GetTaskRewrittenSQLReq": {
-            "type": "object",
-            "properties": {
-                "enable_structure_type": {
-                    "description": "@Description 是否启用结构化类型的重写",
-                    "type": "boolean",
-                    "default": false,
-                    "example": false
-                }
-            }
-        },
-        "v1.GetTaskRewrittenSQLRes": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer",
-                    "example": 0
-                },
-                "data": {
-                    "type": "object",
-                    "$ref": "#/definitions/v1.TaskRewrittenSQLData"
-                },
-                "message": {
-                    "type": "string",
-                    "example": "ok"
-                }
-            }
-        },
         "v1.GetUserTipsResV1": {
             "type": "object",
             "properties": {
@@ -16453,6 +16425,98 @@ var doc = `{
                 }
             }
         },
+        "v1.RewriteSQLData": {
+            "type": "object",
+            "properties": {
+                "business_non_equivalent_desc": {
+                    "description": "@Description 业务不等价性描述，为空表示等价",
+                    "type": "string"
+                },
+                "rewritten_sql": {
+                    "description": "@Description 重写后的SQL",
+                    "type": "string"
+                },
+                "suggestions": {
+                    "description": "@Description 重写建议列表",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1.RewriteSuggestion"
+                    }
+                }
+            }
+        },
+        "v1.RewriteSQLReq": {
+            "type": "object",
+            "properties": {
+                "enable_structure_type": {
+                    "description": "@Description 是否启用结构化类型的重写",
+                    "type": "boolean",
+                    "default": false,
+                    "example": false
+                }
+            }
+        },
+        "v1.RewriteSQLRes": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "object",
+                    "$ref": "#/definitions/v1.RewriteSQLData"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                }
+            }
+        },
+        "v1.RewriteSuggestion": {
+            "type": "object",
+            "properties": {
+                "audit_level": {
+                    "description": "@Description 审核规则等级\n@Required",
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "notice",
+                        "warn",
+                        "error"
+                    ]
+                },
+                "ddl_dcl": {
+                    "description": "@Description 具体的数据库结构变更语句，需要在数据库中执行该变更语句之后再应用重写SQL（包含CREATE/ALTER/DROP等DDL语句，或SET等DCL语句）（适用于结构级重写）",
+                    "type": "string"
+                },
+                "ddl_dcl_desc": {
+                    "description": "@Description 数据库结构变更建议说明（例如：建议添加索引、修改表结构等优化建议）（适用于结构级重写）",
+                    "type": "string"
+                },
+                "desc": {
+                    "description": "@Description 重写描述（适用于所有类型）\n@Required",
+                    "type": "string"
+                },
+                "rewritten_sql": {
+                    "description": "@Description 重写后的SQL（适用于语句级重写和结构级重写）",
+                    "type": "string"
+                },
+                "rule_name": {
+                    "description": "@Description 审核规则名称\n@Required",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "@Description 重写建议类型：语句级重写、结构级重写、其他\n@Required",
+                    "type": "string",
+                    "enum": [
+                        "statement",
+                        "structure",
+                        "other"
+                    ]
+                }
+            }
+        },
         "v1.RiskAuditPlan": {
             "type": "object",
             "properties": {
@@ -16857,50 +16921,6 @@ var doc = `{
                 },
                 "query_timeout_second": {
                     "type": "integer"
-                }
-            }
-        },
-        "v1.SQLRewrittenSuggestion": {
-            "type": "object",
-            "properties": {
-                "audit_level": {
-                    "description": "@Description 审核规则等级\n@Required",
-                    "type": "string",
-                    "enum": [
-                        "normal",
-                        "notice",
-                        "warn",
-                        "error"
-                    ]
-                },
-                "ddl_dcl": {
-                    "description": "@Description 具体的数据库结构变更语句，需要在数据库中执行该变更语句之后再应用重写SQL（包含CREATE/ALTER/DROP等DDL语句，或SET等DCL语句）（适用于结构级重写）",
-                    "type": "string"
-                },
-                "ddl_dcl_desc": {
-                    "description": "@Description 数据库结构变更建议说明（例如：建议添加索引、修改表结构等优化建议）（适用于结构级重写）",
-                    "type": "string"
-                },
-                "desc": {
-                    "description": "@Description 重写描述（适用于所有类型）\n@Required",
-                    "type": "string"
-                },
-                "rewritten_sql": {
-                    "description": "@Description 重写后的SQL（适用于语句级重写和结构级重写）",
-                    "type": "string"
-                },
-                "rule_name": {
-                    "description": "@Description 审核规则名称\n@Required",
-                    "type": "string"
-                },
-                "type": {
-                    "description": "@Description 重写建议类型：语句级重写、结构级重写、其他\n@Required",
-                    "type": "string",
-                    "enum": [
-                        "statement",
-                        "structure",
-                        "other"
-                    ]
                 }
             }
         },
@@ -17493,26 +17513,6 @@ var doc = `{
                 },
                 "target_instance_schema": {
                     "type": "string"
-                }
-            }
-        },
-        "v1.TaskRewrittenSQLData": {
-            "type": "object",
-            "properties": {
-                "business_non_equivalent_desc": {
-                    "description": "@Description 业务不等价性描述，为空表示等价",
-                    "type": "string"
-                },
-                "rewritten_sql": {
-                    "description": "@Description 重写后的SQL",
-                    "type": "string"
-                },
-                "suggestions": {
-                    "description": "@Description 重写建议列表",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/v1.SQLRewrittenSuggestion"
-                    }
                 }
             }
         },

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -16413,7 +16413,11 @@
             "type": "object",
             "properties": {
                 "business_non_equivalent_desc": {
-                    "description": "@Description 业务不等价性描述，为空表示等价",
+                    "description": "@Description 重写前后的业务不等价性描述，为空表示等价",
+                    "type": "string"
+                },
+                "bussiness_desc": {
+                    "description": "@Description 重写前的SQL业务描述",
                     "type": "string"
                 },
                 "rewritten_sql": {

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -9620,13 +9620,19 @@
             }
         },
         "/v1/tasks/audits/{task_id}/sqls/{number}/rewrite": {
-            "get": {
+            "post": {
                 "security": [
                     {
                         "ApiKeyAuth": []
                     }
                 ],
                 "description": "获取特定任务中某条SQL语句的重写后的SQL及相关建议",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "task"
                 ],
@@ -9646,6 +9652,15 @@
                         "name": "number",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "request body",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.GetTaskRewrittenSQLReq"
+                        }
                     }
                 ],
                 "responses": {
@@ -14958,6 +14973,17 @@
                 }
             }
         },
+        "v1.GetTaskRewrittenSQLReq": {
+            "type": "object",
+            "properties": {
+                "enable_structure_type": {
+                    "description": "@Description 是否启用结构化类型的重写",
+                    "type": "boolean",
+                    "default": false,
+                    "example": false
+                }
+            }
+        },
         "v1.GetTaskRewrittenSQLRes": {
             "type": "object",
             "properties": {
@@ -17471,11 +17497,6 @@
                     "items": {
                         "$ref": "#/definitions/v1.SQLRewrittenSuggestion"
                     }
-                },
-                "table_metas": {
-                    "description": "@Description 表结构",
-                    "type": "object",
-                    "$ref": "#/definitions/v1.TableMetas"
                 }
             }
         },

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -16412,12 +16412,12 @@
         "v1.RewriteSQLData": {
             "type": "object",
             "properties": {
-                "business_non_equivalent_desc": {
-                    "description": "@Description 重写前后的业务不等价性描述，为空表示等价",
+                "business_desc": {
+                    "description": "@Description 重写前的SQL业务描述",
                     "type": "string"
                 },
-                "bussiness_desc": {
-                    "description": "@Description 重写前的SQL业务描述",
+                "business_non_equivalent_desc": {
+                    "description": "@Description 重写前后的业务不等价性描述，为空表示等价",
                     "type": "string"
                 },
                 "rewritten_sql": {

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -9637,7 +9637,7 @@
                     "task"
                 ],
                 "summary": "获取任务中指定SQL的重写结果和建议",
-                "operationId": "getTaskRewrittenSQL",
+                "operationId": "RewriteSQL",
                 "parameters": [
                     {
                         "type": "string",
@@ -9659,7 +9659,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/v1.GetTaskRewrittenSQLReq"
+                            "$ref": "#/definitions/v1.RewriteSQLReq"
                         }
                     }
                 ],
@@ -9667,7 +9667,7 @@
                     "200": {
                         "description": "成功返回重写结果",
                         "schema": {
-                            "$ref": "#/definitions/v1.GetTaskRewrittenSQLRes"
+                            "$ref": "#/definitions/v1.RewriteSQLRes"
                         }
                     }
                 }
@@ -14973,34 +14973,6 @@
                 }
             }
         },
-        "v1.GetTaskRewrittenSQLReq": {
-            "type": "object",
-            "properties": {
-                "enable_structure_type": {
-                    "description": "@Description 是否启用结构化类型的重写",
-                    "type": "boolean",
-                    "default": false,
-                    "example": false
-                }
-            }
-        },
-        "v1.GetTaskRewrittenSQLRes": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer",
-                    "example": 0
-                },
-                "data": {
-                    "type": "object",
-                    "$ref": "#/definitions/v1.TaskRewrittenSQLData"
-                },
-                "message": {
-                    "type": "string",
-                    "example": "ok"
-                }
-            }
-        },
         "v1.GetUserTipsResV1": {
             "type": "object",
             "properties": {
@@ -16437,6 +16409,98 @@
                 }
             }
         },
+        "v1.RewriteSQLData": {
+            "type": "object",
+            "properties": {
+                "business_non_equivalent_desc": {
+                    "description": "@Description 业务不等价性描述，为空表示等价",
+                    "type": "string"
+                },
+                "rewritten_sql": {
+                    "description": "@Description 重写后的SQL",
+                    "type": "string"
+                },
+                "suggestions": {
+                    "description": "@Description 重写建议列表",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1.RewriteSuggestion"
+                    }
+                }
+            }
+        },
+        "v1.RewriteSQLReq": {
+            "type": "object",
+            "properties": {
+                "enable_structure_type": {
+                    "description": "@Description 是否启用结构化类型的重写",
+                    "type": "boolean",
+                    "default": false,
+                    "example": false
+                }
+            }
+        },
+        "v1.RewriteSQLRes": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "data": {
+                    "type": "object",
+                    "$ref": "#/definitions/v1.RewriteSQLData"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "ok"
+                }
+            }
+        },
+        "v1.RewriteSuggestion": {
+            "type": "object",
+            "properties": {
+                "audit_level": {
+                    "description": "@Description 审核规则等级\n@Required",
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "notice",
+                        "warn",
+                        "error"
+                    ]
+                },
+                "ddl_dcl": {
+                    "description": "@Description 具体的数据库结构变更语句，需要在数据库中执行该变更语句之后再应用重写SQL（包含CREATE/ALTER/DROP等DDL语句，或SET等DCL语句）（适用于结构级重写）",
+                    "type": "string"
+                },
+                "ddl_dcl_desc": {
+                    "description": "@Description 数据库结构变更建议说明（例如：建议添加索引、修改表结构等优化建议）（适用于结构级重写）",
+                    "type": "string"
+                },
+                "desc": {
+                    "description": "@Description 重写描述（适用于所有类型）\n@Required",
+                    "type": "string"
+                },
+                "rewritten_sql": {
+                    "description": "@Description 重写后的SQL（适用于语句级重写和结构级重写）",
+                    "type": "string"
+                },
+                "rule_name": {
+                    "description": "@Description 审核规则名称\n@Required",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "@Description 重写建议类型：语句级重写、结构级重写、其他\n@Required",
+                    "type": "string",
+                    "enum": [
+                        "statement",
+                        "structure",
+                        "other"
+                    ]
+                }
+            }
+        },
         "v1.RiskAuditPlan": {
             "type": "object",
             "properties": {
@@ -16841,50 +16905,6 @@
                 },
                 "query_timeout_second": {
                     "type": "integer"
-                }
-            }
-        },
-        "v1.SQLRewrittenSuggestion": {
-            "type": "object",
-            "properties": {
-                "audit_level": {
-                    "description": "@Description 审核规则等级\n@Required",
-                    "type": "string",
-                    "enum": [
-                        "normal",
-                        "notice",
-                        "warn",
-                        "error"
-                    ]
-                },
-                "ddl_dcl": {
-                    "description": "@Description 具体的数据库结构变更语句，需要在数据库中执行该变更语句之后再应用重写SQL（包含CREATE/ALTER/DROP等DDL语句，或SET等DCL语句）（适用于结构级重写）",
-                    "type": "string"
-                },
-                "ddl_dcl_desc": {
-                    "description": "@Description 数据库结构变更建议说明（例如：建议添加索引、修改表结构等优化建议）（适用于结构级重写）",
-                    "type": "string"
-                },
-                "desc": {
-                    "description": "@Description 重写描述（适用于所有类型）\n@Required",
-                    "type": "string"
-                },
-                "rewritten_sql": {
-                    "description": "@Description 重写后的SQL（适用于语句级重写和结构级重写）",
-                    "type": "string"
-                },
-                "rule_name": {
-                    "description": "@Description 审核规则名称\n@Required",
-                    "type": "string"
-                },
-                "type": {
-                    "description": "@Description 重写建议类型：语句级重写、结构级重写、其他\n@Required",
-                    "type": "string",
-                    "enum": [
-                        "statement",
-                        "structure",
-                        "other"
-                    ]
                 }
             }
         },
@@ -17477,26 +17497,6 @@
                 },
                 "target_instance_schema": {
                     "type": "string"
-                }
-            }
-        },
-        "v1.TaskRewrittenSQLData": {
-            "type": "object",
-            "properties": {
-                "business_non_equivalent_desc": {
-                    "description": "@Description 业务不等价性描述，为空表示等价",
-                    "type": "string"
-                },
-                "rewritten_sql": {
-                    "description": "@Description 重写后的SQL",
-                    "type": "string"
-                },
-                "suggestions": {
-                    "description": "@Description 重写建议列表",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/v1.SQLRewrittenSuggestion"
-                    }
                 }
             }
         },

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -3530,7 +3530,10 @@ definitions:
   v1.RewriteSQLData:
     properties:
       business_non_equivalent_desc:
-        description: '@Description 业务不等价性描述，为空表示等价'
+        description: '@Description 重写前后的业务不等价性描述，为空表示等价'
+        type: string
+      bussiness_desc:
+        description: '@Description 重写前的SQL业务描述'
         type: string
       rewritten_sql:
         description: '@Description 重写后的SQL'

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -2550,6 +2550,14 @@ definitions:
         example: ok
         type: string
     type: object
+  v1.GetTaskRewrittenSQLReq:
+    properties:
+      enable_structure_type:
+        default: false
+        description: '@Description 是否启用结构化类型的重写'
+        example: false
+        type: boolean
+    type: object
   v1.GetTaskRewrittenSQLRes:
     properties:
       code:
@@ -4263,10 +4271,6 @@ definitions:
         items:
           $ref: '#/definitions/v1.SQLRewrittenSuggestion'
         type: array
-      table_metas:
-        $ref: '#/definitions/v1.TableMetas'
-        description: '@Description 表结构'
-        type: object
     type: object
   v1.TestAuditPlanNotifyConfigResDataV1:
     properties:
@@ -12428,7 +12432,9 @@ paths:
       tags:
       - task
   /v1/tasks/audits/{task_id}/sqls/{number}/rewrite:
-    get:
+    post:
+      consumes:
+      - application/json
       description: 获取特定任务中某条SQL语句的重写后的SQL及相关建议
       operationId: getTaskRewrittenSQL
       parameters:
@@ -12442,6 +12448,14 @@ paths:
         name: number
         required: true
         type: integer
+      - description: request body
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/v1.GetTaskRewrittenSQLReq'
+      produces:
+      - application/json
       responses:
         "200":
           description: 成功返回重写结果

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -2550,26 +2550,6 @@ definitions:
         example: ok
         type: string
     type: object
-  v1.GetTaskRewrittenSQLReq:
-    properties:
-      enable_structure_type:
-        default: false
-        description: '@Description 是否启用结构化类型的重写'
-        example: false
-        type: boolean
-    type: object
-  v1.GetTaskRewrittenSQLRes:
-    properties:
-      code:
-        example: 0
-        type: integer
-      data:
-        $ref: '#/definitions/v1.TaskRewrittenSQLData'
-        type: object
-      message:
-        example: ok
-        type: string
-    type: object
   v1.GetUserTipsResV1:
     properties:
       code:
@@ -3547,6 +3527,81 @@ definitions:
       violated_queries_str:
         type: string
     type: object
+  v1.RewriteSQLData:
+    properties:
+      business_non_equivalent_desc:
+        description: '@Description 业务不等价性描述，为空表示等价'
+        type: string
+      rewritten_sql:
+        description: '@Description 重写后的SQL'
+        type: string
+      suggestions:
+        description: '@Description 重写建议列表'
+        items:
+          $ref: '#/definitions/v1.RewriteSuggestion'
+        type: array
+    type: object
+  v1.RewriteSQLReq:
+    properties:
+      enable_structure_type:
+        default: false
+        description: '@Description 是否启用结构化类型的重写'
+        example: false
+        type: boolean
+    type: object
+  v1.RewriteSQLRes:
+    properties:
+      code:
+        example: 0
+        type: integer
+      data:
+        $ref: '#/definitions/v1.RewriteSQLData'
+        type: object
+      message:
+        example: ok
+        type: string
+    type: object
+  v1.RewriteSuggestion:
+    properties:
+      audit_level:
+        description: |-
+          @Description 审核规则等级
+          @Required
+        enum:
+        - normal
+        - notice
+        - warn
+        - error
+        type: string
+      ddl_dcl:
+        description: '@Description 具体的数据库结构变更语句，需要在数据库中执行该变更语句之后再应用重写SQL（包含CREATE/ALTER/DROP等DDL语句，或SET等DCL语句）（适用于结构级重写）'
+        type: string
+      ddl_dcl_desc:
+        description: '@Description 数据库结构变更建议说明（例如：建议添加索引、修改表结构等优化建议）（适用于结构级重写）'
+        type: string
+      desc:
+        description: |-
+          @Description 重写描述（适用于所有类型）
+          @Required
+        type: string
+      rewritten_sql:
+        description: '@Description 重写后的SQL（适用于语句级重写和结构级重写）'
+        type: string
+      rule_name:
+        description: |-
+          @Description 审核规则名称
+          @Required
+        type: string
+      type:
+        description: |-
+          @Description 重写建议类型：语句级重写、结构级重写、其他
+          @Required
+        enum:
+        - statement
+        - structure
+        - other
+        type: string
+    type: object
   v1.RiskAuditPlan:
     properties:
       audit_plan_name:
@@ -3819,47 +3874,6 @@ definitions:
         type: integer
       query_timeout_second:
         type: integer
-    type: object
-  v1.SQLRewrittenSuggestion:
-    properties:
-      audit_level:
-        description: |-
-          @Description 审核规则等级
-          @Required
-        enum:
-        - normal
-        - notice
-        - warn
-        - error
-        type: string
-      ddl_dcl:
-        description: '@Description 具体的数据库结构变更语句，需要在数据库中执行该变更语句之后再应用重写SQL（包含CREATE/ALTER/DROP等DDL语句，或SET等DCL语句）（适用于结构级重写）'
-        type: string
-      ddl_dcl_desc:
-        description: '@Description 数据库结构变更建议说明（例如：建议添加索引、修改表结构等优化建议）（适用于结构级重写）'
-        type: string
-      desc:
-        description: |-
-          @Description 重写描述（适用于所有类型）
-          @Required
-        type: string
-      rewritten_sql:
-        description: '@Description 重写后的SQL（适用于语句级重写和结构级重写）'
-        type: string
-      rule_name:
-        description: |-
-          @Description 审核规则名称
-          @Required
-        type: string
-      type:
-        description: |-
-          @Description 重写建议类型：语句级重写、结构级重写、其他
-          @Required
-        enum:
-        - statement
-        - structure
-        - other
-        type: string
     type: object
   v1.SQLStatement:
     properties:
@@ -4257,20 +4271,6 @@ definitions:
         type: string
       target_instance_schema:
         type: string
-    type: object
-  v1.TaskRewrittenSQLData:
-    properties:
-      business_non_equivalent_desc:
-        description: '@Description 业务不等价性描述，为空表示等价'
-        type: string
-      rewritten_sql:
-        description: '@Description 重写后的SQL'
-        type: string
-      suggestions:
-        description: '@Description 重写建议列表'
-        items:
-          $ref: '#/definitions/v1.SQLRewrittenSuggestion'
-        type: array
     type: object
   v1.TestAuditPlanNotifyConfigResDataV1:
     properties:
@@ -12436,7 +12436,7 @@ paths:
       consumes:
       - application/json
       description: 获取特定任务中某条SQL语句的重写后的SQL及相关建议
-      operationId: getTaskRewrittenSQL
+      operationId: RewriteSQL
       parameters:
       - description: task id
         in: path
@@ -12453,14 +12453,14 @@ paths:
         name: req
         required: true
         schema:
-          $ref: '#/definitions/v1.GetTaskRewrittenSQLReq'
+          $ref: '#/definitions/v1.RewriteSQLReq'
       produces:
       - application/json
       responses:
         "200":
           description: 成功返回重写结果
           schema:
-            $ref: '#/definitions/v1.GetTaskRewrittenSQLRes'
+            $ref: '#/definitions/v1.RewriteSQLRes'
       security:
       - ApiKeyAuth: []
       summary: 获取任务中指定SQL的重写结果和建议

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -3529,11 +3529,11 @@ definitions:
     type: object
   v1.RewriteSQLData:
     properties:
+      business_desc:
+        description: '@Description 重写前的SQL业务描述'
+        type: string
       business_non_equivalent_desc:
         description: '@Description 重写前后的业务不等价性描述，为空表示等价'
-        type: string
-      bussiness_desc:
-        description: '@Description 重写前的SQL业务描述'
         type: string
       rewritten_sql:
         description: '@Description 重写后的SQL'


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2037

## 描述你的变更
设计原型发生变更，本次跟进调整：
1. 添加默认的重写配置，方便用户识别配置
2. API入参增加“是否开启数据库结构类型重写”的开关，默认为false
3. API返回增加“sql业务含义”
4. 接口从GET变为POST，考虑原因：api中涉及了模型调用，可能产生费用，且生成不幂等，换为POST接口

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [ ] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
