### PR TITLE
feat(api): 添加规则版本信息

### DIFF
--- a/sqle/api/controller/v1/rule.go
+++ b/sqle/api/controller/v1/rule.go
@@ -498,6 +498,7 @@ type RuleResV1 struct {
 	HasAuditPower   bool                `json:"has_audit_power"`
 	HasRewritePower bool                `json:"has_rewrite_power"`
 	Categories      map[string][]string `json:"categories"`
+	Version         uint32              `json:"version"`
 }
 
 type RuleParamResV1 struct {
@@ -538,6 +539,7 @@ func convertRuleToRes(ctx context.Context, rule *model.Rule) RuleResV1 {
 		ruleRes.Params = paramsRes
 	}
 	ruleRes.Categories = associateCategories(rule.Categories)
+	ruleRes.Version = rule.Version
 	return ruleRes
 }
 
@@ -554,6 +556,7 @@ func convertCustomRuleToRuleResV1(rule *model.CustomRule) RuleResV1 {
 		HasRewritePower: false,
 	}
 	ruleRes.Categories = associateCategories(rule.Categories)
+	ruleRes.Version = 1
 	return ruleRes
 }
 


### PR DESCRIPTION
### **User description**
- 在获取规则信息时，将规则版本添加到响应中
- 默认自定义规则的版本为 1

## 关联的 issue
- https://github.com/actiontech/sqle-ee/issues/2353
## 描述你的变更

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 添加 `Version` 字段用于展示规则版本

- 在规则响应中返回规则版本信息

- 为自定义规则设置默认版本为 1


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rule.go</strong><dd><code>为规则响应结构添加版本字段</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/api/controller/v1/rule.go

<li>在 <code>RuleResV1</code> 结构中新增 <code>Version</code> 字段<br> <li> 在 <code>convertRuleToRes</code> 函数中分配规则版本<br> <li> 在 <code>convertCustomRuleToRuleResV1</code> 函数中设置默认版本为 1


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3027/files#diff-697f6581cf908ccfceda0f89354f16cecfe57ad0144cc3f35bc78ffab3298a58">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>