### PR TITLE
fix：单元测试描述有误

### DIFF
--- a/sqle/driver/mysql/rule_00108_test.go
+++ b/sqle/driver/mysql/rule_00108_test.go
@@ -61,7 +61,7 @@ func TestRuleSQLE00108(t *testing.T) {
 	// 	"WITH CTE AS (SELECT * FROM exist_db.exist_tb_1 WHERE id IN (SELECT id FROM exist_db.exist_tb_1 WHERE id IN (SELECT id FROM exist_db.exist_tb_1 WHERE id IN (SELECT id FROM exist_db.exist_tb_1 WHERE id IN (SELECT id FROM exist_db.exist_tb_1 WHERE id = 'value'))))) SELECT * FROM CTE",
 	// 	nil, nil, newTestResult())
 
-	runAIRuleCase(rule, t, "case 13_tes: SELECT语句where中包含6层嵌套子查询，使用示例中的表结构",
+	runAIRuleCase(rule, t, "case 13: SELECT语句from中包含2层嵌套子查询，使用示例中的表结构",
 		"SELECT AVG(subquery_middle.subquery_grade) AS subquery_middle_avg FROM (SELECT grade AS subquery_grade FROM st1 WHERE st1.cid IN (SELECT cid FROM st_class WHERE cname = 'class2')) subquery_middle;",
 		session.NewAIMockContext().WithSQL("CREATE TABLE st1 (id bigint, name VARCHAR(32), cid bigint, grade NUMERIC); CREATE TABLE st_class (cid bigint, cname VARCHAR(32));"),
 		nil, newTestResult())


### PR DESCRIPTION
rule_00108_test.go 中的case 13 描述有误。原始的描述中说有6层嵌套子查询，实际上是低于阈值5的，由于case 13 使用newTestResult()判断，所以CI/CD中执行成功，不会报错。