### PR TITLE
feat(auditplan): create cost metric records only when mysql

### DIFF
--- a/sqle/server/auditplan/task_wrap.go
+++ b/sqle/server/auditplan/task_wrap.go
@@ -309,10 +309,13 @@ func (at *TaskWrapper) pushSQLToManagerSQLQueue(sqlList []*model.SQLManageQueue,
 		return err
 	}
 
-	for _, sqlQueue := range SqlQueueList {
-		err = createSqlManageCostMetricRecord(sqlQueue, ap.Instance)
-		if err != nil {
-			log.Logger().Errorf("createSqlManageCostMetricRecord: %v", err)
+	// 目前只支持MySQL
+	if ap.DBType == driverV2.DriverTypeMySQL {
+		for _, sqlQueue := range SqlQueueList {
+			err = createSqlManageCostMetricRecord(sqlQueue, ap.Instance)
+			if err != nil {
+				log.Logger().Errorf("createSqlManageCostMetricRecord: %v", err)
+			}
 		}
 	}
 	err = at.persist.PushSQLToManagerSQLQueue(SqlQueueList)
@@ -642,7 +645,7 @@ func createSqlManageCostMetricRecord(sqlManageQueue *model.SQLManageQueue, insta
 	}
 	cost, err := GetQueryCost(plugin, sqlManageQueue.SqlText)
 	if err != nil {
-		log.Logger().Errorf("createSqlManageCostMetricRecord: parse explain cost to float64 failed %v", err)
+		log.Logger().Errorf("createSqlManageCostMetricRecord: failed %v", err)
 		return err
 	}
 	storage := model.GetStorage()


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2375
## 描述你的变更

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 添加 MySQL 判断条件，避免非 MySQL 环境创建成本记录

- 修改 createSqlManageCostMetricRecord 中错误日志提示信息

- 保证批量更新和队列推送逻辑维持原有功能


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task_wrap.go</strong><dd><code>为 SQL 成本记录创建增加 MySQL 条件判断</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/server/auditplan/task_wrap.go

- 引入对 `ap.DBType` 的 MySQL 判断
- 将创建成本记录逻辑包裹在条件判断内
- 更新错误日志输出，简化错误描述


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3052/files#diff-2b7c095b05a4ccaf4fc53856e4ec5f65095d284ce2e939eccc0f42beeab9d568">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>