### PR TITLE
feat(server): support PostgreSQL connection termination detection

### DIFF
--- a/sqle/server/sqled.go
+++ b/sqle/server/sqled.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/actiontech/sqle/sqle/dms"
 	"github.com/actiontech/sqle/sqle/driver"
 	"github.com/actiontech/sqle/sqle/utils"
-	"github.com/go-sql-driver/mysql"
 
 	_ "github.com/actiontech/sqle/sqle/driver/mysql"
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
@@ -264,6 +264,37 @@ func (a *action) terminatedFailed() {
 	a.Lock()
 	a.terminateStatus = statusTerminateFailed
 	a.Unlock()
+}
+
+// isConnectionTerminatedError 判断执行错误是否由连接终止操作导致。
+// 该函数通过匹配错误消息字符串来识别各种数据库驱动的连接终止错误。
+// 支持的错误模式：
+//   - MySQL: "invalid connection" (mysql.ErrInvalidConn 的 Error() 输出)
+//   - PostgreSQL: "57P01" (SQLSTATE admin_shutdown，pg_terminate_backend 触发)
+//   - PostgreSQL: "conn closed" (pgconn 连接已关闭状态)
+func isConnectionTerminatedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	// MySQL: 连接被 KILL 命令终止后，mysql 驱动返回 ErrInvalidConn，
+	// 其 Error() 为 "invalid connection"。错误可能经过 CodeError 或 fmt.Errorf 包装，
+	// 但包装后的字符串仍包含 "invalid connection"。
+	if strings.Contains(errMsg, "invalid connection") {
+		return true
+	}
+	// PostgreSQL: 连接被 pg_terminate_backend 终止后，pgx 驱动返回 PgError，
+	// 其 SQLSTATE 为 57P01 (admin_shutdown)。错误经过 gRPC 传输后以字符串形式保留。
+	// 典型格式: "FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"
+	if strings.Contains(errMsg, "57P01") {
+		return true
+	}
+	// PostgreSQL: 连接已被标记为关闭状态后，后续操作返回 "conn closed"。
+	// 这是 pgconn 的 connLockError 错误，在连接被终止后尝试复用时出现。
+	if strings.Contains(errMsg, "conn closed") {
+		return true
+	}
+	return false
 }
 
 var (
@@ -653,7 +684,7 @@ func (a *action) executeSQLBatch(executeSQLs []*model.ExecuteSQL) error {
 		for idx, executeSQL := range executeSQLs {
 			executeSQL.ExecStatus = model.SQLExecuteStatusFailed
 			executeSQL.ExecResult = execErr.Error()
-			if a.hasTermination() && _errors.Is(mysql.ErrInvalidConn, execErr) {
+			if a.hasTermination() && isConnectionTerminatedError(execErr) {
 				executeSQL.ExecStatus = model.SQLExecuteStatusTerminateSucc
 				if idx >= len(results) || results[idx] == nil {
 					continue
@@ -690,7 +721,7 @@ func (a *action) execSQL(executeSQL *model.ExecuteSQL) error {
 	if execErr != nil {
 		executeSQL.ExecStatus = model.SQLExecuteStatusFailed
 		executeSQL.ExecResult = execErr.Error()
-		if a.hasTermination() && _errors.Is(mysql.ErrInvalidConn, execErr) {
+		if a.hasTermination() && isConnectionTerminatedError(execErr) {
 			executeSQL.ExecStatus = model.SQLExecuteStatusTerminateSucc
 		}
 	} else {
@@ -731,7 +762,7 @@ func (a *action) execSQLs(executeSQLs []*model.ExecuteSQL) error {
 		if txErr != nil {
 			executeSQL.ExecStatus = model.SQLExecuteStatusFailed
 			executeSQL.ExecResult = txErr.Error()
-			if a.hasTermination() && _errors.Is(mysql.ErrInvalidConn, txErr) {
+			if a.hasTermination() && isConnectionTerminatedError(txErr) {
 				executeSQL.ExecStatus = model.SQLExecuteStatusTerminateSucc
 			}
 			continue
@@ -740,6 +771,9 @@ func (a *action) execSQLs(executeSQLs []*model.ExecuteSQL) error {
 			if results.ExecErr.ErrSqlIndex == uint32(idx) {
 				executeSQL.ExecStatus = model.SQLExecuteStatusFailed
 				executeSQL.ExecResult = results.ExecErr.SqlExecErrMsg
+				if a.hasTermination() && isConnectionTerminatedError(fmt.Errorf(results.ExecErr.SqlExecErrMsg)) {
+					executeSQL.ExecStatus = model.SQLExecuteStatusTerminateSucc
+				}
 			} else {
 				executeSQL.ExecStatus = model.SQLExecuteStatusFailed
 				executeSQL.ExecResult = model.TaskExecResultRollback

--- a/sqle/server/sqled_terminate_test.go
+++ b/sqle/server/sqled_terminate_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isConnectionTerminatedError(t *testing.T) {
+	tests := map[string]struct {
+		err      error
+		expected bool
+	}{
+		// ===== MySQL 终止错误 (正向匹配) =====
+		"MySQL: raw ErrInvalidConn message": {
+			err:      fmt.Errorf("invalid connection"),
+			expected: true,
+		},
+		"MySQL: ErrInvalidConn wrapped in CodeError": {
+			err:      fmt.Errorf("connect remote database error: invalid connection"),
+			expected: true,
+		},
+		"MySQL: ErrInvalidConn wrapped in ExecBatch format": {
+			err:      fmt.Errorf("exec sql failed: \nSELECT 1 \ninvalid connection"),
+			expected: true,
+		},
+		"MySQL: ErrInvalidConn through gRPC": {
+			err:      fmt.Errorf("rpc error: code = Unknown desc = invalid connection"),
+			expected: true,
+		},
+
+		// ===== PostgreSQL 终止错误 (正向匹配) =====
+		"PostgreSQL: 57P01 admin_shutdown from pgx": {
+			err:      fmt.Errorf("FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"),
+			expected: true,
+		},
+		"PostgreSQL: 57P01 through gRPC": {
+			err:      fmt.Errorf("rpc error: code = Unknown desc = FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"),
+			expected: true,
+		},
+		"PostgreSQL: 57P01 wrapped in driver adaptor": {
+			err:      fmt.Errorf("exec sql in driver adaptor: FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"),
+			expected: true,
+		},
+		"PostgreSQL: conn closed": {
+			err:      fmt.Errorf("conn closed"),
+			expected: true,
+		},
+		"PostgreSQL: conn closed through gRPC": {
+			err:      fmt.Errorf("rpc error: code = Unknown desc = conn closed"),
+			expected: true,
+		},
+
+		// ===== 非终止错误 (反向匹配，不应误判) =====
+		"nil error": {
+			err:      nil,
+			expected: false,
+		},
+		"syntax error": {
+			err:      fmt.Errorf("ERROR: syntax error at or near \"SELECTT\" (SQLSTATE 42601)"),
+			expected: false,
+		},
+		"permission denied": {
+			err:      fmt.Errorf("ERROR: permission denied for table users (SQLSTATE 42501)"),
+			expected: false,
+		},
+		"connection refused": {
+			err:      fmt.Errorf("connection refused"),
+			expected: false,
+		},
+		"context deadline exceeded": {
+			err:      fmt.Errorf("context deadline exceeded"),
+			expected: false,
+		},
+		"generic exec error": {
+			err:      fmt.Errorf("exec sql failed: ERROR: relation \"nonexistent\" does not exist"),
+			expected: false,
+		},
+		"unique constraint violation": {
+			err:      fmt.Errorf("ERROR: duplicate key value violates unique constraint (SQLSTATE 23505)"),
+			expected: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := isConnectionTerminatedError(tc.err)
+			assert.Equal(t, tc.expected, result, "case: %s", name)
+		})
+	}
+}


### PR DESCRIPTION
### **User description**
## Summary

- Replace MySQL-specific `_errors.Is(mysql.ErrInvalidConn, execErr)` with unified `isConnectionTerminatedError` function
- Support PostgreSQL termination detection via string matching on error messages ("57P01" SQLSTATE and "conn closed")
- Add termination detection for `execSQLs` ExecErr branch (covers SQL execution-time termination in transaction mode)
- Remove direct dependency on `github.com/go-sql-driver/mysql` package in sqled.go

## Test plan

- [x] Unit tests: 16 cases covering MySQL positive (4), PostgreSQL positive (5), and negative matches (7)
- [x] `go build ./sqle/server/...` passes
- [x] `go vet ./sqle/server/...` passes
- [x] `go test -run Test_isConnectionTerminatedError ./sqle/server/...` all PASS

Closes https://github.com/actiontech/sqle-ee/issues/2727


___

### **Description**
- 添加统一的连接终止错误检测函数

- 使用字符串匹配支持 MySQL 与 PostgreSQL

- 替换原有 mysql 包错误检测逻辑

- 新增单元测试覆盖多种错误场景


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["\"sqled.go 文件修改\""] -- "新增统一检测函数" --> B["\"添加 isConnectionTerminatedError\""]
  B -- "替换旧错误判断" --> C["\"修改 SQL 执行流程\""]
  C -- "新增测试覆盖" --> D["\"新增单元测试文件\""]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sqled.go</strong><dd><code>修改 SQL 执行中的连接终止错误检测</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/server/sqled.go

<ul><li>引入字符串库以支持错误匹配<br> <li> 新增 isConnectionTerminatedError 函数及详细注释<br> <li> 修改 executeSQLBatch、execSQL、execSQLs 错误判断逻辑</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3266/files#diff-3b6067d3682f8b6ade9eb58b4588afc0a12adbf6ea744a5453d7f22beb73eee0">+38/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sqled_terminate_test.go</strong><dd><code>新增连接终止错误检测单元测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/server/sqled_terminate_test.go

- 新增单元测试文件检测连接终止错误
- 包含 MySQL 与 PostgreSQL 多场景测试用例


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3266/files#diff-bba94ce99288aed6a1b5cb16e0d87e917ff5b2137eb2481c3fb36aacef3b4d5d">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

