### PR TITLE
fix: remove hardcoded project id in permission middleware

### DIFF
--- a/sqle/api/middleware/permission.go
+++ b/sqle/api/middleware/permission.go
@@ -10,26 +10,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// AdminUserAllowed is a `echo` middleware, only allow admin user to access next.
-func AdminUserAllowed() echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			uid, err := dmsJWT.GetUserUidStrFromContextWithOldJwt(c)
-			if err != nil {
-				return echo.NewHTTPError(http.StatusForbidden)
-			}
-			up, err := dms.NewUserPermission(uid, "700300" /*TODO 支持不传空间 */)
-			if err != nil {
-				return echo.NewHTTPError(http.StatusForbidden)
-			}
-			if up.IsAdmin() {
-				return next(c)
-			}
-			return echo.NewHTTPError(http.StatusForbidden)
-		}
-	}
-}
-
 func OpGlobalAllowed() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -37,15 +17,13 @@ func OpGlobalAllowed() echo.MiddlewareFunc {
 			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}
-			up, err := dms.NewUserPermission(uid, "700300" /*TODO 支持不传空间 */)
+			up, err := dms.NewUserPermission(uid, "")
 			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}
-
 			if up.CanOpGlobal() {
 				return next(c)
 			}
-
 			return echo.NewHTTPError(http.StatusForbidden)
 		}
 	}
@@ -58,7 +36,13 @@ func OpProjectAllowed() echo.MiddlewareFunc {
 			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}
-			up, err := dms.NewUserPermission(uid, "700300" /*TODO 支持不传空间 */)
+
+			projectUid, err := dms.GetPorjectUIDByName(context.TODO(), c.Param("project_name"))
+			if err != nil {
+				return controller.JSONBaseErrorReq(c, err)
+			}
+
+			up, err := dms.NewUserPermission(uid, projectUid)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}
@@ -79,15 +63,13 @@ func ViewGlobalAllowed() echo.MiddlewareFunc {
 			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}
-			up, err := dms.NewUserPermission(uid, "700300" /*TODO 支持不传空间 */)
+			up, err := dms.NewUserPermission(uid, "")
 			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}
-
 			if up.CanViewGlobal() {
 				return next(c)
 			}
-
 			return echo.NewHTTPError(http.StatusForbidden)
 		}
 	}
@@ -100,7 +82,12 @@ func ViewProjectAllowed() echo.MiddlewareFunc {
 			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}
-			up, err := dms.NewUserPermission(uid, "700300" /*TODO 支持不传空间 */)
+			projectUid, err := dms.GetPorjectUIDByName(context.TODO(), c.Param("project_name"))
+			if err != nil {
+				return controller.JSONBaseErrorReq(c, err)
+			}
+
+			up, err := dms.NewUserPermission(uid, projectUid)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2933
## 描述你的变更
- 项目相关权限检查使用了正确的 project_uid，移除了硬编码的空间ID "700300"
- 修改了全局权限检查的逻辑，使用空字符串
- 移除了未使用的 AdminUserAllowed 中间件
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
