### PR TITLE
optimize SQLs in SQLE and add TODO 

### DIFF
--- a/sqle/model/instance_audit_plan.go
+++ b/sqle/model/instance_audit_plan.go
@@ -186,8 +186,8 @@ func (s *Storage) GetLatestStartTimeAuditPlanSQLV2(sourceId uint) (string, error
 type SQLManageRecord struct {
 	Model
 
-	Source         string         `json:"source" gorm:"type:varchar(255)"`
-	SourceId       string         `json:"source_id" gorm:"type:varchar(255)"`
+	Source         string         `json:"source" gorm:"type:varchar(255);index:idx_source_id_source"`
+	SourceId       string         `json:"source_id" gorm:"type:varchar(255);index:idx_source_id_source"`
 	ProjectId      string         `json:"project_id" gorm:"type:varchar(255)"`
 	InstanceID     string         `json:"instance_id" gorm:"type:varchar(255)"`
 	SchemaName     string         `json:"schema_name" gorm:"type:varchar(255)"`

--- a/sqle/model/instance_audit_plan_list.go
+++ b/sqle/model/instance_audit_plan_list.go
@@ -206,7 +206,7 @@ var instanceAuditPlanSQLBodyTpl = `
 {{ define "body" }}
 
 FROM sql_manage_records AS audit_plan_sqls
-JOIN audit_plans_v2 ON audit_plans_v2.instance_audit_plan_id = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
+JOIN audit_plans_v2 ON CONCAT(audit_plans_v2.instance_audit_plan_id, '') = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
 JOIN instance_audit_plans ON instance_audit_plans.id = audit_plans_v2.instance_audit_plan_id
 
 WHERE audit_plan_sqls.deleted_at IS NULL

--- a/sqle/model/instance_audit_plan_list_test.go
+++ b/sqle/model/instance_audit_plan_list_test.go
@@ -37,7 +37,7 @@ IF(audit_plan_sqls.audit_results IS NULL,'being_audited','') AS audit_status,
 audit_plan_sqls.priority
 
 FROM sql_manage_records AS audit_plan_sqls
-JOIN audit_plans_v2 ON audit_plans_v2.instance_audit_plan_id = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
+JOIN audit_plans_v2 ON CONCAT(audit_plans_v2.instance_audit_plan_id, '') = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
 JOIN instance_audit_plans ON instance_audit_plans.id = audit_plans_v2.instance_audit_plan_id
 
 WHERE audit_plan_sqls.deleted_at IS NULL
@@ -65,7 +65,7 @@ IF(audit_plan_sqls.audit_results IS NULL,'being_audited','') AS audit_status,
 audit_plan_sqls.priority
 
 FROM sql_manage_records AS audit_plan_sqls
-JOIN audit_plans_v2 ON audit_plans_v2.instance_audit_plan_id = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
+JOIN audit_plans_v2 ON CONCAT(audit_plans_v2.instance_audit_plan_id, '') = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
 JOIN instance_audit_plans ON instance_audit_plans.id = audit_plans_v2.instance_audit_plan_id
 
 WHERE audit_plan_sqls.deleted_at IS NULL
@@ -94,7 +94,7 @@ IF(audit_plan_sqls.audit_results IS NULL,'being_audited','') AS audit_status,
 audit_plan_sqls.priority
 
 FROM sql_manage_records AS audit_plan_sqls
-JOIN audit_plans_v2 ON audit_plans_v2.instance_audit_plan_id = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
+JOIN audit_plans_v2 ON CONCAT(audit_plans_v2.instance_audit_plan_id, '') = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
 JOIN instance_audit_plans ON instance_audit_plans.id = audit_plans_v2.instance_audit_plan_id
 
 WHERE audit_plan_sqls.deleted_at IS NULL
@@ -123,7 +123,7 @@ IF(audit_plan_sqls.audit_results IS NULL,'being_audited','') AS audit_status,
 audit_plan_sqls.priority
 
 FROM sql_manage_records AS audit_plan_sqls
-JOIN audit_plans_v2 ON audit_plans_v2.instance_audit_plan_id = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
+JOIN audit_plans_v2 ON CONCAT(audit_plans_v2.instance_audit_plan_id, '') = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
 JOIN instance_audit_plans ON instance_audit_plans.id = audit_plans_v2.instance_audit_plan_id
 
 WHERE audit_plan_sqls.deleted_at IS NULL
@@ -153,7 +153,7 @@ IF(audit_plan_sqls.audit_results IS NULL,'being_audited','') AS audit_status,
 audit_plan_sqls.priority
 
 FROM sql_manage_records AS audit_plan_sqls
-JOIN audit_plans_v2 ON audit_plans_v2.instance_audit_plan_id = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
+JOIN audit_plans_v2 ON CONCAT(audit_plans_v2.instance_audit_plan_id, '') = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
 JOIN instance_audit_plans ON instance_audit_plans.id = audit_plans_v2.instance_audit_plan_id
 
 WHERE audit_plan_sqls.deleted_at IS NULL
@@ -182,7 +182,7 @@ IF(audit_plan_sqls.audit_results IS NULL,'being_audited','') AS audit_status,
 audit_plan_sqls.priority
 
 FROM sql_manage_records AS audit_plan_sqls
-JOIN audit_plans_v2 ON audit_plans_v2.instance_audit_plan_id = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
+JOIN audit_plans_v2 ON CONCAT(audit_plans_v2.instance_audit_plan_id, '') = audit_plan_sqls.source_id AND audit_plans_v2.type = audit_plan_sqls.source
 JOIN instance_audit_plans ON instance_audit_plans.id = audit_plans_v2.instance_audit_plan_id
 
 WHERE audit_plan_sqls.deleted_at IS NULL

--- a/sqle/model/utils.go
+++ b/sqle/model/utils.go
@@ -87,7 +87,7 @@ type Model struct {
 	ID        uint           `json:"id" gorm:"primary_key" example:"1"`
 	CreatedAt time.Time      `json:"created_at" gorm:"default:current_timestamp(3)" example:"2018-10-21T16:40:23+08:00"`
 	UpdatedAt time.Time      `json:"updated_at" gorm:"default:current_timestamp(3) on update current_timestamp(3)" example:"2018-10-21T16:40:23+08:00"`
-	DeletedAt gorm.DeletedAt `json:"-" sql:"index"`
+	DeletedAt gorm.DeletedAt `json:"-" sql:"index" gorm:"index"`
 }
 
 func (m Model) GetIDStr() string {


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2145#issuecomment-2606576888
## 描述你的变更
1. Model增加deleted_at的索引，保证在使用deleted_at作为筛选字段的时候能够有效利用索引 https://github.com/actiontech/sqle-ee/issues/2145#issuecomment-2603993413
2. sql_manage_records表中增加复合索引idx_source_id_source。因为有很多的SQL根据这两个字段筛选记录。增加该索引后，有很多SQL都能使用上该索引。
3. 优化GetManagerSQLListByAuditPlanId函数：影响扫描任务触发sql审核功能 https://github.com/actiontech/sqle-ee/issues/2145#issuecomment-2603808056
4. 优化GetManagerSqlSchemaNameByAuditPlan函数：影响部分可以通过schema筛选记录的智能扫描，如mysql slow log(目前仅有它 https://github.com/actiontech/sqle-ee/issues/2145#issuecomment-2604181713
5. 优化GetManagerSqlMetricTipsByAuditPlan函数：影响部分可以通过指定Metric如dbuser筛选记录的智能扫描，如mysql slow log(目前仅有它 https://github.com/actiontech/sqle-ee/issues/2145#issuecomment-2604325480
6. 优化GetAuditPlanTotalSQL 函数：影响接口获取实例扫描任务概览 https://github.com/actiontech/sqle-ee/issues/2145#issuecomment-2603808444
7. 优化instanceAuditPlanSQLBodyTpl SQL模板：影响接口获取指定扫描任务的SQL列表（所有扫描任务）和 导出指定扫描任务的 SQL CSV 列表 https://github.com/actiontech/sqle-ee/issues/2145#issuecomment-2604143283
8. 优化GetAuditPlanUnsolvedSQLCount ：影响接口获取实例扫描任务概览 https://github.com/actiontech/sqle-ee/issues/2145#issuecomment-2606576888
9. 增加了一些TODO，其中包含高优先级待优化的SQL，但由于SQL难以优化，改动成本高，所以先记录
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [X] 我已完成自测
- [X] 我已记录完整日志方便进行诊断
- [X] 我已在关联的issue里补充了实现方案
- [X] 我已在关联的issue里补充了测试影响面
- [X] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [X] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
