### PR TITLE
fix: notify all users with permission when workflow success or failed

### DIFF
--- a/sqle/model/workflow.go
+++ b/sqle/model/workflow.go
@@ -427,6 +427,9 @@ func (w *Workflow) GetTaskIds() []uint {
 }
 
 func (w *Workflow) GetInstanceIds() []uint64 {
+	if w.Record == nil || w.Record.InstanceRecords == nil {
+		return nil
+	}
 	instanceIds := make([]uint64, len(w.Record.InstanceRecords))
 	for i, instRecord := range w.Record.InstanceRecords {
 		instanceIds[i] = instRecord.InstanceId

--- a/sqle/model/workflow.go
+++ b/sqle/model/workflow.go
@@ -426,6 +426,14 @@ func (w *Workflow) GetTaskIds() []uint {
 	return taskIds
 }
 
+func (w *Workflow) GetInstanceIds() []uint64 {
+	instanceIds := make([]uint64, len(w.Record.InstanceRecords))
+	for i, instRecord := range w.Record.InstanceRecords {
+		instanceIds[i] = instRecord.InstanceId
+	}
+	return instanceIds
+}
+
 func (w *Workflow) isExecuteStep() bool {
 	currentStep := w.CurrentStep()
 	if currentStep == nil {

--- a/sqle/notification/notification.go
+++ b/sqle/notification/notification.go
@@ -210,7 +210,7 @@ func (w *WorkflowNotification) notifyUser() []string {
 		auditUsers, err := w.getAuditUsersForWorkflowInstances()
 		if err != nil {
 			log.NewEntry().Errorf("get audit users for workflow instances error: %v", err)
-			return []string{}
+			return []string{w.workflow.CreateUserId}
 		}
 		return auditUsers
 	default:

--- a/sqle/notification/notification.go
+++ b/sqle/notification/notification.go
@@ -206,16 +206,109 @@ func (w *WorkflowNotification) notifyUser() []string {
 		}
 		// if workflow is executed, the creator and executor needs to be notified.
 	case WorkflowNotifyTypeExecuteSuccess, WorkflowNotifyTypeExecuteFail:
-		users := []string{
-			w.workflow.CreateUserId,
+		// 获取该工单对应数据源上有工单审核权限的所有用户
+		auditUsers, err := w.getAuditUsersForWorkflowInstances()
+		if err != nil {
+			log.NewEntry().Errorf("get audit users for workflow instances error: %v", err)
 		}
-		if executeUser := w.workflow.FinalStep().OperationUserId; executeUser != "" {
-			users = append(users, executeUser)
-		}
-		return users
+		return auditUsers
 	default:
 		return []string{}
 	}
+}
+
+// getAuditUsersForWorkflowInstances 获取工单对应数据源上有工单审核权限的所有用户
+func (w *WorkflowNotification) getAuditUsersForWorkflowInstances() ([]string, error) {
+	instanceIds := w.workflow.GetInstanceIds()
+	// 获取实例信息
+	instances, err := dms.GetInstancesInProjectByIds(context.Background(), string(w.workflow.ProjectId), instanceIds)
+	if err != nil {
+		return nil, fmt.Errorf("get instances by ids error: %v", err)
+	}
+	// 获取项目成员和权限信息
+	memberWithPermissions, _, err := dmsobject.ListMembersInProject(context.Background(), controller.GetDMSServerAddress(), v1.ListMembersForInternalReq{
+		ProjectUid: string(w.workflow.ProjectId),
+		PageSize:   999,
+		PageIndex:  1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list members in project error: %v", err)
+	}
+
+	// 收集所有有审核权限的用户ID
+	auditUserIds := make(map[string]struct{})
+	for _, instance := range instances {
+		// 获取该实例上有审核权限的用户
+		userIds, err := w.getCanOpInstanceUsers(memberWithPermissions, instance, []v1.OpPermissionType{v1.OpPermissionTypeAuditWorkflow})
+		if err != nil {
+			log.NewEntry().Errorf("get can op instance users error: %v", err)
+			continue
+		}
+
+		// 将用户ID添加到集合中
+		for _, user := range userIds {
+			auditUserIds[user] = struct{}{}
+		}
+	}
+	auditUserIds[w.workflow.CreateUserId] = struct{}{}
+	// 转换为字符串切片
+	result := make([]string, 0, len(auditUserIds))
+	for userId := range auditUserIds {
+		result = append(result, userId)
+	}
+	return result, nil
+}
+
+// getCanOpInstanceUsers 获取实例上有指定权限的用户
+func (w *WorkflowNotification) getCanOpInstanceUsers(memberWithPermissions []*v1.ListMembersForInternalItem, instance *model.Instance, opPermissions []v1.OpPermissionType) (userIds []string, err error) {
+	opMapUsers := make(map[string]struct{}, 0)
+	for _, memberWithPermission := range memberWithPermissions {
+		for _, memberOpPermission := range memberWithPermission.MemberOpPermissionList {
+			if w.CanOperationInstance([]v1.OpPermissionItem{memberOpPermission}, opPermissions, instance) {
+				userId := memberWithPermission.User.Uid
+				if _, ok := opMapUsers[userId]; !ok {
+					opMapUsers[userId] = struct{}{}
+					userIds = append(userIds, userId)
+				}
+			}
+		}
+	}
+	return userIds, nil
+}
+
+func (w *WorkflowNotification) CanOperationInstance(userOpPermissions []v1.OpPermissionItem, needOpPermissionTypes []v1.OpPermissionType, instance *model.Instance) bool {
+	for _, userOpPermission := range userOpPermissions {
+		// 全局操作权限用户
+		if userOpPermission.OpPermissionType == v1.OpPermissionTypeGlobalManagement {
+			return true
+		}
+
+		// 项目管理员可以访问所有数据源
+		if userOpPermission.OpPermissionType == v1.OpPermissionTypeProjectAdmin {
+			return true
+		}
+
+		// 动作权限(创建、审核、上线工单等)
+		hasPrivilege := false
+		for _, needOpPermissionType := range needOpPermissionTypes {
+			if needOpPermissionType == userOpPermission.OpPermissionType {
+				hasPrivilege = true
+				break
+			}
+		}
+		if !hasPrivilege {
+			continue
+		}
+		// 对象权限(指定数据源)
+		if userOpPermission.RangeType == v1.OpRangeTypeDBService {
+			for _, id := range userOpPermission.RangeUids {
+				if id == instance.GetIDStr() {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func notifyWorkflowWebhook(workflow *model.Workflow, wt WorkflowNotifyType) {

--- a/sqle/notification/notification.go
+++ b/sqle/notification/notification.go
@@ -210,6 +210,7 @@ func (w *WorkflowNotification) notifyUser() []string {
 		auditUsers, err := w.getAuditUsersForWorkflowInstances()
 		if err != nil {
 			log.NewEntry().Errorf("get audit users for workflow instances error: %v", err)
+			return []string{}
 		}
 		return auditUsers
 	default:


### PR DESCRIPTION
### **User description**
link https://github.com/actiontech/dms-ee/pull/651
## 关联的 issue
https://github.com/actiontech/dms-ee/issues/597#issuecomment-3191071930
## 描述你的变更
- SQL工单上线成功/失败需要通知所有在该数据源上有权限的人
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 添加获取实例ID方法

- 优化成功/失败通知逻辑

- 新增审核权限用户过滤功能


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow对象"] --> B["GetInstanceIds方法"]
  B --> C["getAuditUsersForWorkflowInstances"]
  C --> D["getCanOpInstanceUsers"]
  D --> E["CanOperationInstance"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow.go</strong><dd><code>添加获取 Workflow 实例 ID 方法</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/model/workflow.go

- 新增 GetInstanceIds 方法，提取 workflow 实例 ID
- 针对空记录进行 nil 检查


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3112/files#diff-d94f236664e1fd810e77c57c7ebde41e6467546a8bee1ad14d4617a83d897ff6">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>notification.go</strong><dd><code>优化工单通知逻辑及审核权限判断</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/notification/notification.go

<ul><li>修改执行成功/失败通知，通知有审核权限用户<br> <li> 新增 getAuditUsersForWorkflowInstances 辅助函数获取数据源对应实例<br> <li> 新增 getCanOpInstanceUsers 方法，过滤具有审核权限的用户<br> <li> 添加 CanOperationInstance 方法进行权限判断</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3112/files#diff-71c5b5a353e5daec95a583409966cc3a4f25acad0328fd226dede7db7b56101e">+100/-6</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

