### PR TITLE
fix：Handle SQL audit failures by soft-deleting the audit record and m…

### DIFF
--- a/sqle/api/controller/v1/sql_audit_record.go
+++ b/sqle/api/controller/v1/sql_audit_record.go
@@ -167,6 +167,9 @@ func CreateSQLAuditRecord(c echo.Context) error {
 
 	task, err = server.GetSqled().AddTaskWaitResult(projectUid, fmt.Sprintf("%d", task.ID), server.ActionTypeAudit)
 	if err != nil {
+		if txrr := s.HandleSQLAuditFailure(&record); txrr != nil {
+			return controller.JSONBaseErrorReq(c, fmt.Errorf("audit task execute failed %v, rollback sql audit record failed: %v", err, txrr))
+		}
 		return controller.JSONBaseErrorReq(c, err)
 	}
 

--- a/sqle/model/sql_audit_record.go
+++ b/sqle/model/sql_audit_record.go
@@ -66,3 +66,17 @@ func (s *Storage) GetSQLAuditRecordById(projectId string, SQLAuditRecordId strin
 	}
 	return record, true, nil
 }
+
+func (s *Storage) HandleSQLAuditFailure(record *SQLAuditRecord) error {
+	if record == nil {
+		return errors.New(errors.DataInvalid, fmt.Errorf("sql audit record is nil"))
+	}
+
+	if err := s.Delete(record); err != nil {
+		return err
+	}
+	if err := s.UpdateTaskStatusById(record.TaskId, TaskStatusExecuteFailed); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
### **User description**
…arking the associated task as exec_failed without using a transaction.

## 关联的 issue
https://github.com/actiontech/sqle/issues/3245
## 描述你的变更
新增 ProcessSQLAuditFailed 失败处理逻辑：当 SQL 审核流程失败时，执行软删除对应的 SQLAuditRecord，并将关联 Task 状态更新为 exec_failed，避免保留“可见但无效”的审核记录。
## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------


___

### **Description**
- 增加审核失败错误处理逻辑

- 新增软删除审核记录策略

- 更新任务状态为执行失败


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Controller: 任务创建失败"] -- "调用HandleSQLAuditFailure" --> B["Model: 执行软删除操作"]
  B -- "更新任务状态" --> C["将任务状态设为exec_failed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_audit_record.go</strong><dd><code>处理审核失败错误逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/api/controller/v1/sql_audit_record.go

- 在任务执行失败时调用`HandleSQLAuditFailure`
- 返回详细错误提示信息


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3246/files#diff-b08f2ce9cc6fbbfb37b43b37b25e7ac6cb5246127d14eec7eb5b5465877f0f85">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_audit_record.go</strong><dd><code>新增SQL审核失败处理函数</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/model/sql_audit_record.go

- 新增`HandleSQLAuditFailure`函数
- 实施软删除审核记录和更新任务状态


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3246/files#diff-1a85851855586cee58f96035aa3fea75cad80df06faefe46a1118e6a979ea21e">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

