### PR TITLE
fix(dms): tolerate empty SQLEConfig/RuleTemplateID in convertInstance (sqle-ee#2815)

### DIFF
--- a/sqle/dms/instance.go
+++ b/sqle/dms/instance.go
@@ -83,9 +83,15 @@ func convertInstance(instance *dmsV2.ListDBService) (*model.Instance, error) {
 		return nil, err
 	}
 
-	ruleTemplateId, err := strconv.ParseInt(instance.SQLEConfig.RuleTemplateID, 0, 64)
-	if err != nil {
-		return nil, err
+	// RuleTemplateID may be empty when the data source has no SQLE rule template
+	// configured. In that case, fall back to 0 instead of failing with a ParseInt
+	// error so that single-instance lookups (e.g. /schemas, /tables) keep working.
+	var ruleTemplateId int64
+	if instance.SQLEConfig != nil && instance.SQLEConfig.RuleTemplateID != "" {
+		ruleTemplateId, err = strconv.ParseInt(instance.SQLEConfig.RuleTemplateID, 0, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var maintenancePeriod = make(model.Periods, 0)
@@ -127,12 +133,16 @@ func convertInstance(instance *dmsV2.ListDBService) (*model.Instance, error) {
 		environmentTagUID = instance.EnvironmentTag.UID
 		environmentTagName = instance.EnvironmentTag.Name
 	}
+	var ruleTemplateName string
+	if instance.SQLEConfig != nil {
+		ruleTemplateName = instance.SQLEConfig.RuleTemplateName
+	}
 	return &model.Instance{
 		ID:                 uint64(instanceId),
 		Name:               instance.Name,
 		DbType:             instance.DBType,
 		RuleTemplateId:     uint64(ruleTemplateId),
-		RuleTemplateName:   instance.SQLEConfig.RuleTemplateName,
+		RuleTemplateName:   ruleTemplateName,
 		ProjectId:          instance.ProjectUID,
 		MaintenancePeriod:  maintenancePeriod,
 		Host:               instance.Host,


### PR DESCRIPTION
### **User description**
## 问题

`GET /sqle/v1/projects/{project_name}/instances/{instance_name}/schemas` 等单实例接口在目标数据源未配置 SQLE 规则模板（`sqle_config.rule_template_id` 为空）时返回：

```json
{"code":-1,"message":"convert instance error: strconv.ParseInt: parsing \"\": invalid syntax"}
```

## 根因 & 修复

`sqle/dms/instance.go` 的 `convertInstance` 单实例路径在 `SQLEConfig` 为 `nil` 或 `RuleTemplateID` 为空时仍直接 `strconv.ParseInt`，必然失败；且 `SQLEConfig.RuleTemplateName` 缺 nil 守卫会 panic。

- 跳过空 `RuleTemplateID` 的 `ParseInt`，兜底为 0。
- 访问 `RuleTemplateName` 前做 `SQLEConfig` nil 检查。

## 关联

- EE 对应 PR：actiontech/sqle-ee#2873
- EE Issue：actiontech/sqle-ee#2815
- 同步说明：本 commit 仅含 CE 文件（`sqle/dms/instance.go`），无 vendor 改动。


___

### **Description**
- 修复空 RuleTemplateID 解析错误问题

- 增加 SQLEConfig nil 检查防止 panic

- 改进单实例查询的容错性


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["检查 SQLEConfig 是否为空"] -- "为空时" --> B["设置 RuleTemplateId 为 0"]
  A -- "不为空且 RuleTemplateID 非空" --> C["解析 RuleTemplateID"]
  A -- "不为空" --> D["安全读取 RuleTemplateName"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>instance.go</strong><dd><code>增加空值检查与错误容错逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/dms/instance.go

<ul><li>添加对空 RuleTemplateID 的判定和默认处理<br> <li> 对 SQLEConfig 进行 nil 检查，防止直接访问产生 panic<br> <li> 修改获取 RuleTemplateName 的逻辑以增加健壮性</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3300/files#diff-6204bd1849099215a0f3da9647aaaebc142b2e037248431c599414f6f454f9d4">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

