### PR TITLE
fix: panic when analysis insert into select stmt

### DIFF
--- a/sqle/driver/mysql/analysis.go
+++ b/sqle/driver/mysql/analysis.go
@@ -310,7 +310,12 @@ func (i *MysqlDriverImpl) ExtractSchemaTableList(sql string) ([]SchemaTable, err
 	case *ast.InsertStmt:
 		getMultiTables(stmt.Table.TableRefs)
 		if stmt.Select != nil {
-			getMultiTables(stmt.Select.(*ast.SelectStmt).From.TableRefs)
+			// TODO：INSERT INTO SQLE00115_t1_tmp_employee (id, cname, sex, age, salary) SELECT 4000002, '小张', 0, 25, (SELECT AVG(salary) FROM SQLE00115_t1_employee) 对于这条SQL，解析器无法解析子查询为一个Select语句，而是认为是一个文本
+			if selectStmt, ok := stmt.Select.(*ast.SelectStmt); ok {
+				if selectStmt.From != nil{
+					getMultiTables(selectStmt.From.TableRefs)
+				}
+			}
 		}
 	case *ast.DeleteStmt:
 		getMultiTables(stmt.TableRefs.TableRefs)

--- a/sqle/driver/mysql/util/util.go
+++ b/sqle/driver/mysql/util/util.go
@@ -84,7 +84,7 @@ func GetAffectedRowNum(ctx context.Context, originSql string, conn *executor.Exe
 		affectedRowSql = fmt.Sprintf("select count(*) from (%s) as t", trimSuffix)
 	} else {
 		if newNode == nil {
-			log.NewEntry().Errorf("get select node from %v failed", originSql)
+			log.NewEntry().Errorf("in GetAffectedRowNum, when getting select node from %v failed", originSql)
 			return 0, fmt.Errorf("get select node from %v failed", originSql)
 		}
 		sqlBuilder := new(strings.Builder)


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2928?open_in_browser=true
## 描述你的变更
1. 修复在分析INSERT INTO ...... SELECT语句的时候，SELECT语句没有FROM导致的panic问题
2. 修复在分析INSERT INTO ...... SELECT语句的时候，SELECT语句使用UNION导致的panic问题
3. 增加了TODO项目，用于解决无法解析出SELECT子句中SELECT Field中的SUBQUERY refer的表
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [X] 我已完成自测
- [X] 我已记录完整日志方便进行诊断
- [X] 我已在关联的issue里补充了实现方案
- [X] 我已在关联的issue里补充了测试影响面
- [X] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [X] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
