### PR TITLE
Issue 2962

### DIFF
--- a/sqle/driver/mysql/splitter/comment_cleaner.go
+++ b/sqle/driver/mysql/splitter/comment_cleaner.go
@@ -57,17 +57,17 @@ func removeSQLComments(sql string) string {
 				continue
 			}
 			if c == '/' && i+1 < n && runes[i+1] == '*' {
-				// 判断是否为 Hint：检查是否有 "+" 符号
-				if i+2 < n && runes[i+2] == '+' {
-					// Hint 不删除，原样输出整个 Hint 注释
+				// 判断是否为 Hint/条件注释：检查是否有 "+"/"!" 符号
+				if i+2 < n && (runes[i+2] == '+' || runes[i+2] == '!') {
+					// Hint和条件注释 不删除，原样输出整个注释
 					startIndex := i
-					// 找到 Hint 结束位置
+					// 使用辅助函数找 Hint/条件注释 结束位置
 					endPos := findCommentEnd(runes, i)
 					result = append(result, runes[startIndex:endPos]...)
 					i = endPos - 1
 					continue
 				} else {
-					// 非 Hint 块注释，进入删除状态
+					// 非 Hint/条件注释 块注释，进入删除状态
 					inBlockComment = true
 					i++ // 跳过 '*'
 					continue
@@ -86,11 +86,7 @@ func removeSQLComments(sql string) string {
 
 		result = append(result, c)
 	}
-	// 处理dump文件可能存在多行注释结尾有分号问题
-	if strings.TrimSpace(string(result)) == ";" {
-		return ""
-	}
-	return string(result)
+	return strings.TrimSpace(string(result))
 }
 
 // findCommentEnd 返回从 pos 开始的块注释结束位置（包括 "*/"），如果没找到则返回 n

--- a/sqle/driver/mysql/splitter/comment_cleaner.go
+++ b/sqle/driver/mysql/splitter/comment_cleaner.go
@@ -1,0 +1,83 @@
+package splitter
+
+import (
+	"strings"
+	"unicode"
+)
+
+/*
+该方法用于清除sql语句中的注释信息
+*/
+func removeSQLComments(sql string) string {
+	var result []rune
+	inSingleQuote, inDoubleQuote, inBackQuote := false, false, false
+	inLineComment, inBlockComment := false, false
+	runes := []rune(sql)
+	n := len(runes)
+
+	for i := 0; i < n; i++ {
+		c := runes[i]
+
+		// 结束行注释
+		if inLineComment {
+			if c == '\n' || c == '\r' {
+				inLineComment = false
+				result = append(result, c)
+			}
+			continue
+		}
+
+		// 结束块注释
+		if inBlockComment {
+			if c == '*' && i+1 < n && runes[i+1] == '/' {
+				inBlockComment = false
+				i++ // 跳过 '/'
+				// 在块注释结束后，检查下一个字符
+				if i+1 < n && !unicode.IsSpace(runes[i+1]) {
+					// 只有当 result 最后字符不是空格时，才插入一个空格
+					if len(result) == 0 || !unicode.IsSpace(result[len(result)-1]) {
+						result = append(result, ' ')
+					}
+				}
+			}
+			continue
+		}
+
+		// 进入引号状态（进入前保留引号）
+		if !inSingleQuote && !inDoubleQuote && !inBackQuote {
+			// 行注释：-- 开始
+			if c == '-' && i+1 < n && runes[i+1] == '-' {
+				inLineComment = true
+				i++ // 跳过第二个 -
+				continue
+			}
+			// 行注释：# 开始
+			if c == '#' {
+				inLineComment = true
+				continue
+			}
+			// 块注释：/* 开始
+			if c == '/' && i+1 < n && runes[i+1] == '*' {
+				inBlockComment = true
+				i++ // 跳过 *
+				continue
+			}
+		}
+
+		// 状态切换：引号内不检查注释
+		if c == '\'' && !inDoubleQuote && !inBackQuote {
+			inSingleQuote = !inSingleQuote
+		} else if c == '"' && !inSingleQuote && !inBackQuote {
+			inDoubleQuote = !inDoubleQuote
+		} else if c == '`' && !inSingleQuote && !inDoubleQuote {
+			inBackQuote = !inBackQuote
+		}
+
+		result = append(result, c)
+	}
+	// 处理dump文件可能存在多行注释结尾有分号问题
+	if strings.TrimSpace(string(result)) == ";" {
+		return ""
+	}
+	return string(result)
+}

--- a/sqle/driver/mysql/splitter/comment_cleaner.go
+++ b/sqle/driver/mysql/splitter/comment_cleaner.go
@@ -56,11 +56,22 @@ func removeSQLComments(sql string) string {
 				inLineComment = true
 				continue
 			}
-			// 块注释：/* 开始
 			if c == '/' && i+1 < n && runes[i+1] == '*' {
-				inBlockComment = true
-				i++ // 跳过 *
-				continue
+				// 判断是否为 Hint：检查是否有 "+" 符号
+				if i+2 < n && runes[i+2] == '+' {
+					// Hint 不删除，原样输出整个 Hint 注释
+					startIndex := i
+					// 找到 Hint 结束位置
+					endPos := findCommentEnd(runes, i)
+					result = append(result, runes[startIndex:endPos]...)
+					i = endPos - 1
+					continue
+				} else {
+					// 非 Hint 块注释，进入删除状态
+					inBlockComment = true
+					i++ // 跳过 '*'
+					continue
+				}
 			}
 		}
 
@@ -80,4 +91,16 @@ func removeSQLComments(sql string) string {
 		return ""
 	}
 	return string(result)
+}
+
+// findCommentEnd 返回从 pos 开始的块注释结束位置（包括 "*/"），如果没找到则返回 n
+func findCommentEnd(runes []rune, pos int) int {
+	n := len(runes)
+	for pos < n-1 {
+		if runes[pos] == '*' && runes[pos+1] == '/' {
+			return pos + 2
+		}
+		pos++
+	}
+	return n
 }

