### PR TITLE
Cherry pick main mysql v1规则问题

### DIFF
--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -4027,9 +4027,9 @@ func getColumnWithCharset(stmt *ast.CreateTableStmt, input *RuleHandlerInput) []
 		// 如果 col.Tp 不为 nil，先处理 Charset 和 Collate
 		if col.Tp != nil {
 			// 如果 col.Tp.Charset 非空，直接加入
-			if col.Tp.Charset != "" {
+			if col.Tp.Charset != "" && col.Tp.Charset != "binary" {
 				columnWithCharset = append(columnWithCharset, col)
-			} else if col.Tp.Collate != "" {
+			} else if col.Tp.Collate != "" && col.Tp.Charset != "binary" {
 				// 如果 col.Tp.Collate 非空，设置 Charset
 				col.Tp.Charset, _ = input.Ctx.GetSchemaCharacterByCollation(col.Tp.Collate)
 				columnWithCharset = append(columnWithCharset, col)


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2438
## 描述你的变更
- cherry-pick from main mysql v1规则问题
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 修改字符集判断逻辑，排除 "binary" 字符集

- 非空校验中跳过 BLOB 类型检查

- 新增 isBlob 函数以识别 BLOB 类型


___

### **Changes diagram**

```mermaid
flowchart LR
    A["获取列字符集信息"] --> B["排除 'binary' 字符集"]
    C["非空列校验"] --> D["新增 isBlob 函数判断 BLOB 类型"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rule.go</strong><dd><code>字符集判定与非空校验调整</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/rule/rule.go

<li>在 getColumnWithCharset 中增加过滤 "binary" 字符集条件<br> <li> 在 checkColumnNotNull 中跳过 BLOB 类型的非空检查<br> <li> 新增 isBlob 函数用于判断 BLOB 类型


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3083/files#diff-99e3ee5f0b3ed14dba8f5d47ca0b1fc7ed980287be50ca0e92b721232d237146">+15/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>