### PR TITLE
fix(mysql): enable window function parsing for data export sql_type

### DIFF
--- a/sqle/driver/mysql/mysql_test.go
+++ b/sqle/driver/mysql/mysql_test.go
@@ -38,6 +38,12 @@ WHERE last_name = 'Smith';`)
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 1)
 	assert.Equal(t, nodes[0].Type, driverV2.SQLTypeDML)
+
+	nodes, err = DefaultMysqlInspect().Parse(context.TODO(),
+		"SELECT id, ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary) AS rn FROM emp")
+	assert.NoError(t, err)
+	assert.Len(t, nodes, 1)
+	assert.Equal(t, driverV2.SQLTypeDQL, nodes[0].Type)
 }
 
 func TestInspect_onlineddlWithGhost(t *testing.T) {
@@ -208,6 +214,11 @@ CREATE TABLE new_tbl AS SELECT * FROM orig_tbl;`,
 			`
 CREATEaa TABLE new_tbl AS SELECT * FROM orig_tbl;`,
 			driverV2.SQLTypeDDL,
+		},
+		{
+			"case 8 window function select",
+			`SELECT id, ROW_NUMBER() OVER (PARTITION BY nominate_app_id ORDER BY create_date ASC) AS rn FROM sourcing.tt_nomi_record`,
+			driverV2.SQLTypeDQL,
 		},
 	}
 	i := &MysqlDriverImpl{}

--- a/sqle/driver/mysql/rule_00082_test.go
+++ b/sqle/driver/mysql/rule_00082_test.go
@@ -74,20 +74,20 @@ func TestRuleSQLE00082(t *testing.T) {
 			},
 		}, newTestResult())
 
-	// case 5: SELECT 语句使用窗口函数可能触发 filesort // TODO 当前解析器解析不了此语法
-	// runAIRuleCase(rule, t, "case 5: SELECT 语句使用窗口函数可能触发 filesort",
-	// 	"SELECT age FROM (SELECT age, ROW_NUMBER() OVER (PARTITION BY age ORDER BY age DESC) gn FROM customers) T WHERE gn=1 LIMIT 1;",
-	// 	session.NewAIMockContext().WithSQL("CREATE TABLE customers (id INT, age INT);"),
-	// 	[]*AIMockSQLExpectation{
-	// 		{
-	// 			Query: "EXPLAIN SELECT age FROM (SELECT age, ROW_NUMBER() OVER (PARTITION BY age ORDER BY age DESC) gn FROM customers) T WHERE gn=1 LIMIT 1;",
-	// 			Rows:  sqlmock.NewRows([]string{"Extra"}).AddRow("Using filesort"),
-	// 		},
-	// 		{
-	// 			Query: "SHOW WARNINGS",
-	// 			Rows:  sqlmock.NewRows(nil),
-	// 		},
-	// 	}, newTestResult().addResult(ruleName))
+	// case 5: SELECT 语句使用窗口函数可能触发 filesort
+	runAIRuleCase(rule, t, "case 5: SELECT 语句使用窗口函数可能触发 filesort",
+		"SELECT age FROM (SELECT age, ROW_NUMBER() OVER (PARTITION BY age ORDER BY age DESC) gn FROM customers) T WHERE gn=1 LIMIT 1;",
+		session.NewAIMockContext().WithSQL("CREATE TABLE customers (id INT, age INT);"),
+		[]*AIMockSQLExpectation{
+			{
+				Query: "EXPLAIN SELECT age FROM (SELECT age, ROW_NUMBER() OVER (PARTITION BY age ORDER BY age DESC) gn FROM customers) T WHERE gn=1 LIMIT 1;",
+				Rows:  sqlmock.NewRows([]string{"Extra"}).AddRow("Using filesort"),
+			},
+			{
+				Query: "SHOW WARNINGS",
+				Rows:  sqlmock.NewRows(nil),
+			},
+		}, newTestResult().addResult(ruleName))
 
 	// case 6: SELECT 语句使用 GROUP BY 和 ORDER BY 不一致可能触发 filesort
 	runAIRuleCase(rule, t, "case 6: SELECT 语句使用 GROUP BY 和 ORDER BY 不一致可能触发 filesort",

--- a/sqle/driver/mysql/splitter/splitter.go
+++ b/sqle/driver/mysql/splitter/splitter.go
@@ -16,8 +16,10 @@ type splitter struct {
 }
 
 func NewSplitter() *splitter {
+	p := parser.New()
+	p.EnableWindowFunc(true)
 	return &splitter{
-		parser:    parser.New(),
+		parser:    p,
 		delimiter: NewDelimiter(),
 		scanner:   parser.NewScanner(""),
 	}

--- a/sqle/driver/mysql/splitter/splitter_test.go
+++ b/sqle/driver/mysql/splitter/splitter_test.go
@@ -249,6 +249,24 @@ Alter table point_trans_shard_00_part_202401 ADD CONSTRAINT chk_point_trans_shar
 	}
 }
 
