### PR TITLE
feat(git): add newCloneOptions function and corresponding tests for Git clone options

### DIFF
--- a/sqle/api/controller/v1/configuration.go
+++ b/sqle/api/controller/v1/configuration.go
@@ -477,19 +477,12 @@ func CloneGitRepository(ctx context.Context, url, username, password, branch str
 		return os.RemoveAll(directory)
 	}
 
-	cloneOpts := &git.CloneOptions{
-		URL:             url,
-		InsecureSkipTLS: true, // 跳过 SSL 证书验证,支持自签名证书
-	}
-	if branch != "" {
-		cloneOpts.ReferenceName = plumbing.ReferenceName(branch)
-	}
-
 	auth, err := getGitAuthMethod(url, username, password)
 	if err != nil {
 		return nil, "", cleanup, err
 	}
-	cloneOpts.Auth = auth
+
+	cloneOpts := newCloneOptions(url, branch, auth)
 
 	repository, err = git.PlainCloneContext(ctx, directory, false, cloneOpts)
 	if err != nil {
@@ -497,6 +490,23 @@ func CloneGitRepository(ctx context.Context, url, username, password, branch str
 	}
 
 	return repository, directory, cleanup, nil
+}
+
+const shallowCloneDepth = 1
+
+func newCloneOptions(url, branch string, auth transport.AuthMethod) *git.CloneOptions {
+	cloneOpts := &git.CloneOptions{
+		URL:             url,
+		Auth:            auth,
+		Depth:           shallowCloneDepth,
+		InsecureSkipTLS: true, // 跳过 SSL 证书验证,支持自签名证书
+	}
+	if branch != "" {
+		cloneOpts.ReferenceName = plumbing.ReferenceName(branch)
+		cloneOpts.SingleBranch = true
+	}
+
+	return cloneOpts
 }
 
 type TestGitConnectionReqV1 struct {

--- a/sqle/api/controller/v1/configuration_test.go
+++ b/sqle/api/controller/v1/configuration_test.go
@@ -1,0 +1,45 @@
+package v1
+
+import (
+	"testing"
+)
+
+func TestNewCloneOptionsWithoutBranch(t *testing.T) {
+	cloneOpts := newCloneOptions("https://example.com/test.git", "", nil)
+
+	if cloneOpts.URL != "https://example.com/test.git" {
+		t.Fatalf("unexpected clone url: %s", cloneOpts.URL)
+	}
+	if cloneOpts.Depth != shallowCloneDepth {
+		t.Fatalf("unexpected clone depth: %d", cloneOpts.Depth)
+	}
+	if !cloneOpts.InsecureSkipTLS {
+		t.Fatal("expected InsecureSkipTLS to be true")
+	}
+	if cloneOpts.SingleBranch {
+		t.Fatal("expected SingleBranch to be false when branch is empty")
+	}
+	if cloneOpts.ReferenceName.String() != "" {
+		t.Fatalf("unexpected reference name: %s", cloneOpts.ReferenceName.String())
+	}
+}
+
+func TestNewCloneOptionsWithBranch(t *testing.T) {
+	cloneOpts := newCloneOptions("https://example.com/test.git", "refs/heads/main", nil)
+
+	if cloneOpts.URL != "https://example.com/test.git" {
+		t.Fatalf("unexpected clone url: %s", cloneOpts.URL)
+	}
+	if cloneOpts.Depth != shallowCloneDepth {
+		t.Fatalf("unexpected clone depth: %d", cloneOpts.Depth)
+	}
+	if !cloneOpts.InsecureSkipTLS {
+		t.Fatal("expected InsecureSkipTLS to be true")
+	}
+	if !cloneOpts.SingleBranch {
+		t.Fatal("expected SingleBranch to be true when branch is provided")
+	}
+	if cloneOpts.ReferenceName.String() != "refs/heads/main" {
+		t.Fatalf("unexpected reference name: %s", cloneOpts.ReferenceName.String())
+	}
+}


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle/issues/3220
## 描述你的变更
使用浅克隆减少审核仓库耗时
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 使用浅克隆降低仓库克隆数据量

- 新增 newCloneOptions 函数以复用克隆配置

- 配置单分支克隆以减少不必要数据

- 添加单元测试确保配置正确


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["配置克隆选项"] -- "调用newCloneOptions" --> B["设置浅克隆深度与TLS选项"]
  B -- "判断分支" --> C["设置SingleBranch与ReferenceName"]
  C -- "传递给PlainCloneContext" --> D["执行仓库克隆"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.go</strong><dd><code>重构Git克隆配置以使用浅克隆</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/api/controller/v1/configuration.go

- 替换原始克隆配置
- 使用 newCloneOptions 生成克隆选项
- 设置浅克隆深度为1
- 对存在分支时启用单分支克隆


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3221/files#diff-59cc77e3c15c339627c09f862b3979d8216a05c768a3822ae6d52988cc5a9e33">+19/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration_test.go</strong><dd><code>为newCloneOptions添加单元测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/api/controller/v1/configuration_test.go

<ul><li>添加无分支下的 newCloneOptions 测试<br> <li> 添加有分支下的 newCloneOptions 测试<br> <li> 验证浅克隆深度和单分支配置</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3221/files#diff-b9ebce0fece0f4e17e4befa9e81fcddf8a09f61ad9d9f5fe3bf3fc17829ba23d">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

