### PR TITLE
fix: mismatching between pipeline permissions and actual obtained values

### DIFF
--- a/sqle/api/controller/v1/pipeline.go
+++ b/sqle/api/controller/v1/pipeline.go
@@ -3,10 +3,10 @@ package v1
 import (
 	"context"
 	"fmt"
-	v1 "github.com/actiontech/dms/pkg/dms-common/api/dms/v1"
-	"github.com/actiontech/sqle/sqle/errors"
 	"net/http"
 	"strconv"
+
+	"github.com/actiontech/sqle/sqle/errors"
 
 	"github.com/actiontech/sqle/sqle/api/controller"
 	"github.com/actiontech/sqle/sqle/dms"
@@ -234,19 +234,10 @@ func GetPipelines(c echo.Context) error {
 	if err != nil {
 		return errors.New(errors.ConnectStorageError, fmt.Errorf("check get pipelines failed: %v", err))
 	}
-	userId := ""
-	if !userPermission.CanViewProject() {
-		userId = user.GetIDStr()
-	}
-	rangeDatasourceIds := make([]string, 0)
-	viewPipelinePermission := userPermission.GetOnePermission(v1.OpPermissionViewPipeline)
-	if viewPipelinePermission != nil {
-		userId = ""
-		rangeDatasourceIds = viewPipelinePermission.RangeUids
-	}
-	// 4. 获取存储对象并查询流水线列表
+
+	// 3. 获取存储对象并查询流水线列表
 	var pipelineSvc pipeline.PipelineSvc
-	count, pipelineList, err := pipelineSvc.GetPipelineList(limit, offset, req.FuzzySearchNameDesc, projectUid, userId, rangeDatasourceIds)
+	count, pipelineList, err := pipelineSvc.GetPipelineListWithPermission(limit, offset, req.FuzzySearchNameDesc, projectUid, userPermission, user.GetIDStr())
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}


### PR DESCRIPTION
## 关联的 issue
ISSUE https://github.com/actiontech/sqle/issues/3140
TEST https://github.com/actiontech/sqle/issues/3140#issuecomment-3450641750
## 描述你的变更
1. 问题修复：修复用户看不到自己创建的流水线的问题，经确认，查看流水线的权限逻辑如下：

    - 超级管理员或项目管理员：可以查看项目中的所有流水线
    - 拥有"查看流水线"权限的普通用户：可以查看指定数据源相关的流水线 + 自己创建的所有流水线
    - 普通用户：只能查看自己创建的流水线

2. 增加代码可读性：在代码中显式地区分不同类型权限
3. 性能优化：解决了查询流水线节点的1+N多次查询的问题

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [X] 我已完成自测
- [X] 我已记录完整日志方便进行诊断
- [X] 我已在关联的issue里补充了实现方案
- [X] 我已在关联的issue里补充了测试影响面
- [X] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [X] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
