### PR TITLE
refactor(rule): remove redundant regex patterns in event SQL detection

### DIFF
--- a/sqle/driver/mysql/rule/rule.go
+++ b/sqle/driver/mysql/rule/rule.go
@@ -5434,9 +5434,15 @@ func avoidSet(input *RuleHandlerInput) error {
 }
 
 func checkEventScheduler(input *RuleHandlerInput) error {
-	if utils.IsOpenEventScheduler(input.Node.Text()) ||
-		utils.IsEventSQL(input.Node.Text()) {
+	if utils.IsOpenEventScheduler(input.Node.Text()) {
 		addResult(input.Res, input.Rule, input.Rule.Name)
 	}
+	switch input.Node.(type) {
+	case *ast.UnparsedStmt:
+		if utils.IsEventSQL(input.Node.Text()) {
+			addResult(input.Res, input.Rule, input.Rule.Name)
+		}
+	}
+
 	return nil
 }

--- a/sqle/utils/util.go
+++ b/sqle/utils/util.go
@@ -216,9 +216,9 @@ func IsOpenEventScheduler(sql string) bool {
 
 // TODO: 暂时使用正则表达式匹配event，后续会修改语法树进行匹配event
 func IsEventSQL(sql string) bool {
-	createPattern := `^CREATE\s+(DEFINER\s?=.+?)?EVENT`
+	createPattern := `CREATE\s+(DEFINER\s?=.+?)?EVENT`
 	createRe := regexp.MustCompile(createPattern)
-	alterPattern := `^ALTER\s+(DEFINER\s?=.+?)?EVENT`
+	alterPattern := `ALTER\s+(DEFINER\s?=.+?)?EVENT`
 	alterRe := regexp.MustCompile(alterPattern)
 
 	sql = strings.ToUpper(strings.TrimSpace(sql))


### PR DESCRIPTION

## 关联的 issue
https://github.com/actiontech/sqle/issues/2049#issuecomment-3209488978

## 描述你的变更
调整“禁止使用event”规则的正则表达式，使之可以匹配包含调整分隔符语句的情况

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------

assign in @LordofAvernus 