### PR TITLE
feat(audit): 重构oracle top sql功能

### DIFF
--- a/sqle/model/instance_audit_plan_list.go
+++ b/sqle/model/instance_audit_plan_list.go
@@ -164,11 +164,16 @@ var FilterMap = map[FilterName]FilterType{
 }
 
 var OrderByMap = map[string] /* field name */ string /* field name with table*/ {
-	"counter":                "audit_plan_sqls.info->'$.counter'",
-	"last_receive_timestamp": "audit_plan_sqls.info->'$.last_receive_timestamp'",
-	"query_time_avg":         "audit_plan_sqls.info->'$.query_time_avg'",
-	"query_time_max":         "audit_plan_sqls.info->'$.query_time_max'",
-	"row_examined_avg":       "audit_plan_sqls.info->'$.row_examined_avg'",
+	"counter":                 "audit_plan_sqls.info->'$.counter'",
+	"query_time_total":        "audit_plan_sqls.info->'$.query_time_total'",
+	"cpu_time_total":          "audit_plan_sqls.info->'$.cpu_time_total'",
+	"disk_read_total":         "audit_plan_sqls.info->'$.disk_read_total'",
+	"buffer_read_total":       "audit_plan_sqls.info->'$.buffer_read_total'",
+	"user_io_wait_time_total": "audit_plan_sqls.info->'$.user_io_wait_time_total'",
+	"last_receive_timestamp":  "audit_plan_sqls.info->'$.last_receive_timestamp'",
+	"query_time_avg":          "audit_plan_sqls.info->'$.query_time_avg'",
+	"query_time_max":          "audit_plan_sqls.info->'$.query_time_max'",
+	"row_examined_avg":        "audit_plan_sqls.info->'$.row_examined_avg'",
 }
 
 var instanceAuditPlanSQLQueryTpl = `

--- a/sqle/pkg/oracle/db.go
+++ b/sqle/pkg/oracle/db.go
@@ -53,7 +53,7 @@ func (o *DB) Close() error {
 	return o.db.Close()
 }
 
-func (o *DB) QueryTopSQLs(ctx context.Context, topN int, notInUsers []string, orderBy string) ([]*DynPerformanceSQLArea, error) {
+func (o *DB) QueryTopSQLs(ctx context.Context, collectIntervalMinute string, topN int, notInUsers []string, orderBy string) ([]*DynPerformanceSQLArea, error) {
 	// if notInUsers is empty, notInUsersStr will be empty
 	// if notInUsers is not empty, notInUsersStr will be formatted as "AND u.username NOT IN ('user1', 'user2')"
 	var notInUsersStr string
@@ -75,7 +75,7 @@ func (o *DB) QueryTopSQLs(ctx context.Context, topN int, notInUsers []string, or
 	}
 	var ret []*DynPerformanceSQLArea
 	for _, metric := range metrics {
-		query := fmt.Sprintf(DynPerformanceViewSQLAreaTpl, notInUsersStr, metric, topN)
+		query := fmt.Sprintf(DynPerformanceViewSQLAreaTpl, collectIntervalMinute, notInUsersStr, metric, topN)
 		rows, err := o.db.QueryContext(ctx, query)
 		if err != nil {
 			rows.Close()

--- a/sqle/pkg/oracle/db.go
+++ b/sqle/pkg/oracle/db.go
@@ -78,21 +78,24 @@ func (o *DB) QueryTopSQLs(ctx context.Context, topN int, notInUsers []string, or
 		query := fmt.Sprintf(DynPerformanceViewSQLAreaTpl, notInUsersStr, metric, topN)
 		rows, err := o.db.QueryContext(ctx, query)
 		if err != nil {
+			rows.Close()
 			return nil, errors.Wrapf(err, "failed to query %s", query)
 		}
-		defer rows.Close()
 
 		for rows.Next() {
 			res := DynPerformanceSQLArea{}
 			err = rows.Scan(&res.SQLFullText, &res.Executions, &res.ElapsedTime, &res.UserIOWaitTime, &res.CPUTime, &res.DiskReads, &res.BufferGets, &res.UserName)
 			if err != nil {
+				rows.Close()
 				return nil, errors.Wrapf(err, "failed to scan %s", query)
 			}
 			ret = append(ret, &res)
 		}
 		if err := rows.Err(); err != nil {
+			rows.Close()
 			return nil, errors.Wrapf(err, "failed to iterate %s", query)
 		}
+		rows.Close()
 	}
 	return ret, nil
 }

--- a/sqle/pkg/oracle/perf.go
+++ b/sqle/pkg/oracle/perf.go
@@ -33,6 +33,7 @@ SELECT * FROM (
     JOIN
         DBA_USERS u ON s.parsing_user_id = u.user_id
     WHERE
+        last_active_time >= SYSDATE - INTERVAL '%v' MINUTE AND
         s.EXECUTIONS > 0
         %v
     ORDER BY %v DESC

--- a/sqle/server/auditplan/task_type_oracle_topsql.go
+++ b/sqle/server/auditplan/task_type_oracle_topsql.go
@@ -125,7 +125,7 @@ func (at *OracleTopSQLTaskV2) ExtractSQL(logger *logrus.Entry, ap *AuditPlan, pe
 		notInUser = append(notInUser, blacklist.FilterContent)
 	}
 	// filter db user by
-	sqls, err := db.QueryTopSQLs(ctx, ap.Params.GetParam("top_n").Int(), notInUser, ap.Params.GetParam("order_by_column").String())
+	sqls, err := db.QueryTopSQLs(ctx, ap.Params.GetParam("collect_interval_minute").String(), ap.Params.GetParam("top_n").Int(), notInUser, ap.Params.GetParam("order_by_column").String())
 	if err != nil {
 		return nil, fmt.Errorf("query top sql fail, error: %v", err)
 	}

--- a/sqle/server/auditplan/task_type_oracle_topsql.go
+++ b/sqle/server/auditplan/task_type_oracle_topsql.go
@@ -39,20 +39,7 @@ func (at *OracleTopSQLTaskV2) Params(instanceId ...string) params.Params {
 			Type:     params.ParamTypeInt,
 			I18nDesc: locale.Bundle.LocalizeAll(locale.ParamCollectIntervalMinuteOracle),
 		},
-		{
-			Key:   "top_n",
-			Desc:  "Top N",
-			Value: "3",
-			Type:  params.ParamTypeInt,
-		},
-		{
-			Key:      "order_by_column",
-			Value:    oracle.DynPerformanceViewSQLAreaColumnElapsedTime,
-			Type:     params.ParamTypeString,
-			I18nDesc: locale.Bundle.LocalizeAll(locale.ParamOrderByColumn),
-		},
 	}
-
 }
 
 func (at *OracleTopSQLTaskV2) Metrics() []string {
@@ -207,28 +194,34 @@ func (at *OracleTopSQLTaskV2) Head(ap *AuditPlan) []Head {
 			Desc: model.AuditResultDesc,
 		},
 		{
-			Name: MetricNameCounter,
-			Desc: locale.ApMetricNameCounter,
+			Name:     MetricNameCounter,
+			Desc:     locale.ApMetricNameCounter,
+			Sortable: true,
 		},
 		{
-			Name: MetricNameQueryTimeTotal,
-			Desc: locale.ApMetricNameQueryTimeTotal,
+			Name:     MetricNameQueryTimeTotal,
+			Desc:     locale.ApMetricNameQueryTimeTotal,
+			Sortable: true,
 		},
 		{
-			Name: MetricNameCPUTimeTotal,
-			Desc: locale.ApMetricNameCPUTimeTotal,
+			Name:     MetricNameCPUTimeTotal,
+			Desc:     locale.ApMetricNameCPUTimeTotal,
+			Sortable: true,
 		},
 		{
-			Name: MetricNameDiskReadTotal,
-			Desc: locale.ApMetricNameDiskReadTotal,
+			Name:     MetricNameDiskReadTotal,
+			Desc:     locale.ApMetricNameDiskReadTotal,
+			Sortable: true,
 		},
 		{
-			Name: MetricNameBufferGetCounter,
-			Desc: locale.ApMetricNameBufferGetCounter,
+			Name:     MetricNameBufferGetCounter,
+			Desc:     locale.ApMetricNameBufferGetCounter,
+			Sortable: true,
 		},
 		{
-			Name: MetricNameUserIOWaitTimeTotal,
-			Desc: locale.ApMetricNameUserIOWaitTimeTotal,
+			Name:     MetricNameUserIOWaitTimeTotal,
+			Desc:     locale.ApMetricNameUserIOWaitTimeTotal,
+			Sortable: true,
 		},
 		{
 			Name: MetricNameDBUser,


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2356
## 描述你的变更
- 重构 DB 查询逻辑，支持按不同指标排序和筛选
- 更新审计计划列表的排序选项，增加多个指标- 修改 Oracle Top SQL 任务的参数配置，简化设置 
- 为度量指标添加可排序标记，提升用户体验
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 新增 collectIntervalMinute 参数支持

- 优化 Top SQL 查询及资源释放

- 更新指标查询与排序逻辑

- 调整审计任务的排序标记


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>instance_audit_plan_list.go</strong><dd><code>更新 OrderByMap 字段映射规则</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/model/instance_audit_plan_list.go

- 修改 OrderByMap 字段映射
- 添加新指标字段（query_time_total, cpu_time_total, 等）


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3036/files#diff-e08c8cc35398f1c65f25b8dd9b36564e6d145f1a3f2f8203c0822d5d26c91f77">+10/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>perf.go</strong><dd><code>调整 SQL 查询条件</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/pkg/oracle/perf.go

- 增加 last_active_time 条件
- 调整查询 SQL 语句条件


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3036/files#diff-5956f82bc4a07086d0c9697310bc58eca9792f0c3e82324f951bf35b5897c209">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task_type_oracle_topsql.go</strong><dd><code>更新审计任务参数配置</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/server/auditplan/task_type_oracle_topsql.go

- 修改 Params 参数配置
- 更新 QueryTopSQLs 函数调用参数
- 为指标添加 Sortable 标记


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3036/files#diff-728d90a9ae259a29bd50f1a0eb00944bf6471d8145a50d5ab54a0b86c7cd339a">+19/-26</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db.go</strong><dd><code>优化 QueryTopSQLs 查询函数</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/pkg/oracle/db.go

- 新增 collectIntervalMinute 参数
- 用匿名函数优化查询处理
- 改进错误处理及资源释放


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3036/files#diff-b1a675bfb54540a019c46841d2814e5d97b990a471986d2b1fd0c4c2266f1a59">+38/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>