### PR TITLE
fix: api: sql_analysis add cost property

### DIFF
--- a/sqle/api/controller/v1/analysis.go
+++ b/sqle/api/controller/v1/analysis.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"github.com/actiontech/sqle/sqle/common"
 	"github.com/actiontech/sqle/sqle/driver"
@@ -11,6 +12,7 @@ import (
 )
 
 type AnalysisResult struct {
+	Cost             *string
 	ExplainResult    *driverV2.ExplainResult
 	ExplainResultErr error
 
@@ -35,11 +37,33 @@ func GetSQLAnalysisResult(l *logrus.Entry, instance *model.Instance, schema, sql
 	defer plugin.Close(context.TODO())
 
 	res = &AnalysisResult{}
+
+	res.Cost, err = GetQueryCost(plugin, sql)
 	res.ExplainResult, res.ExplainResultErr = Explain(instance.DbType, plugin, sql)
 	res.TableMetaResult, res.TableMetaResultErr = GetTableMetas(instance.DbType, plugin, sql)
 	res.AffectRowsResult, res.AffectRowsResultErr = GetRowsAffected(instance.DbType, plugin, sql)
 
 	return res, nil
+}
+
+func GetQueryCost(plugin driver.Plugin, sql string) (cost *string, err error) {
+	explainJSONResult, err := plugin.ExplainJSONFormat(context.TODO(), &driverV2.ExplainConf{Sql: sql})
+	if err != nil {
+		return nil, err
+	}
+	sqlNodes, err := plugin.Parse(context.TODO(), sql)
+	if err != nil {
+		return nil, err
+	}
+	if len(sqlNodes) == 0 {
+		return nil, errors.Errorf("failed to get query cost invalid sql: %v", sql)
+	}
+	// 不是SELECT语句直接忽略
+	if sqlNodes[0].Type != driverV2.SQLTypeDQL {
+		return nil, errors.Errorf("failed to get query cost because it is not DQL: %v", sql)
+	}
+	cost = &explainJSONResult.QueryBlock.CostInfo.QueryCost
+	return cost, nil
 }
 
 func Explain(dbType string, plugin driver.Plugin, sql string) (res *driverV2.ExplainResult, err error) {

--- a/sqle/api/controller/v1/sql_manage.go
+++ b/sqle/api/controller/v1/sql_manage.go
@@ -352,6 +352,7 @@ func convertSQLAnalysisResultToRes(ctx context.Context, res *AnalysisResult, raw
 	// explain
 	{
 		data.SQLExplain = &SQLExplain{SQL: rawSQL}
+		data.SQLExplain.Cost = *res.Cost
 		if res.ExplainResultErr != nil {
 			data.SQLExplain.Message = res.ExplainResultErr.Error()
 		} else {

--- a/sqle/api/controller/v1/sql_manage.go
+++ b/sqle/api/controller/v1/sql_manage.go
@@ -305,9 +305,10 @@ func GetSqlManageSqlAnalysisV1(c echo.Context) error {
 }
 
 type SqlManageAnalysisChartReq struct {
-	StartTime  *string `query:"start_time" json:"start_time"`
-	EndTime    *string `query:"end_time" json:"end_time"`
-	MetricName *string `query:"metric_name" json:"metric_name"`
+	LatestPointEnabled bool    `query:"latest_point_enabled" json:"latest_point_enabled"`
+	StartTime          *string `query:"start_time" json:"start_time"`
+	EndTime            *string `query:"end_time" json:"end_time"`
+	MetricName         *string `query:"metric_name" json:"metric_name"`
 }
 
 type SqlManageAnalysisChartResp struct {
@@ -322,6 +323,7 @@ type SqlManageAnalysisChartResp struct {
 // @Tags SqlManage
 // @Param project_name path string true "project name"
 // @Param sql_manage_id path string true "sql manage id"
+// @Param latest_point_enabled query bool true "latest_point_enabled"
 // @Param start_time query string true "start time"
 // @Param end_time query string true "end time"
 // @Param metric_name query string true "metric_name"

--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -795,6 +795,7 @@ func CheckCurrentUserCanOpTask(c echo.Context, task *model.Task) (err error) {
 
 type SQLExplain struct {
 	SQL     string `json:"sql"`
+	Cost    string `json:"cost"`
 	Message string `json:"message"`
 	// explain result in table format
 	ClassicResult ExplainClassicResult `json:"classic_result"`

--- a/sqle/api/controller/v1/task.go
+++ b/sqle/api/controller/v1/task.go
@@ -794,9 +794,9 @@ func CheckCurrentUserCanOpTask(c echo.Context, task *model.Task) (err error) {
 }
 
 type SQLExplain struct {
-	SQL     string `json:"sql"`
-	Cost    string `json:"cost"`
-	Message string `json:"message"`
+	SQL     string  `json:"sql"`
+	Cost    float64 `json:"cost"`
+	Message string  `json:"message"`
 	// explain result in table format
 	ClassicResult ExplainClassicResult `json:"classic_result"`
 }

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -17312,6 +17312,9 @@ var doc = `{
                     "type": "object",
                     "$ref": "#/definitions/v1.ExplainClassicResult"
                 },
+                "cost": {
+                    "type": "string"
+                },
                 "message": {
                     "type": "string"
                 },

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -5554,6 +5554,13 @@ var doc = `{
                         "required": true
                     },
                     {
+                        "type": "boolean",
+                        "description": "latest_point_enabled",
+                        "name": "latest_point_enabled",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
                         "type": "string",
                         "description": "start time",
                         "name": "start_time",
@@ -17313,7 +17320,7 @@ var doc = `{
                     "$ref": "#/definitions/v1.ExplainClassicResult"
                 },
                 "cost": {
-                    "type": "string"
+                    "type": "number"
                 },
                 "message": {
                     "type": "string"

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -5538,6 +5538,13 @@
                         "required": true
                     },
                     {
+                        "type": "boolean",
+                        "description": "latest_point_enabled",
+                        "name": "latest_point_enabled",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
                         "type": "string",
                         "description": "start time",
                         "name": "start_time",
@@ -17297,7 +17304,7 @@
                     "$ref": "#/definitions/v1.ExplainClassicResult"
                 },
                 "cost": {
-                    "type": "string"
+                    "type": "number"
                 },
                 "message": {
                     "type": "string"

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -17296,6 +17296,9 @@
                     "type": "object",
                     "$ref": "#/definitions/v1.ExplainClassicResult"
                 },
+                "cost": {
+                    "type": "string"
+                },
                 "message": {
                     "type": "string"
                 },

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -4012,7 +4012,7 @@ definitions:
         description: explain result in table format
         type: object
       cost:
-        type: string
+        type: number
       message:
         type: string
       sql:
@@ -9760,6 +9760,11 @@ paths:
         name: sql_manage_id
         required: true
         type: string
+      - description: latest_point_enabled
+        in: query
+        name: latest_point_enabled
+        required: true
+        type: boolean
       - description: start time
         in: query
         name: start_time

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -4011,6 +4011,8 @@ definitions:
         $ref: '#/definitions/v1.ExplainClassicResult'
         description: explain result in table format
         type: object
+      cost:
+        type: string
       message:
         type: string
       sql:


### PR DESCRIPTION
## 关联的 issue
- https://github.com/actiontech/sqle-ee/issues/2164
## 描述你的变更
- sql_analysis接口增加cost字段
- 当前端选中24小时tab需要将当前执行计划展示到趋势图
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
