### PR TITLE
fix(model): add DisableReportPushConfigInProject for project deletion

### DIFF
--- a/sqle/model/report_push_config.go
+++ b/sqle/model/report_push_config.go
@@ -114,6 +114,10 @@ func (s Storage) GetReportPushConfigInProjectByType(projectID, typ string) (*Rep
 	return reportPushConfig, nil
 }
 
+func (s Storage) DisableReportPushConfigInProject(projectID string) error {
+	return s.db.Model(&ReportPushConfig{}).Where("project_id = ? AND enabled = ?", projectID, true).Update("enabled", false).Error
+}
+
 func (s Storage) DeleteReportPushConfigInProject(projectID string) error {
 	configs, err := s.GetReportPushConfigListInProject(projectID)
 	if err != nil {


### PR DESCRIPTION
### **User description**
## Problem

Deleting a DMS project fails when SQLE report push configs are enabled (default workflow push is enabled on project creation). The delete pre-check blocks deletion instead of stopping push rules automatically.

## Solution

Add `DisableReportPushConfigInProject` storage helper to disable enabled report push configs before project deletion proceeds.

## Test plan

- [x] `make EDITION=ce docker_install` passes
- EE-side handler change depends on this CE commit; merge CE PR before EE PR

Fixes actiontech/dms-ee#440



___

### **Description**
- 新增 DisableReportPushConfigInProject 方法

- 禁用启用状态的 report push config

- 修复项目删除时的阻塞问题


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["新增DisableReportPushConfigInProject方法"]
  B["更新数据库禁用配置"]
  A -- "调用" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>report_push_config.go</strong><dd><code>新增禁用ReportPushConfig函数</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/model/report_push_config.go

- 添加 DisableReportPushConfigInProject 方法
- 通过数据库更新禁用报表推送配置


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3343/files#diff-80de69fb3ee7c339094cc2f4c4162a3597cd0d101761f040b0ffbd895fff9105">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

