### PR TITLE
fix(compare): add String() cases for database compare OptionalModules

### DIFF
--- a/sqle/driver/v2/util.go
+++ b/sqle/driver/v2/util.go
@@ -82,6 +82,10 @@ func (m OptionalModule) String() string {
 		return "ExecBatch"
 	case OptionalModuleI18n:
 		return "I18n"
+	case OptionalGetDatabaseObjectDDL:
+		return "GetDatabaseObjectDDL"
+	case OptionalGetDatabaseDiffModifySQL:
+		return "GetDatabaseDiffModifySQL"
 	case OptionalBackup:
 		return "Backup"
 	default:


### PR DESCRIPTION
### **User description**
## Summary

- Add `OptionalGetDatabaseObjectDDL` and `OptionalGetDatabaseDiffModifySQL` cases to `OptionalModule.String()` so capability-check error messages use human-readable module names instead of raw numeric values.
- Part of the database structure comparison OB Oracle support work.

Fixes https://github.com/actiontech/sqle-ee/issues/2747


___

### **Description**
- 新增GetDatabaseObjectDDL枚举转换

- 新增GetDatabaseDiffModifySQL枚举转换


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OptionalModule.String()"] --> B["添加GetDatabaseObjectDDL转换"]
  A --> C["添加GetDatabaseDiffModifySQL转换"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>新增枚举字符串转换case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/v2/util.go

- 添加两个case语句返回新枚举字符串值
- 保持其他逻辑不变


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3274/files#diff-b155962b27c72b7fac034c0399d4c768078776145a1343003c9a270527d3d3f6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

