### PR TITLE
fix(backup): 使用ConvertProtoBackupStrategyToDriver替代String()转换备份策略 #2779

### DIFF
--- a/sqle/driver/v2/driver_grpc_server.go
+++ b/sqle/driver/v2/driver_grpc_server.go
@@ -115,7 +115,7 @@ func (d *DriverGrpcServer) Backup(ctx context.Context, req *protoV2.BackupReq) (
 		return &protoV2.BackupRes{}, err
 	}
 	res, err := driver.Backup(ctx, &BackupReq{
-		BackupStrategy: req.BackupStrategy.String(),
+		BackupStrategy: ConvertProtoBackupStrategyToDriver(req.BackupStrategy),
 		Sql:            req.Sql,
 		BackupMaxRows:  req.BackupMaxRows,
 	})


### PR DESCRIPTION
### **User description**
## Summary
- 修复 gRPC 服务端 Backup 方法中备份策略转换使用 String() 导致的策略值不匹配问题，改用 ConvertProtoBackupStrategyToDriver 进行正确的 proto 到 driver 层策略转换

https://github.com/actiontech/sqle-ee/issues/2779


___

### **Description**
- 修正备份策略转换逻辑

- 使用 ConvertProtoBackupStrategyToDriver 函数进行转换

- 确保 proto 枚举值正确映射到 driver 字符串


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["传入 proto 备份策略"] -- "调用转换函数" --> B["转换为 driver 格式"]
  B -- "用于备份操作" --> C["备份请求正确处理"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver_grpc_server.go</strong><dd><code>使用转换函数替换原有备份策略转换方式</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/v2/driver_grpc_server.go

<ul><li>替换 req.BackupStrategy.String() 为 <br>ConvertProtoBackupStrategyToDriver(req.BackupStrategy)<br> <li> 保障备份策略转换正确性</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3283/files#diff-ae435779ec5743f12cf2f7546bbb49bc1d2369049c8cf57fd0725148b5aa28b9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

