### PR TITLE
cherry-pick rule fix to release 3.2408.x

### DIFF
--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -6480,7 +6480,7 @@ func TestDMLCheckScanRows(t *testing.T) {
 	inspect3 := NewMockInspect(e)
 	handler.ExpectQuery(regexp.QuoteMeta("select * from exist_tb_2 where v1 = 'a'")).
 		WillReturnRows(sqlmock.NewRows([]string{"rows", "type"}).AddRow("100000000000", "const"))
-	runSingleRuleInspectCase(rule, t, "", inspect3, "select * from exist_tb_2 where v1 = 'a'", newTestResult())
+	runSingleRuleInspectCase(rule, t, "", inspect3, "select * from exist_tb_2 where v1 = 'a'", newTestResult().addResult(rulepkg.DMLCheckScanRows))
 
 	inspect4 := NewMockInspect(e)
 	handler.ExpectQuery(regexp.QuoteMeta("select * from exist_tb_2 where v1 in (select v2 from exist_tb_1)")).
@@ -6505,7 +6505,7 @@ func TestDMLCheckScanRows(t *testing.T) {
 	inspect8 := NewMockInspect(e)
 	handler.ExpectQuery(regexp.QuoteMeta("update exist_tb_2 set v1=1 where v2=1")).
 		WillReturnRows(sqlmock.NewRows([]string{"rows", "type"}).AddRow("100000000", "range"))
-	runSingleRuleInspectCase(rule, t, "", inspect8, "update exist_tb_2 set v1=1 where v2=1", newTestResult())
+	runSingleRuleInspectCase(rule, t, "", inspect8, "update exist_tb_2 set v1=1 where v2=1", newTestResult().addResult(rulepkg.DMLCheckScanRows))
 
 	inspect9 := NewMockInspect(e)
 	handler.ExpectQuery(regexp.QuoteMeta("update exist_tb_2 set v1=1 where v2=1")).
@@ -6520,7 +6520,7 @@ func TestDMLCheckScanRows(t *testing.T) {
 	inspect11 := NewMockInspect(e)
 	handler.ExpectQuery(regexp.QuoteMeta("delete from exist_tb_2 where v1=1")).
 		WillReturnRows(sqlmock.NewRows([]string{"rows", "type"}).AddRow("100000000", "range"))
-	runSingleRuleInspectCase(rule, t, "", inspect11, "delete from exist_tb_2 where v1=1", newTestResult())
+	runSingleRuleInspectCase(rule, t, "", inspect11, "delete from exist_tb_2 where v1=1", newTestResult().addResult(rulepkg.DMLCheckScanRows))
 }
 
 // TODO

--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5198,10 +5198,8 @@ func checkScanRows(input *RuleHandlerInput) error {
 	}
 	for _, record := range epRecords {
 		if record.Rows > int64(max)*int64(TenThousand) {
-			if record.Type == executor.ExplainRecordAccessTypeIndex || record.Type == executor.ExplainRecordAccessTypeAll {
 				addResult(input.Res, input.Rule, input.Rule.Name)
 				break
-			}
 		}
 	}
 	return nil

--- a/sqle/driver/mysql/rule/rule_list.go
+++ b/sqle/driver/mysql/rule/rule_list.go
@@ -1981,7 +1981,7 @@ var RuleHandlers = []RuleHandler{
 	{
 		Rule: driverV2.Rule{
 			Name:       DMLCheckScanRows,
-			Desc:       "扫描行数超过阈值，筛选条件必须带上主键或者索引",
+			Desc:       "扫描行数超过阈值，请检查索引配置",
 			Annotation: "筛选条件必须带上主键或索引可降低数据库查询的时间复杂度，提高查询效率。",
 			Level:      driverV2.RuleLevelError,
 			Category:   RuleTypeDMLConvention,
@@ -1995,7 +1995,7 @@ var RuleHandlers = []RuleHandler{
 			},
 		},
 		AllowOffline: false,
-		Message:      "扫描行数超过阈值，筛选条件必须带上主键或者索引",
+		Message:      "扫描行数超过阈值，请检查索引配置",
 		Func:         checkScanRows,
 	},
 	{

--- a/sqle/driver/mysql/rule/rule_list_trial.go
+++ b/sqle/driver/mysql/rule/rule_list_trial.go
@@ -177,7 +177,7 @@ var RuleHandlers = []RuleHandler{
 	{
 		Rule: driverV2.Rule{
 			Name:       DMLCheckScanRows,
-			Desc:       "扫描行数超过阈值，筛选条件必须带上主键或者索引",
+			Desc:       "扫描行数超过阈值，请检查索引配置",
 			Annotation: "筛选条件必须带上主键或索引可降低数据库查询的时间复杂度，提高查询效率。",
 			Level:      driverV2.RuleLevelError,
 			Category:   RuleTypeDMLConvention,
@@ -191,7 +191,7 @@ var RuleHandlers = []RuleHandler{
 			},
 		},
 		AllowOffline: false,
-		Message:      "扫描行数超过阈值，筛选条件必须带上主键或者索引",
+		Message:      "扫描行数超过阈值，请检查索引配置",
 		Func:         checkScanRows,
 	},
 	{


### PR DESCRIPTION
https://github.com/actiontech/sqle/issues/2857
将DMLCheckScanRows的规则变更应用到3.2408.x
目的是为了给zjrc的tdsql插件增加一个基于3.2408.x-ee的分支