### PR TITLE
fix: the error when getting the number of affected rows in a sql …

### DIFF
--- a/sqle/driver/mysql/audit_test.go
+++ b/sqle/driver/mysql/audit_test.go
@@ -6575,68 +6575,68 @@ func TestDMLCheckSelectRows(t *testing.T) {
 	runSingleRuleInspectCase(rule, t, "", inspect6, "select * from exist_tb_2 where user_id in (select v3 from exist_tb_3)", newTestResult().addResult(rulepkg.DMLCheckSelectRows))
 
 	inspect7 := NewMockInspect(e)
-	handler.ExpectQuery(regexp.QuoteMeta("select id, v1 as id from exist_tb_2 limit 10, 10")).
+	handler.ExpectQuery(regexp.QuoteMeta("select id, v1 from exist_tb_2 limit 10, 10")).
 		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow(executor.ExplainRecordAccessTypeIndex).AddRow("range"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
 	// 添加 EXPLAIN 结果
-	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (SELECT 1 FROM `exist_tb_2` LIMIT 10,10) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta(`EXPLAIN select count(*) from (select id, v1 from exist_tb_2 limit 10, 10) as t`)).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "select_type", "table", "partitions", "type", "possible_keys", "key", "key_len", "ref", "rows", "filtered", "Extra"}).
 			AddRow(1, "SIMPLE", "exist_tb_2", nil, "index", "idx_v1", "idx_v1", 5, nil, 1000, 100.00, "Using where").
 			AddRow(2, "SIMPLE", "exist_tb_2", nil, "range", nil, nil, nil, nil, 1000, 100.00, "Using where"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
-	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (SELECT 1 FROM `exist_tb_2` LIMIT 10,10) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (select id, v1 from exist_tb_2 limit 10, 10) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow("100000000"))
-	runSingleRuleInspectCase(rule, t, "", inspect7, "select id, v1 as id from exist_tb_2 limit 10, 10", newTestResult().addResult(rulepkg.DMLCheckSelectRows))
+	runSingleRuleInspectCase(rule, t, "", inspect7, "select id, v1 from exist_tb_2 limit 10, 10", newTestResult().addResult(rulepkg.DMLCheckSelectRows))
 
 	inspect8 := NewMockInspect(e)
-	handler.ExpectQuery(regexp.QuoteMeta("select id, v1 as id from exist_tb_2 group by id, v1")).
+	handler.ExpectQuery(regexp.QuoteMeta("select id, v1 from exist_tb_2 group by id, v1")).
 		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow(executor.ExplainRecordAccessTypeIndex).AddRow("range"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
 	// 添加 EXPLAIN 结果
-	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`,`v1`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (select id, v1 from exist_tb_2 group by id, v1) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "select_type", "table", "partitions", "type", "possible_keys", "key", "key_len", "ref", "rows", "filtered", "Extra"}).
 			AddRow(1, "SIMPLE", "exist_tb_2", nil, "index", "idx_v1", "idx_v1", 5, nil, 1000, 100.00, "Using where").
 			AddRow(2, "SIMPLE", "exist_tb_2", nil, "range", nil, nil, nil, nil, 1000, 100.00, "Using where"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
-	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`,`v1`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (select id, v1 from exist_tb_2 group by id, v1) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow("100000000"))
-	runSingleRuleInspectCase(rule, t, "", inspect8, "select id, v1 as id from exist_tb_2 group by id, v1", newTestResult().addResult(rulepkg.DMLCheckSelectRows))
+	runSingleRuleInspectCase(rule, t, "", inspect8, "select id, v1 from exist_tb_2 group by id, v1", newTestResult().addResult(rulepkg.DMLCheckSelectRows))
 
 	inspect9 := NewMockInspect(e)
