### PR TITLE
fix(driver/mysql): add backticks around schema and table names in GetTableIndexesInfo

### DIFF
--- a/sqle/driver/mysql/executor/executor.go
+++ b/sqle/driver/mysql/executor/executor.go
@@ -12,6 +12,7 @@ import (
 
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
 	"github.com/actiontech/sqle/sqle/errors"
+	"github.com/actiontech/sqle/sqle/utils"
 	"github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
 )
@@ -786,7 +787,10 @@ type TableIndexesInfo struct {
 
 // When using keywords as view names, you need to pay attention to wrapping them in quotation marks
 func (c *Executor) GetTableIndexesInfo(schema, tableName string) ([]*TableIndexesInfo, error) {
-	records, err := c.Db.Query(fmt.Sprintf("SHOW INDEX FROM %s.%s", schema, tableName))
+	records, err := c.Db.Query(fmt.Sprintf("SHOW INDEX FROM %s.%s",
+		utils.SupplementalQuotationMarks(schema),
+		utils.SupplementalQuotationMarks(tableName),
+	))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change prevents potential errors when schema or table names contain special characters or keywords. By enclosing them in backticks, we ensure proper SQL syntax and improve code robustness.

## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2287
test https://github.com/actiontech/sqle-ee/issues/2287#issuecomment-2723818485
## 描述你的变更
1. 给采集index的sql的库表加上反引号
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [X] 我已完成自测
- [X] 我已记录完整日志方便进行诊断
- [X] 我已在关联的issue里补充了实现方案
- [X] 我已在关联的issue里补充了测试影响面
- [X] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [X] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
