### PR TITLE
fix: enable the subquery function to recognize subqueries in the FROM clause

### DIFF
--- a/sqle/driver/mysql/rule_00108_test.go
+++ b/sqle/driver/mysql/rule_00108_test.go
@@ -72,15 +72,15 @@ func TestRuleSQLE00108(t *testing.T) {
 		nil, newTestResult())
 
 	// 这个子查询中实际扫描表的子查询 只有1个，因此不算违规
-	runAIRuleCase(rule, t, "case 15: SELECT语句中使用JOIN的ON条件中嵌套子查询5层, 但是实际扫描表的子查询只有1次，因此不算违规",
+	runAIRuleCase(rule, t, "case 15: SELECT语句中使用JOIN的ON条件中嵌套子查询5层",
 		"SELECT st1.id FROM st1 JOIN st_class ON st1.cid in (SELECT cid FROM (SELECT cid FROM (SELECT cid FROM (SELECT cid FROM (SELECT cid FROM st_class WHERE cname = 'class2') AS sub1) AS sub2) AS sub3) AS sub4);",
 		session.NewAIMockContext().WithSQL("CREATE TABLE st1 (id INT, cid INT); CREATE TABLE st_class (cid INT, cname VARCHAR(50));"),
 		nil, newTestResult())
 
-	runAIRuleCase(rule, t, "case 16: SELECT语句中使用JOIN的ON条件中嵌套子查询6层, 但是实际扫描表的子查询只有2次，因此不算违规",
+	runAIRuleCase(rule, t, "case 16: SELECT语句中使用JOIN的ON条件中嵌套子查询6层, 违规",
 		"SELECT st1.id FROM st1 JOIN st_class ON st1.cid in (SELECT cid FROM (SELECT cid FROM (SELECT cid FROM (SELECT cid FROM (SELECT cid FROM st_class WHERE cname in (SELECT cname FROM st_class WHERE cname = 'class2')) AS sub1) AS sub2) AS sub3) AS sub4);",
 		session.NewAIMockContext().WithSQL("CREATE TABLE st1 (id INT, cid INT); CREATE TABLE st_class (cid INT, cname VARCHAR(50));"),
-		nil, newTestResult())
+		nil, newTestResult().addResult(ruleName))
 
 	runAIRuleCase(rule, t, "case 17: SELECT语句中 查询列中, 嵌套子查询2层",
 		"SELECT 1, st1.id, (SELECT (SELECT id0 FROM exist_db.exist_tb_1 WHERE id1 = 'value') xx2 FROM exist_db.exist_tb_1 WHERE id1 = 'value') xxx FROM st1;",

--- a/sqle/driver/mysql/rule_00109_test.go
+++ b/sqle/driver/mysql/rule_00109_test.go
@@ -71,12 +71,11 @@ func TestRuleSQLE00109(t *testing.T) {
 			WithSQL("CREATE TABLE orders_archive (id INT, amount DECIMAL(10,2));"),
 		nil, newTestResult())
 
-	// 特殊情况：解析器好像对from中嵌套的子查询 ，会被视作为属于非实际路由的子查询，因此没有累计（相当于只是个外壳嵌套而已，因此这里可以视作为不违规
-	runAIRuleCase(rule, t, "case 9: SELECT ... UNION ALL SELECT语句中的子查询使用LIMIT，但是这里子查询其实是可以直接push到外层的，可以不算做子查询",
+	runAIRuleCase(rule, t, "case 9: SELECT ... UNION ALL SELECT语句中的子查询使用LIMIT",
 		"SELECT * FROM (SELECT id FROM products LIMIT 1) AS sub UNION ALL SELECT * FROM products;",
 		session.NewAIMockContext().
 			WithSQL("CREATE TABLE products (id INT, name VARCHAR(100));"),
-		nil, newTestResult())
+		nil, newTestResult().addResult(ruleName))
 
 	runAIRuleCase(rule, t, "case 10: SELECT ... UNION ALL SELECT语句中的子查询不使用LIMIT",
 		"SELECT * FROM (SELECT id FROM products) AS sub UNION ALL SELECT * FROM products;",


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2989
## 描述你的变更

1. 添加对 FROM 子查询的支持：在原有处理 WHERE、IN 和 EXISTS 等中子查询的基础上，新增了对嵌套在 FROM 子句中的子查询的识别和处理。
2. 代码修改：对于 FROM 子句中的子查询，判断是否是 ast.TableSource 类型，并进一步检查是否包含 ast.SelectStmt。如果符合条件，将 SelectStmt 包装为 ast.SubqueryExpr 形式并统一处理。
3. 单元测试修改：之前认为"SELECT语句中使用JOIN的ON条件中嵌套子查询6层,    但是实际扫描表的子查询只有2次，因此不算违规",mysql官方文档中对子查询的定义是["子查询是嵌套在另一个SQL语句内部的SELECT语句"](https://dev.mysql.com/doc/refman/9.3/en/subqueries.html)，和是否实际扫描表无关，因此应该认为违规。

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
