### PR TITLE
fix: initialize I18nAuditResultInfo map in AuditHandler.Audit to prev…

### DIFF
--- a/sqle/pkg/driver/builder.go
+++ b/sqle/pkg/driver/builder.go
@@ -8,6 +8,7 @@ import (
 	driverV2 "github.com/actiontech/sqle/sqle/driver/v2"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/pkg/errors"
+	"golang.org/x/text/language"
 )
 
 type RawSQLRuleHandler func(ctx context.Context, rule *driverV2.Rule, rawSQL string, nextSQL []string) (i18nPkg.I18nStr, error)
@@ -21,7 +22,9 @@ type AuditHandler struct {
 }
 
 func (a *AuditHandler) Audit(ctx context.Context, rule *driverV2.Rule, sql string, nextSQL []string) (*driverV2.AuditResult, error) {
-	result := &driverV2.AuditResult{}
+	result := &driverV2.AuditResult{
+		I18nAuditResultInfo: make(map[language.Tag]driverV2.AuditResultInfo),
+	}
 	message := i18nPkg.I18nStr{}
 	var err error
 


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2804
## 描述你的变更
修复：在 AuditHandler.Audit 中初始化 I18nAuditResultInfo map，以防止出现 nil panic。

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
assign in @LordofAvernus


___

### **Description**
- 在 Audit 方法中初始化 I18nAuditResultInfo map

- 防止因 nil map 导致 panic

- 新增对 language 包的依赖


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AuditHandler.Audit 方法"] -- "初始化 I18nAuditResultInfo map" --> B["防止 nil panic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>builder.go</strong><dd><code>初始化 I18nAuditResultInfo 避免 nil panic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/pkg/driver/builder.go

<ul><li>在构造 driverV2.AuditResult 时初始化 I18nAuditResultInfo map<br> <li> 新增对 golang.org/x/text/language 包的导入</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3287/files#diff-4c75ad94a058093aa672c04b9f6d131584b74dcafed0f868b3efcbee406fd706">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