--- a/sqle/driver/mysql/splitter/splitter.go
+++ b/sqle/driver/mysql/splitter/splitter.go
@@ -135,7 +135,7 @@ func (s *splitter) formateOriginSql(originSql string) string {
 			originSql = trimmedSql + DefaultDelimiterString
 		}
 	}
-	return originSql
+	return removeSQLComments(originSql)
 }
 
 func (s *splitter) matchSql(sql string) bool {

--- a/sqle/driver/mysql/splitter/splitter.go
+++ b/sqle/driver/mysql/splitter/splitter.go
@@ -125,6 +125,7 @@ func (s *splitter) getNextSql(sqlText string) (*singleSQL, error) {
 // 如果SQL没有分隔符，则返回没有分隔符的SQL
 // 如果分隔符不是默认分隔符，则将其替换为默认分隔符
 // 如果去除分隔符和空白符之后SQL为空字符串，则返回空字符串，空字符串需跳过
+// 如果去除注释信息之后SQL为空字符串，则返回空字符串，空字符串需跳过
 func (s *splitter) formateOriginSql(originSql string) string {
 	if strings.HasSuffix(originSql, s.delimiter.DelimiterStr) {
 		trimmedSql := strings.TrimSuffix(originSql, s.delimiter.DelimiterStr)
@@ -135,7 +136,10 @@ func (s *splitter) formateOriginSql(originSql string) string {
 			originSql = trimmedSql + DefaultDelimiterString
 		}
 	}
-	return removeSQLComments(originSql)
+	if removeSQLComments(originSql) == "" {
+		return ""
+	}
+	return originSql
 }
 
 func (s *splitter) matchSql(sql string) bool {

--- a/sqle/driver/mysql/splitter/splitter_test.go
+++ b/sqle/driver/mysql/splitter/splitter_test.go
@@ -1283,6 +1283,33 @@ func TestRemoveSQLComments(t *testing.T) {
 			expected: "SELECT name FROM users",
 		},
 		{
+			name: "hint test 1",
+			input: `SELECT /*+ SQL_SMALL_RESULT */  column1 
+FROM small_table 
+GROUP BY column1;`,
+			expected: `SELECT /*+ SQL_SMALL_RESULT */  column1 
+FROM small_table 
+GROUP BY column1;`,
+		},
+		{
+			name: "hint test 2",
+			input: `SELECT /*+ SQL_SMALL_RESULT *//* comment */ column1 
+FROM small_table 
+GROUP BY column1;`,
+			expected: `SELECT /*+ SQL_SMALL_RESULT */ column1 
+FROM small_table 
+GROUP BY column1;`,
+		},
+		{
+			name: "hint test 3",
+			input: `SELECT /* comment *//*+ SQL_SMALL_RESULT */ column1 
+FROM small_table 
+GROUP BY column1;`,
+			expected: `SELECT /*+ SQL_SMALL_RESULT */ column1 
+FROM small_table 
+GROUP BY column1;`,
+		},
+		{
 			name:     "semicolon only after trim",
 			input:    "/* comment */;",
 			expected: "",

--- a/sqle/driver/mysql/splitter/splitter_test.go
+++ b/sqle/driver/mysql/splitter/splitter_test.go
@@ -3,13 +3,14 @@ package splitter
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/pingcap/parser/ast"
 	parser_formate "github.com/pingcap/parser/format"
 	_ "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"strings"
-	"testing"
 )
 
 func TestSplitSqlText(t *testing.T) {
@@ -1182,5 +1183,116 @@ func TestGeometryColumnIsNotReserved(t *testing.T) {
 				t.Errorf("expect sql format: %s; actual sql format: %s", c.formatSQL, buf.String())
 			}
 		}
+	}
+}
+
+// 测试清除sql中的注释信息
+func TestRemoveSQLComments(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "comment before sql statement",
+			input:    "/* this is comment */SELECT * FROM users WHERE id = 1;",
+			expected: " SELECT * FROM users WHERE id = 1;",
+		},
+		{
+			name:     "comments after sql statements 1",
+			input:    "SELECT * FROM users WHERE id = 1;/* this is comment */",
+			expected: "SELECT * FROM users WHERE id = 1;",
+		},
+		{
+			name:     "comments after sql statements 2",
+			input:    "SELECT * FROM users WHERE id = 1/* this is comment */;",
+			expected: "SELECT * FROM users WHERE id = 1 ;",
+		},
+		{
+			name: "comments are conditions2",
+			input: `SELECT * FROM db1.t11 WHERE t11.c  = '
+-- EXFSYS."RLM$INCRRRSCHACT" definition
+';`,
+			expected: `SELECT * FROM db1.t11 WHERE t11.c  = '
+-- EXFSYS."RLM$INCRRRSCHACT" definition
+';`,
+		},
+		{
+			name:     "comments after sql statements 3",
+			input:    "SELECT * FROM users WHERE id = 1;#",
+			expected: "SELECT * FROM users WHERE id = 1;",
+		},
+		{
+			name:     "no comments",
+			input:    "SELECT * FROM users WHERE id = 1;",
+			expected: "SELECT * FROM users WHERE id = 1;",
+		},
+		{
+			name:     "single line comment with --",
+			input:    "SELECT * FROM users -- this is comment\nWHERE id = 1;",
+			expected: "SELECT * FROM users \nWHERE id = 1;",
+		},
+		{
+			name:     "single line comment with #",
+			input:    "SELECT * FROM users # this is comment\nWHERE id = 1;",
+			expected: "SELECT * FROM users \nWHERE id = 1;",
+		},
+		{
+			name:     "multi line comment",
+			input:    "SELECT * FROM /* this is \n comment */ users WHERE id = 1;",
+			expected: "SELECT * FROM  users WHERE id = 1;",
+		},
+		{
+			name:     "comment in single quotes",
+			input:    "SELECT '-- not a comment' FROM users;",
+			expected: "SELECT '-- not a comment' FROM users;",
+		},
+		{
+			name:     "comment in double quotes",
+			input:    `SELECT "-- not a comment" FROM users;`,
+			expected: `SELECT "-- not a comment" FROM users;`,
+		},
+		{
+			name:     "comment in back quotes",
+			input:    "SELECT `-- not a comment` FROM users;",
+			expected: "SELECT `-- not a comment` FROM users;",
+		},
+		{
+			name:     "mixed quotes and comments",
+			input:    "SELECT `-- not a comment`, '/* not a comment */', \"-- not a comment\" -- real comment\nFROM users;",
+			expected: "SELECT `-- not a comment`, '/* not a comment */', \"-- not a comment\" \nFROM users;",
+		},
+		{
+			name:     "only comment",
+			input:    "-- only comment",
+			expected: "",
+		},
+		{
+			name:     "unclosed block comment",
+			input:    "SELECT * FROM users /* unclosed comment",
+			expected: "SELECT * FROM users ",
+		},
+		{
+			name:     "space after block comment",
+			input:    "SELECT/*comment*/name FROM users",
+			expected: "SELECT name FROM users",
+		},
+		{
+			name:     "semicolon only after trim",
+			input:    "/* comment */;",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := removeSQLComments(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
 	}
 }

--- a/sqle/driver/mysql/splitter/splitter_test.go
+++ b/sqle/driver/mysql/splitter/splitter_test.go
@@ -1201,7 +1201,7 @@ func TestRemoveSQLComments(t *testing.T) {
 		{
 			name:     "comment before sql statement",
 			input:    "/* this is comment */SELECT * FROM users WHERE id = 1;",
-			expected: " SELECT * FROM users WHERE id = 1;",
+			expected: "SELECT * FROM users WHERE id = 1;",
 		},
 		{
 			name:     "comments after sql statements 1",
@@ -1274,8 +1274,8 @@ func TestRemoveSQLComments(t *testing.T) {
 		},
 		{
 			name:     "unclosed block comment",
-			input:    "SELECT * FROM users /* unclosed comment",
-			expected: "SELECT * FROM users ",
+			input:    "SELECT * FROM users/* unclosed comment",
+			expected: "SELECT * FROM users",
 		},
 		{
 			name:     "space after block comment",
@@ -1310,9 +1310,19 @@ FROM small_table
 GROUP BY column1;`,
 		},
 		{
-			name:     "semicolon only after trim",
-			input:    "/* comment */;",
-			expected: "",
+			name:     "conditional comments test 1",
+			input:    `/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;`,
+			expected: `/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;`,
+		},
+		{
+			name:     "conditional comments test 2",
+			input:    `SELECT * FROM users /*! WHERE active = 1 */;`,
+			expected: `SELECT * FROM users /*! WHERE active = 1 */;`,
+		},
+		{
+			name:     "conditional comments test 3",
+			input:    `SELECT * FROM/* comments */ users /*! WHERE active = 1 */;`,
+			expected: `SELECT * FROM users /*! WHERE active = 1 */;`,
 		},
 	}
 


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle/issues/2962
## 描述你的变更
mysql审核时删除sql语句的注释信息
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 修复审核SQL以注释结尾时报错

- 优化日志输出，添加错误行信息

- 引入清除SQL注释的功能

- 增加相关单元测试


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comment_cleaner.go</strong><dd><code>引入SQL注释清理功能</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/splitter/comment_cleaner.go

- 添加清除SQL注释的函数
- 处理单行和块注释
- 保留Hint和条件注释


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/2992/files#diff-491b9dcbe14a7af76893811fe4f38275f958a603b5080da444ace2e75517c7fe">+102/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>splitter.go</strong><dd><code>修改分割器以支持注释清理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/splitter/splitter.go

- 修改分割器以移除SQL注释
- 添加注释清理逻辑
- 确保空SQL被跳过


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/2992/files#diff-2f9331d7a87a888a209e41f541ebc83b530b70b943a85d0f0b61f6e9a97bd24f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>splitter_test.go</strong><dd><code>增加SQL注释清理的测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/splitter/splitter_test.go

- 增加清除SQL注释的单元测试
- 覆盖多种注释场景
- 测试Hint和条件注释保留


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/2992/files#diff-e67558d1efff3ebeb7c27c6336554c814444f30d5b70b9fafab31361c12a8462">+152/-3</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>