-	handler.ExpectQuery(regexp.QuoteMeta("select id, v1 as id from exist_tb_2 limit 10, 10")).
+	handler.ExpectQuery(regexp.QuoteMeta("select id, v1 from exist_tb_2 limit 10, 10")).
 		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow(executor.ExplainRecordAccessTypeIndex).AddRow("range"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
 	// 添加 EXPLAIN 结果
-	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (SELECT 1 FROM `exist_tb_2` LIMIT 10,10) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (select id, v1 from exist_tb_2 limit 10, 10) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "select_type", "table", "partitions", "type", "possible_keys", "key", "key_len", "ref", "rows", "filtered", "Extra"}).
 			AddRow(1, "SIMPLE", "exist_tb_2", nil, "index", "idx_v1", "idx_v1", 5, nil, 1000, 100.00, "Using where").
 			AddRow(2, "SIMPLE", "exist_tb_2", nil, "range", nil, nil, nil, nil, 1000, 100.00, "Using where"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
-	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (SELECT 1 FROM `exist_tb_2` LIMIT 10,10) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (select id, v1 from exist_tb_2 limit 10, 10) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow("10"))
-	runSingleRuleInspectCase(rule, t, "", inspect9, "select id, v1 as id from exist_tb_2 limit 10, 10", newTestResult())
+	runSingleRuleInspectCase(rule, t, "", inspect9, "select id, v1 from exist_tb_2 limit 10, 10", newTestResult())
 
 	inspect10 := NewMockInspect(e)
-	handler.ExpectQuery(regexp.QuoteMeta("select id, v1 as id from exist_tb_2 group by id, v1")).
+	handler.ExpectQuery(regexp.QuoteMeta("select id, v1 from exist_tb_2 group by id, v1")).
 		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow(executor.ExplainRecordAccessTypeIndex).AddRow("range"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
 	// 添加 EXPLAIN 结果
-	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`,`v1`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (select id, v1 from exist_tb_2 group by id, v1) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "select_type", "table", "partitions", "type", "possible_keys", "key", "key_len", "ref", "rows", "filtered", "Extra"}).
 			AddRow(1, "SIMPLE", "exist_tb_2", nil, "index", "idx_v1", "idx_v1", 5, nil, 1000, 100.00, "Using where").
 			AddRow(2, "SIMPLE", "exist_tb_2", nil, "range", nil, nil, nil, nil, 1000, 100.00, "Using where"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
-	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`,`v1`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (select id, v1 from exist_tb_2 group by id, v1) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow("10"))
-	runSingleRuleInspectCase(rule, t, "", inspect10, "select id, v1 as id from exist_tb_2 group by id, v1", newTestResult())
+	runSingleRuleInspectCase(rule, t, "", inspect10, "select id, v1 from exist_tb_2 group by id, v1", newTestResult())
 
 	inspect11 := NewMockInspect(e)
 	handler.ExpectQuery(regexp.QuoteMeta("select max(v1) from exist_tb_2 group by id")).
@@ -6644,13 +6644,13 @@ func TestDMLCheckSelectRows(t *testing.T) {
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
 	// 添加 EXPLAIN 结果
-	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (select max(v1) from exist_tb_2 group by id) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "select_type", "table", "partitions", "type", "possible_keys", "key", "key_len", "ref", "rows", "filtered", "Extra"}).
 			AddRow(1, "SIMPLE", "exist_tb_2", nil, "index", "idx_id", "idx_id", 5, nil, 1000, 100.00, "Using where").
 			AddRow(2, "SIMPLE", "exist_tb_2", nil, "range", nil, nil, nil, nil, 1000, 100.00, "Using where"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
-	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (select max(v1) from exist_tb_2 group by id) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow("10"))
 	runSingleRuleInspectCase(rule, t, "", inspect11, "select max(v1) from exist_tb_2 group by id", newTestResult())
 
