### PR TITLE
fix: optimize TabularDataHead i18n description processing

### DIFF
--- a/sqle/driver/v2/util.go
+++ b/sqle/driver/v2/util.go
@@ -392,15 +392,17 @@ func ConvertProtoTabularDataToDriver(pTd *protoV2.TabularData, isI18n bool) (Tab
 			I18nDesc: nil,
 		}
 		if isI18n {
-			if _, exist := c.I18NDesc[i18nPkg.DefaultLang.String()]; !exist {
-				// 多语言的插件 需包含 i18nPkg.DefaultLang
-				return TabularData{}, fmt.Errorf("client TabularDataHead: %s does not support language: %s", c.Name, i18nPkg.DefaultLang.String())
+			if len(c.I18NDesc) > 0 { // 列描述可以为空，为空时跳过
+				if _, exist := c.I18NDesc[i18nPkg.DefaultLang.String()]; !exist {
+					// 多语言的插件 需包含 i18nPkg.DefaultLang
+					return TabularData{}, fmt.Errorf("client TabularDataHead: %s does not support language: %s", c.Name, i18nPkg.DefaultLang.String())
+				}
+				i18nDesc, err := i18nPkg.ConvertStrMap2I18nStr(c.I18NDesc)
+				if err != nil {
+					return TabularData{}, fmt.Errorf("TabularData: %w", err)
+				}
+				h.I18nDesc = i18nDesc
 			}
-			i18nDesc, err := i18nPkg.ConvertStrMap2I18nStr(c.I18NDesc)
-			if err != nil {
-				return TabularData{}, fmt.Errorf("TabularData: %w", err)
-			}
-			h.I18nDesc = i18nDesc
 		} else {
 			// 对非多语言的插件支持
 			h.I18nDesc.SetStrInLang(i18nPkg.DefaultLang, c.Desc)


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2391

## 描述你的变更
允许国际化的插件执行计划的列头描述字段为空

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 改进多语言列描述为空情况处理

- 添加空判断避免不必要的错误返回

- 优化国际化列描述转换逻辑


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>改进多语言列描述处理逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/v2/util.go

- 在多语言场景下判断列描述是否为空
- 添加默认语言键存在性检查
- 增加错误处理和国际化转换调用


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3057/files#diff-b155962b27c72b7fac034c0399d4c768078776145a1343003c9a270527d3d3f6">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>