### PR TITLE
build: remove leading and trailing spaces from PROJECT_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ ifeq ($(IS_PRODUCTION_RELEASE),true)
 # 2. if there is no tag on current commit, means that
 #    current branch is on process.
 #    Set rpm name with current branch name(release-1.2109.x-ee or release-1.2109.x -> 1.2109.x).
-    PROJECT_VERSION = $(if $(HEAD_TAG),\
+    PROJECT_VERSION = $(strip $(if $(HEAD_TAG),\
     $(shell echo $(HEAD_TAG) | sed 's/v\(.*\)/\1/'),\
-    $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1))
+    $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1)))
 else
 #    When performing daily packaging, set rpm name with current branch name(release-1.2109.x-ee or release-1.2109.x -> 1.2109.x).
-    PROJECT_VERSION = $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1)
+    PROJECT_VERSION = $(strip $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1))
 endif
 
 EDITION ?= ce


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2354#issuecomment-3149818211

## 描述你的变更
修复makefile构建流程 RPM_NAME 变量包含空格

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`

link https://github.com/actiontech/dms/pull/504


___

### **Description**
- 使用 strip 移除多余空格

- 修复项目版本拼接逻辑

- 优化 Makefile 构建流程


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Makefile 修改"] --> B["添加 strip 删除空格"]
  B --> C["确保 PROJECT_VERSION 正确"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>移除 PROJECT_VERSION 前后空格</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- 在生产分支使用 strip 包裹 HEAD_TAG 判断逻辑
- 在非生产分支统一使用 strip 移除空格


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3105/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