@@ -6660,47 +6660,47 @@ func TestDMLCheckSelectRows(t *testing.T) {
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
 	// 添加 EXPLAIN 结果
-	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (select max(v1) from exist_tb_2 group by id) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "select_type", "table", "partitions", "type", "possible_keys", "key", "key_len", "ref", "rows", "filtered", "Extra"}).
 			AddRow(1, "SIMPLE", "exist_tb_2", nil, "index", "idx_id", "idx_id", 5, nil, 1000, 100.00, "Using where").
 			AddRow(2, "SIMPLE", "exist_tb_2", nil, "range", nil, nil, nil, nil, 1000, 100.00, "Using where"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
-	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (select max(v1) from exist_tb_2 group by id) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow("10000000"))
 	runSingleRuleInspectCase(rule, t, "", inspect12, "select max(v1) from exist_tb_2 group by id", newTestResult().addResult(rulepkg.DMLCheckSelectRows))
 
 	inspect13 := NewMockInspect(e)
-	handler.ExpectQuery(regexp.QuoteMeta("select max(v1) as id, id from exist_tb_2 group by id")).
+	handler.ExpectQuery(regexp.QuoteMeta("select max(v1) as id from exist_tb_2 group by id")).
 		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow(executor.ExplainRecordAccessTypeIndex).AddRow("range"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
 	// 添加 EXPLAIN 结果
-	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (select max(v1) as id from exist_tb_2 group by id) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "select_type", "table", "partitions", "type", "possible_keys", "key", "key_len", "ref", "rows", "filtered", "Extra"}).
 			AddRow(1, "SIMPLE", "exist_tb_2", nil, "index", "idx_id", "idx_id", 5, nil, 1000, 100.00, "Using where").
 			AddRow(2, "SIMPLE", "exist_tb_2", nil, "range", nil, nil, nil, nil, 1000, 100.00, "Using where"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
-	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (select max(v1) as id from exist_tb_2 group by id) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow("10"))
-	runSingleRuleInspectCase(rule, t, "", inspect13, "select max(v1) as id, id from exist_tb_2 group by id", newTestResult())
+	runSingleRuleInspectCase(rule, t, "", inspect13, "select max(v1) as id from exist_tb_2 group by id", newTestResult())
 
 	inspect14 := NewMockInspect(e)
-	handler.ExpectQuery(regexp.QuoteMeta("select max(v1) as id, id from exist_tb_2 group by id")).
+	handler.ExpectQuery(regexp.QuoteMeta("select max(v1) as id from exist_tb_2 group by id")).
 		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow(executor.ExplainRecordAccessTypeIndex).AddRow("range"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
 	// 添加 EXPLAIN 结果
-	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("EXPLAIN select count(*) from (select max(v1) as id from exist_tb_2 group by id) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "select_type", "table", "partitions", "type", "possible_keys", "key", "key_len", "ref", "rows", "filtered", "Extra"}).
 			AddRow(1, "SIMPLE", "exist_tb_2", nil, "index", "idx_id", "idx_id", 5, nil, 1000, 100.00, "Using where").
 			AddRow(2, "SIMPLE", "exist_tb_2", nil, "range", nil, nil, nil, nil, 1000, 100.00, "Using where"))
 	handler.ExpectQuery(regexp.QuoteMeta(showWarnings)).
 		WillReturnRows(sqlmock.NewRows([]string{"Level", "Code", "Message"}))
-	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (SELECT 1 FROM `exist_tb_2` GROUP BY `id`) as t")).
+	handler.ExpectQuery(regexp.QuoteMeta("select count(*) from (select max(v1) as id from exist_tb_2 group by id) as t")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow("10000000"))
-	runSingleRuleInspectCase(rule, t, "", inspect14, "select max(v1) as id, id from exist_tb_2 group by id", newTestResult().addResult(rulepkg.DMLCheckSelectRows))
+	runSingleRuleInspectCase(rule, t, "", inspect14, "select max(v1) as id from exist_tb_2 group by id", newTestResult().addResult(rulepkg.DMLCheckSelectRows))
 
 }
 


### PR DESCRIPTION
…statement containing group by

## 关联的 issue
https://github.com/actiontech/sqle/issues/2867
## 描述你的变更
修复获取带有group by或group by having的sql的受影响行数时，出现报错问题
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
