### PR TITLE
FillingSQLWithParamMarker 添加对非MySQL数据库类型的错误处理，确保遇到其他数据库类型快速返回

### DIFF
--- a/sqle/server/fillsql/fill_sql.go
+++ b/sqle/server/fillsql/fill_sql.go
@@ -27,6 +27,9 @@ const (
 )
 
 func FillingSQLWithParamMarker(sqlContent string, task *model.Task) (string, error) {
+	if task.DBType != v2.DriverTypeMySQL {
+		return sqlContent, fmt.Errorf("fill sql with param marker unsupported database type: %s, only MySQL is supported", task.DBType)
+	}
 	l := log.NewEntry()
 	driver := mysql.MysqlDriverImpl{}
 	nodes, err := driver.ParseSql(sqlContent)


### PR DESCRIPTION
### **User description**
FillingSQLWithParamMarker 添加对非MySQL数据库类型的错误处理，确保遇到其他数据库类型快速返回

## 关联的 issue
 https://github.com/actiontech/sqle-ee/issues/2464
## 描述你的变更

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 为非 MySQL 数据库快速返回错误

- 添加错误提示机制

- 提升 SQL 解析逻辑健壮性


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["原始 SQL 解析流程"] --> B["判断数据库类型"]
  B -- "非 MySQL" --> C["返回错误提示"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fill_sql.go</strong><dd><code>添加非 MySQL 错误返回处理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/server/fillsql/fill_sql.go

- 新增数据库类型判断逻辑
- 针对非 MySQL 返回错误


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3096/files#diff-594d10ca56da5c9e33cc985f7e975c2be2c6e421c9732e2e6070c97601ecb18d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