+func TestParseWindowFunctionSelect(t *testing.T) {
+	parser := NewSplitter()
+	sql := "SELECT id, ROW_NUMBER() OVER (PARTITION BY nominate_app_id ORDER BY create_date ASC) AS rn FROM sourcing.tt_nomi_record WHERE is_delete = 0"
+	stmt, err := parser.ParseSqlText(sql)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stmt) != 1 {
+		t.Fatalf("expect 1 stmt, got %d", len(stmt))
+	}
+	if _, ok := stmt[0].(*ast.UnparsedStmt); ok {
+		t.Fatal("expect SelectStmt, got UnparsedStmt")
+	}
+	if _, ok := stmt[0].(*ast.SelectStmt); !ok {
+		t.Fatalf("expect SelectStmt, got %T", stmt[0])
+	}
+}
+
 func TestPerfectParse(t *testing.T) {
 	parser := NewSplitter()
 


### PR DESCRIPTION
### **User description**
Fixes actiontech/sqle-ee#2987

## Summary
- Enable `parser.EnableWindowFunc(true)` in MySQL splitter so SELECT with `OVER(...)` parses as `SelectStmt` instead of `UnparsedStmt`
- Add unit tests for window function DQL classification and SQLE00082 coverage
- Fixes data export `export_sql_type=ddl` misclassification blocking workflow submit

## Related
- sqle-ee csvw-4.2505.x: https://github.com/actiontech/sqle-ee/pull/2986 (merged)
- sqle-ob-mysql-plugin: http://10.186.18.21/sqle/sqle-ob-mysql-plugin/-/merge_requests/41 (merged)
- sqle-oracle-plugin-j: http://10.186.18.21/sqle/sqle-oracle-plugin-j/-/merge_requests/344 (merged)

## Test plan
- [x] `go test -mod=vendor -count=1 -vet=off -run 'TestInspect_assertSQLType|TestInspect_Parse|TestRuleSQLE00082|TestParseWindowFunctionSelect' ./sqle/driver/mysql/... ./sqle/driver/mysql/splitter/...`
- [x] 146 HTTP smoke 3/3 PASS (see sqle-ee#2987 delivery report)

Made with [Cursor](https://cursor.com)


___

### **Description**
- 启用解析器窗口函数支持

- 更新 MySQL 相关测试用例

- 调整 parser 初始化调用 EnableWindowFunc(true)

- 增加窗口函数解析单元测试验证


___

### Diagram Walkthrough


```mermaid
flowchart LR
  splitter["\"sqle/driver/mysql/splitter/splitter.go\""] -- "启用窗口函数支持" --> mysql_test["\"sqle/driver/mysql/mysql_test.go\""]
  splitter -- "配置解析器" --> splitter_test["\"sqle/driver/mysql/splitter/splitter_test.go\""]
  mysql_test -- "新增窗口函数测试" --> rule_test["\"sqle/driver/mysql/rule_00082_test.go\""]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mysql_test.go</strong><dd><code>添加窗口函数解析测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/mysql_test.go

- 添加窗口函数查询测试案例
- 验证窗口函数返回 DQL 类型


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3335/files#diff-b3775d19b204b3aa70811a143991b827fbdbb31c21e25fde726e1591d0d043c1">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rule_00082_test.go</strong><dd><code>更新窗口函数规则测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/rule_00082_test.go

- 取消注释窗口函数 filesort 测试用例
- 确保窗口函数 SQL 规则正确触发


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3335/files#diff-816e50a5200e0bc2366c3c43e79e71537671ae6121fb15e5ffef021732b65845">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>splitter.go</strong><dd><code>修改窗口函数支持的解析器配置</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/splitter/splitter.go

- 调整 parser 初始化逻辑
- 调用 EnableWindowFunc(true) 启用窗口函数支持


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3335/files#diff-2f9331d7a87a888a209e41f541ebc83b530b70b943a85d0f0b61f6e9a97bd24f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>splitter_test.go</strong><dd><code>添加窗口函数解析单元测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/splitter/splitter_test.go

- 新增 TestParseWindowFunctionSelect 函数
- 验证窗口函数查询返回 SelectStmt 类型


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3335/files#diff-e67558d1efff3ebeb7c27c6336554c814444f30d5b70b9fafab31361c12a8462">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

