### PR TITLE
feat:rule supports matching multiple combined indexes

### DIFF
--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -2249,11 +2249,11 @@ ALTER TABLE exist_db.exist_tb_1 CHANGE COLUMN v2 v3 varchar(255) NOT NULL DEFAUL
 	)
 
 	runSingleRuleInspectCase(rule, t, "alter_table: column without comment(1)", DefaultMysqlInspect(),
-`
+		`
 ALTER TABLE exist_db.exist_tb_1 MODIFY COLUMN v3 varchar(500) NOT NULL DEFAULT "modified unit test";
 `,
-newTestResult().addResult(rulepkg.DDLCheckColumnWithoutComment),
-)
+		newTestResult().addResult(rulepkg.DDLCheckColumnWithoutComment),
+	)
 }
 
 func TestCheckIndexPrefix(t *testing.T) {
@@ -7225,7 +7225,7 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "select-with-equal",
 			Sql:         `select * from exist_tb_9 where v2 = 1`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		{
 			Name:        "select-with-equal",
@@ -7250,7 +7250,7 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "select-without-equal",
 			Sql:         `select * from exist_tb_9 where v2 in(1,2)`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		{
 			Name:        "select-without-equal",
@@ -7280,7 +7280,7 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "join-with-equal",
 			Sql:         `select * from exist_tb_9 t9 join exist_tb_8 t8 on t9.id = t8.id where t9.v1 = 1 and t8.v2 > 1`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		{
 			Name:        "join-with-equal",
@@ -7296,7 +7296,7 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "update-with-equal",
 			Sql:         `update exist_tb_9 set v4 = 1 where v2 = 1`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		{
 			Name:        "update-with-equal",
@@ -7326,7 +7326,7 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "update-without-equal",
 			Sql:         `update exist_tb_9 set v4 = 1 where v2 in(1,2)`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		{
 			Name:        "update-without-equal",
@@ -7347,7 +7347,7 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "delete-with-equal",
 			Sql:         `delete from exist_tb_9 where v2 = 1`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		{
 			Name:        "delete-with-equal",
@@ -7367,7 +7367,7 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "delete-without-equal",
 			Sql:         `delete from exist_tb_9 where v2 > 1`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		{
 			Name:        "delete-without-equal",
@@ -7408,12 +7408,12 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "select-union",
 			Sql:         `select * from exist_tb_9 where v1 = 1 and v2 = 1 union select * from exist_tb_8 where v2 = 1`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		{
 			Name:        "select-union",
 			Sql:         `select * from exist_tb_9 where v2 = 1 union select * from exist_tb_8 where v2 = 1`,
-			TriggerRule: true,
+			TriggerRule: false,
 		},
 		// select subquery
 		{
@@ -7439,6 +7439,21 @@ func TestMustUseLeftMostPrefix(t *testing.T) {
 		{
 			Name:        "select use single index",
 			Sql:         `select * from exist_tb_9 where v3 > 100`,
+			TriggerRule: false,
+		},
+		{
+			Name:        "multiple index",
+			Sql:         "select * from exist_db.exist_tb_11 where data_time2 = '12:00:00' and year_time = '2000'",
+			TriggerRule: false,
+		},
+		{
+			Name:        "incorrect use of composite index order",
+			Sql:         "select * from exist_db.exist_tb_11 where upgrade_time = '2020-01-01 00:00:00' and create_time = '2020-01-01 00:00:00'",
+			TriggerRule: true,
+		},
+		{
+			Name:        "correct use of composite index order",
+			Sql:         "select * from exist_db.exist_tb_11 where create_time = '2020-01-01 00:00:00' and upgrade_time = '2020-01-01 00:00:00'",
 			TriggerRule: false,
 		},
 	}

--- a/sqle/driver/mysql/session/mock_context.go
+++ b/sqle/driver/mysql/session/mock_context.go
@@ -408,7 +408,10 @@ upgrade_time timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_T
 year_time year(4) NOT NULL DEFAULT '2020',
 data_time date NOT NULL DEFAULT '2020-01-01 00:00:00',
 data_time2 TIME NOT NULL DEFAULT '12:00:00', 
-PRIMARY KEY (id) USING BTREE
+PRIMARY KEY (id) USING BTREE,
+KEY idx_1 (data_time,data_time2),
+KEY idx_2 (data_time2,year_time),
+KEY idx_3 (create_time,upgrade_time)
 )ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COMMENT="unit test";
 `
 	node, err := util.ParseOneSql(baseCreateQuery)


### PR DESCRIPTION
## 关联的 issue

https://github.com/actiontech/sqle/issues/2794

## 描述你的变更

1.  当数据表定义中存在多个联合索引时，若查询条件能够匹配任意一个联合索引的最左前缀，则视为通过规则审核。
2.  若查询条件中的字段能够命中数据表上任一联合索引的最左前缀，则满足规则要求。
3.  若查询条件中涉及的字段未包含在任何联合索引中，则不触发该规则。

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
