### PR TITLE
fix: panic when use nil tp of sql in rule DDLRecommendTableColumnCharsetSame

### DIFF
--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -5414,6 +5414,9 @@ func TestDDLRecommendTableColumnCharsetSame(t *testing.T) {
 	runSingleRuleInspectCase(
 		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, "CREATE TABLE `t4` ( `col` char(10) COLLATE gbk_chinese_ci DEFAULT NULL) CHARACTER SET gbk COLLATE gbk_chinese_ci", newTestResult())
 
+	// 修改列, 未声明字符集
+	runSingleRuleInspectCase(
+		rulepkg.RuleHandlerMap[rulepkg.DDLRecommendTableColumnCharsetSame].Rule, t, "success", inspect1, `ALTER TABLE exist_tb_1 ALTER v1 SET DEFAULT NULL;`, newTestResult())
 	// 触发规则
 	// 创建表未声明字符集和排序 列字符集与默认字符集不一致
 	runSingleRuleInspectCase(


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2855
## 描述你的变更
test 
![image](https://github.com/user-attachments/assets/b292c405-378d-4df7-8e72-4578ab752bba)
1. 修复当ALTER语句中修改列解析后列的字符集类型对象为nil时panic的问题
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [X] 我已完成自测
- [X] 我已记录完整日志方便进行诊断
- [X] 我已在关联的issue里补充了实现方案
- [X] 我已在关联的issue里补充了测试影响面
- [X] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [X] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
