### PR TITLE
feat: support multi workflow templates for SQL release and data export

### DIFF
--- a/sqle/api/app.go
+++ b/sqle/api/app.go
@@ -200,6 +200,9 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config *config.SqleOpti
 
 		// workflow template
 		v1OpProjectRouter.PATCH("/:project_name/workflow_template/:workflow_type/", v1.UpdateWorkflowTemplate)
+		v1OpProjectRouter.POST("/:project_name/workflow_templates", v1.CreateWorkflowTemplateV1)
+		v1OpProjectRouter.PATCH("/:project_name/workflow_templates/:workflow_template_id/", v1.UpdateWorkflowTemplateByIdV1)
+		v1OpProjectRouter.DELETE("/:project_name/workflow_templates/:workflow_template_id/", v1.DeleteWorkflowTemplateV1)
 
 		// report push
 		v1OpProjectRouter.PUT("/:project_name/report_push_configs/:report_push_config_id/", v1.UpdateReportPushConfig)
@@ -330,6 +333,7 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config *config.SqleOpti
 
 		// workflow template
 		v1ProjectViewRouter.GET("/:project_name/workflow_templates", v1.GetWorkflowTemplateList)
+		v1ProjectViewRouter.GET("/:project_name/workflow_templates/:workflow_template_id/", v1.GetWorkflowTemplateByIdV1)
 		v1ProjectViewRouter.GET("/:project_name/workflow_template", v1.GetWorkflowTemplate)
 		v1ProjectViewRouter.GET("/:project_name/workflows/:workflow_name/", DeprecatedBy(apiV2))
 		v1ProjectViewRouter.GET("/:project_name/workflows", v1.GetWorkflowsV1)

--- a/sqle/api/controller/v1/workflow.go
+++ b/sqle/api/controller/v1/workflow.go
@@ -50,10 +50,12 @@ type GetWorkflowTemplateResV1 struct {
 }
 
 type WorkflowTemplateDetailResV1 struct {
+	WorkflowTemplateId            uint                         `json:"workflow_template_id"`
 	Name                          string                       `json:"workflow_template_name"`
 	Desc                          string                       `json:"desc,omitempty"`
 	WorkflowType                  string                       `json:"workflow_type" enums:"workflow,data_export"`
 	AllowSubmitWhenLessAuditLevel string                       `json:"allow_submit_when_less_audit_level" enums:"normal,notice,warn,error"`
+	IsDefault                     bool                         `json:"is_default"`
 	Steps                         []*WorkFlowStepTemplateResV1 `json:"workflow_step_template_list"`
 	UpdateTime                    time.Time                    `json:"update_time"`
 }
@@ -73,12 +75,13 @@ type WorkFlowStepTemplateResV1 struct {
 }
 
 // @Summary 获取审批流程模板详情
-// @Description get workflow template detail
+// @Description get workflow template detail; query by workflow_template_id or by workflow_type default template
 // @Tags workflow
 // @Id getWorkflowTemplateV1
 // @Security ApiKeyAuth
 // @Param project_name path string true "project name"
-// @Param workflow_type query string true "filter workflow type" Enums(workflow,data_export)
+// @Param workflow_type query string false "filter workflow type" Enums(workflow,data_export)
+// @Param workflow_template_id query uint false "workflow template id"
 // @Success 200 {object} v1.GetWorkflowTemplateResV1
 // @router /v1/projects/{project_name}/workflow_template [get]
 func GetWorkflowTemplate(c echo.Context) error {
@@ -91,18 +94,82 @@ func GetWorkflowTemplate(c echo.Context) error {
 // @Id getWorkflowTemplateListV1
 // @Security ApiKeyAuth
 // @Param project_name path string true "project name"
+// @Param workflow_type query string false "filter workflow type" Enums(workflow,data_export)
 // @Success 200 {object} v1.GetWorkflowTemplateListResV1
 // @router /v1/projects/{project_name}/workflow_templates [get]
 func GetWorkflowTemplateList(c echo.Context) error {
 	return getWorkflowTemplateList(c)
 }
 
+// CreateWorkflowTemplateV1
+// @Summary 创建审批流程模板
+// @Description create workflow template
+// @Tags workflow
+// @Id createWorkflowTemplateV1
+// @Security ApiKeyAuth
+// @Accept json
+// @Produce json
+// @Param project_name path string true "project name"
+// @Param instance body v1.CreateWorkflowTemplateReqV1 true "create workflow template"
+// @Success 200 {object} v1.GetWorkflowTemplateResV1
+// @router /v1/projects/{project_name}/workflow_templates [post]
+func CreateWorkflowTemplateV1(c echo.Context) error {
+	return createWorkflowTemplate(c)
+}
+
+// GetWorkflowTemplateByIdV1
+// @Summary 根据ID获取审批流程模板详情
+// @Description get workflow template by id
+// @Tags workflow
+// @Id getWorkflowTemplateByIdV1
+// @Security ApiKeyAuth
+// @Param project_name path string true "project name"
+// @Param workflow_template_id path uint true "workflow template id"
+// @Success 200 {object} v1.GetWorkflowTemplateResV1
+// @router /v1/projects/{project_name}/workflow_templates/{workflow_template_id}/ [get]
+func GetWorkflowTemplateByIdV1(c echo.Context) error {
+	return getWorkflowTemplateById(c)
+}
+
+// UpdateWorkflowTemplateByIdV1
+// @Summary 根据ID更新审批流程模板
+// @Description update workflow template by id
+// @Tags workflow
+// @Id updateWorkflowTemplateByIdV1
+// @Security ApiKeyAuth
+// @Accept json
+// @Produce json
+// @Param project_name path string true "project name"
+// @Param workflow_template_id path uint true "workflow template id"
+// @Param instance body v1.UpdateWorkflowTemplateByIdReqV1 true "update workflow template"
+// @Success 200 {object} controller.BaseRes
+// @router /v1/projects/{project_name}/workflow_templates/{workflow_template_id}/ [patch]
+func UpdateWorkflowTemplateByIdV1(c echo.Context) error {
+	return updateWorkflowTemplateById(c)
+}
+
+// DeleteWorkflowTemplateV1
+// @Summary 删除审批流程模板
+// @Description delete workflow template by id
+// @Tags workflow
+// @Id deleteWorkflowTemplateV1
+// @Security ApiKeyAuth
+// @Param project_name path string true "project name"
+// @Param workflow_template_id path uint true "workflow template id"
+// @Success 200 {object} controller.BaseRes
+// @router /v1/projects/{project_name}/workflow_templates/{workflow_template_id}/ [delete]
+func DeleteWorkflowTemplateV1(c echo.Context) error {
+	return deleteWorkflowTemplate(c)
+}
+
 func convertWorkflowTemplateToRes(template *model.WorkflowTemplate) *WorkflowTemplateDetailResV1 {
 	res := &WorkflowTemplateDetailResV1{
+		WorkflowTemplateId:            template.ID,
 		Name:                          template.Name,
 		Desc:                          template.Desc,
 		WorkflowType:                  template.WorkflowType,
 		AllowSubmitWhenLessAuditLevel: template.AllowSubmitWhenLessAuditLevel,
+		IsDefault:                     template.IsDefault,
 		UpdateTime:                    template.UpdatedAt,
 	}
 	stepsRes := make([]*WorkFlowStepTemplateResV1, 0, len(template.Steps))
@@ -141,6 +208,23 @@ type WorkFlowStepTemplateReqV1 struct {
 type UpdateWorkflowTemplateReqV1 struct {
 	Desc                          *string                      `json:"desc" form:"desc"`
 	AllowSubmitWhenLessAuditLevel *string                      `json:"allow_submit_when_less_audit_level" enums:"normal,notice,warn,error"`
+	Steps                         []*WorkFlowStepTemplateReqV1 `json:"workflow_step_template_list" form:"workflow_step_template_list"`
+}
+
+type CreateWorkflowTemplateReqV1 struct {
+	Name                          string                       `json:"workflow_template_name" form:"workflow_template_name" valid:"required,name"`
+	Desc                          string                       `json:"desc" form:"desc"`
+	WorkflowType                  string                       `json:"workflow_type" form:"workflow_type" valid:"required,oneof=workflow data_export" enums:"workflow,data_export"`
+	AllowSubmitWhenLessAuditLevel *string                      `json:"allow_submit_when_less_audit_level" enums:"normal,notice,warn,error"`
+	IsDefault                     *bool                        `json:"is_default" form:"is_default"`
+	Steps                         []*WorkFlowStepTemplateReqV1 `json:"workflow_step_template_list" form:"workflow_step_template_list" valid:"required,dive"`
+}
+
+type UpdateWorkflowTemplateByIdReqV1 struct {
+	Name                          *string                      `json:"workflow_template_name" form:"workflow_template_name"`
+	Desc                          *string                      `json:"desc" form:"desc"`
+	AllowSubmitWhenLessAuditLevel *string                      `json:"allow_submit_when_less_audit_level" enums:"normal,notice,warn,error"`
+	IsDefault                     *bool                        `json:"is_default" form:"is_default"`
 	Steps                         []*WorkFlowStepTemplateReqV1 `json:"workflow_step_template_list" form:"workflow_step_template_list"`
 }
 
@@ -504,16 +588,17 @@ func CreateWorkflowV1(c echo.Context) error {
 }
 
 type CheckedWorkflowInfo struct {
-	WorkflowId    string
-	User          *model.User
-	Tasks         []*model.Task
-	InstanceIds   []uint64
-	StepTemplates []*model.WorkflowStepTemplate
-	ProjectId     model.ProjectUID
-	GetOpExecUser func([]*model.Task) (canAuditUsers [][]*model.User, canExecUsers [][]*model.User)
+	WorkflowId         string
+	User               *model.User
+	Tasks              []*model.Task
+	InstanceIds        []uint64
+	StepTemplates      []*model.WorkflowStepTemplate
+	ProjectId          model.ProjectUID
+	WorkflowTemplateId *uint
+	GetOpExecUser      func([]*model.Task) (canAuditUsers [][]*model.User, canExecUsers [][]*model.User)
 }
 
-func CheckWorkflowCreationPrerequisites(c echo.Context, projectName string, taskIdsToBindWithWorkflow []uint) (*CheckedWorkflowInfo, error) {
+func CheckWorkflowCreationPrerequisites(c echo.Context, projectName string, taskIdsToBindWithWorkflow []uint, workflowTemplateId *uint) (*CheckedWorkflowInfo, error) {
 	// check project
 	projectUid, err := dms.GetProjectUIDByName(context.TODO(), projectName, true)
 	if err != nil {
@@ -568,14 +653,11 @@ func CheckWorkflowCreationPrerequisites(c echo.Context, projectName string, task
 	for _, instance := range instancesOfWorkflowInProject {
 		projectInstanceMap[instance.ID] = instance
 	}
-	// check template of workflow exist
-	workflowTemplate, exist, err := s.GetWorkflowTemplateByProjectId(model.ProjectUID(projectUid))
+	workflowTemplate, err := s.ResolveWorkflowTemplateForCreate(model.ProjectUID(projectUid), workflowTemplateId)
 	if err != nil {
 		return nil, err
 	}
-	if !exist {
-		return nil, errors.New(errors.DataNotExist, fmt.Errorf("the task instance is not bound workflow template"))
-	}
+	templateID := workflowTemplate.ID
 	// check tasks instance
 	for _, task := range tasks {
 		if instance, ok := projectInstanceMap[task.InstanceId]; ok {
@@ -643,12 +725,13 @@ func CheckWorkflowCreationPrerequisites(c echo.Context, projectName string, task
 		return nil, err
 	}
 	return &CheckedWorkflowInfo{
-		WorkflowId:    workflowId,
-		User:          user,
-		Tasks:         tasks,
-		StepTemplates: stepTemplates,
-		InstanceIds:   instanceIdsOfWorkflowTasks,
-		ProjectId:     model.ProjectUID(projectUid),
+		WorkflowId:         workflowId,
+		User:               user,
+		Tasks:              tasks,
+		StepTemplates:      stepTemplates,
+		InstanceIds:        instanceIdsOfWorkflowTasks,
+		ProjectId:          model.ProjectUID(projectUid),
+		WorkflowTemplateId: &templateID,
 		GetOpExecUser: func(tasks []*model.Task) (auditWorkflowUsers, canExecUser [][]*model.User) {
 			auditWorkflowUsers = make([][]*model.User, len(tasks))
 			executorWorkflowUsers := make([][]*model.User, len(tasks))
@@ -694,6 +777,7 @@ type GetWorkflowsReqV1 struct {
 	FilterTaskExecuteStartTimeFrom  string                `json:"filter_task_execute_start_time_from" query:"filter_task_execute_start_time_from"`
 	FilterTaskExecuteStartTimeTo    string                `json:"filter_task_execute_start_time_to" query:"filter_task_execute_start_time_to"`
 	FilterSqlVersionID              *uint                 `json:"filter_sql_version_id" query:"filter_sql_version_id"`
+	FilterWorkflowTemplateId        *uint                 `json:"filter_workflow_template_id" query:"filter_workflow_template_id"`
 	FilterProjectUid                string                `json:"filter_project_uid" query:"filter_project_uid"`
 	FilterInstanceId                string                `json:"filter_instance_id" query:"filter_instance_id"`
 	FilterProjectPriority           dmsV1.ProjectPriority `json:"filter_project_priority" query:"filter_project_priority"  valid:"omitempty,oneof=high medium low"`
@@ -722,6 +806,8 @@ type WorkflowDetailResV1 struct {
 	CurrentStepAssigneeUser []string              `json:"current_step_assignee_user_name_list,omitempty"`
 	Status                  string                `json:"status" enums:"wait_for_audit,wait_for_approve,wait_for_execution,wait_for_export,rejected,canceled,cancel,exec_failed,failed,executing,exporting,finished,finish"`
 	InstanceInfo            []InstanceInfo        `json:"instance_info,omitempty"`
+	WorkflowTemplateId      *uint                 `json:"workflow_template_id,omitempty"`
+	WorkflowTemplateName    string                `json:"workflow_template_name,omitempty"`
 }
 
 type InstanceInfo struct {
@@ -1218,6 +1304,7 @@ func loadInstanceByInstanceIds(ctx context.Context, instanceIds []string) (insta
 // @Param filter_current_step_assignee_user_id query string false "filter current step assignee user id"
 // @Param filter_task_instance_id query string false "filter instance id"
 // @Param filter_sql_version_id query string false "filter sql version id"
+// @Param filter_workflow_template_id query uint false "filter workflow template id"
 // @Param page_index query uint32 true "page index"
 // @Param page_size query uint32 true "size of per page"
 // @Param project_name path string true "project name"
@@ -1248,6 +1335,7 @@ func GetWorkflowsV1(c echo.Context) error {
 	data := map[string]interface{}{
 		"filter_workflow_id":                   req.FilterWorkflowID,
 		"filter_sql_version_id":                req.FilterSqlVersionID,
+		"filter_workflow_template_id":          req.FilterWorkflowTemplateId,
 		"filter_subject":                       req.FilterSubject,
 		"filter_create_time_from":              req.FilterCreateTimeFrom,
 		"filter_create_time_to":                req.FilterCreateTimeTo,
@@ -1283,6 +1371,11 @@ func GetWorkflowsV1(c echo.Context) error {
 		for _, currentStepAssigneeUser := range workflow.CurrentAssigneeUser() {
 			CurrentStepAssigneeUserNames = append(CurrentStepAssigneeUserNames, dms.GetUserNameWithDelTag(currentStepAssigneeUser))
 		}
+		var templateId *uint
+		if workflow.WorkflowTemplateId.Valid {
+			id := uint(workflow.WorkflowTemplateId.Int64)
+			templateId = &id
+		}
 		workflowRes := &WorkflowDetailResV1{
 			ProjectName:             workflow.ProjectId, // dms-todo: 暂时使用id代替name
 			Name:                    workflow.Subject,
@@ -1294,6 +1387,8 @@ func GetWorkflowsV1(c echo.Context) error {
 			CurrentStepAssigneeUser: CurrentStepAssigneeUserNames,
 			Status:                  workflow.Status,
 			SqlVersionName:          workflow.SqlVersionNames,
+			WorkflowTemplateId:      templateId,
+			WorkflowTemplateName:    workflow.WorkflowTemplateName.String,
 		}
 		workflowsResV1 = append(workflowsResV1, workflowRes)
 	}
@@ -1871,11 +1966,12 @@ func GetWorkflowTaskAuditFile(c echo.Context) error {
 }
 
 type CreateRollbackWorkflowReq struct {
-	Subject        string `json:"workflow_subject" form:"workflow_subject" valid:"required,name"`
-	Desc           string `json:"desc" form:"desc"`
-	SqlVersionID   *uint  `json:"sql_version_id" form:"sql_version_id"`
-	TaskIds        []uint `json:"task_ids" form:"task_ids" valid:"required"`
-	RollbackSqlIds []uint `json:"rollback_sql_ids" form:"rollback_sql_ids" valid:"required"`
+	Subject            string `json:"workflow_subject" form:"workflow_subject" valid:"required,name"`
+	Desc               string `json:"desc" form:"desc"`
+	SqlVersionID       *uint  `json:"sql_version_id" form:"sql_version_id"`
+	WorkflowTemplateId *uint  `json:"workflow_template_id" form:"workflow_template_id"`
+	TaskIds            []uint `json:"task_ids" form:"task_ids" valid:"required"`
+	RollbackSqlIds     []uint `json:"rollback_sql_ids" form:"rollback_sql_ids" valid:"required"`
 }
 
 type CreateRollbackWorkflowRes struct {
@@ -1912,8 +2008,9 @@ type AutoCreateAndExecuteWorkflowReqV1 struct {
 	// 审核task group的参数
 	Sql string `json:"sql" form:"sql" example:"alter table tb1 drop columns c1"`
 	// 创建工单的参数
-	Subject string `json:"workflow_subject" form:"workflow_subject" valid:"required,name"`
-	Desc    string `json:"desc" form:"desc"`
+	Subject            string `json:"workflow_subject" form:"workflow_subject" valid:"required,name"`
+	Desc               string `json:"desc" form:"desc"`
+	WorkflowTemplateId *uint  `json:"workflow_template_id" form:"workflow_template_id"`
 }
 
 type AutoCreateAndExecuteWorkflowResV1 struct {
@@ -1995,7 +2092,7 @@ func AutoCreateAndExecuteWorkflowV1(c echo.Context) error {
 		taskIds = append(taskIds, task.ID)
 	}
 
-	w, err := CheckWorkflowCreationPrerequisites(c, projectName, taskIds)
+	w, err := CheckWorkflowCreationPrerequisites(c, projectName, taskIds, req.WorkflowTemplateId)
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}
@@ -2011,7 +2108,7 @@ func AutoCreateAndExecuteWorkflowV1(c echo.Context) error {
 	}
 
 	// 9. 创建工单
-	if err := s.CreateWorkflowV2(req.Subject, w.WorkflowId, req.Desc, w.User, w.Tasks, w.StepTemplates, w.ProjectId, nil, nil, nil, w.GetOpExecUser); err != nil {
+	if err := s.CreateWorkflowV2(req.Subject, w.WorkflowId, req.Desc, w.User, w.Tasks, w.StepTemplates, w.ProjectId, nil, nil, nil, w.WorkflowTemplateId, w.GetOpExecUser); err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}
 
@@ -2060,6 +2157,14 @@ func parseAutoCreateWorkflowRequest(c echo.Context) (*AutoCreateAndExecuteWorkfl
 		if err := json.Unmarshal([]byte(instancesStr), &req.Instances); err != nil {
 			return nil, errors.New(errors.DataInvalid, fmt.Errorf("invalid instances JSON: %v", err))
 		}
+	}
+	if templateIdStr := c.FormValue("workflow_template_id"); templateIdStr != "" {
+		templateId, err := strconv.ParseUint(templateIdStr, 10, 64)
+		if err != nil {
+			return nil, errors.New(errors.DataInvalid, fmt.Errorf("invalid workflow_template_id: %v", err))
+		}
+		id := uint(templateId)
+		req.WorkflowTemplateId = &id
 	}
 	return req, nil
 }

--- a/sqle/api/controller/v1/workflow_ce.go
+++ b/sqle/api/controller/v1/workflow_ce.go
@@ -23,6 +23,7 @@ var (
 	errCommunityEditionDoesNotSupportFileOrder                 = errors.New(errors.EnterpriseEditionFeatures, e.New("community edition does not support file order"))
 	errCommunityEditionDoesNotSupportDataExportWorkflowList    = errors.New(errors.EnterpriseEditionFeatures, e.New("community edition does not support data export workflow list"))
 	errCommunityEditionDoesNotSupportWorkflowTemplateList      = errors.New(errors.EnterpriseEditionFeatures, e.New("community edition does not support workflow template list"))
+	errCommunityEditionDoesNotSupportMultiWorkflowTemplate     = errors.New(errors.EnterpriseEditionFeatures, e.New("community edition does not support multi workflow template"))
 )
 
 func exportWorkflowV1(c echo.Context) error {
@@ -63,4 +64,20 @@ func getGlobalDataExportWorkflowStatisticsV1(c echo.Context) error {
 
 func getWorkflowTemplateList(c echo.Context) error {
 	return controller.JSONBaseErrorReq(c, errCommunityEditionDoesNotSupportWorkflowTemplateList)
+}
+
+func createWorkflowTemplate(c echo.Context) error {
+	return controller.JSONBaseErrorReq(c, errCommunityEditionDoesNotSupportMultiWorkflowTemplate)
+}
+
+func getWorkflowTemplateById(c echo.Context) error {
+	return controller.JSONBaseErrorReq(c, errCommunityEditionDoesNotSupportMultiWorkflowTemplate)
+}
+
+func updateWorkflowTemplateById(c echo.Context) error {
+	return controller.JSONBaseErrorReq(c, errCommunityEditionDoesNotSupportMultiWorkflowTemplate)
+}
+
+func deleteWorkflowTemplate(c echo.Context) error {
+	return controller.JSONBaseErrorReq(c, errCommunityEditionDoesNotSupportMultiWorkflowTemplate)
 }

--- a/sqle/api/controller/v2/instance_audit_plan.go
+++ b/sqle/api/controller/v2/instance_audit_plan.go
@@ -104,7 +104,7 @@ func GetInstanceTips(c echo.Context) error {
 		return controller.JSONBaseErrorReq(c, err)
 	}
 	s := model.GetStorage()
-	template, exist, err := s.GetWorkflowTemplateByProjectId(model.ProjectUID(projectUid))
+	template, exist, err := s.GetDefaultWorkflowTemplateByProjectIdAndType(model.ProjectUID(projectUid), model.WorkflowTemplateTypeWorkflow)
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}

--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -586,10 +586,11 @@ func GetSummaryOfWorkflowTasksV2(c echo.Context) error {
 }
 
 type CreateWorkflowReqV2 struct {
-	Subject      string `json:"workflow_subject" form:"workflow_subject" valid:"required,name"`
-	Desc         string `json:"desc" form:"desc"`
-	SqlVersionID *uint  `json:"sql_version_id" form:"sql_version_id"`
-	TaskIds      []uint `json:"task_ids" form:"task_ids" valid:"required"`
+	Subject            string `json:"workflow_subject" form:"workflow_subject" valid:"required,name"`
+	Desc               string `json:"desc" form:"desc"`
+	SqlVersionID       *uint  `json:"sql_version_id" form:"sql_version_id"`
+	WorkflowTemplateId *uint  `json:"workflow_template_id" form:"workflow_template_id"`
+	TaskIds            []uint `json:"task_ids" form:"task_ids" valid:"required"`
 }
 
 type CreateWorkflowResV2 struct {
@@ -619,7 +620,7 @@ func CreateWorkflowV2(c echo.Context) error {
 		return controller.JSONBaseErrorReq(c, err)
 	}
 
-	w, err := v1.CheckWorkflowCreationPrerequisites(c, c.Param("project_name"), req.TaskIds)
+	w, err := v1.CheckWorkflowCreationPrerequisites(c, c.Param("project_name"), req.TaskIds, req.WorkflowTemplateId)
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}
@@ -632,7 +633,7 @@ func CreateWorkflowV2(c echo.Context) error {
 	}
 	s := model.GetStorage()
 	// create workflow with checking op permission in task
-	err = s.CreateWorkflowV2(req.Subject, w.WorkflowId, req.Desc, w.User, w.Tasks, w.StepTemplates, w.ProjectId, req.SqlVersionID, nil, nil, w.GetOpExecUser)
+	err = s.CreateWorkflowV2(req.Subject, w.WorkflowId, req.Desc, w.User, w.Tasks, w.StepTemplates, w.ProjectId, req.SqlVersionID, nil, nil, w.WorkflowTemplateId, w.GetOpExecUser)
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}
@@ -1002,6 +1003,8 @@ type WorkflowResV2 struct {
 	ExecMode                    string                        `json:"exec_mode" enums:"sql_file,sqls"`
 	CreateUser                  string                        `json:"create_user_name"`
 	CreateTime                  *time.Time                    `json:"create_time"`
+	WorkflowTemplateId          *uint                         `json:"workflow_template_id,omitempty"`
+	WorkflowTemplateName        string                        `json:"workflow_template_name,omitempty"`
 	SqlVersion                  *SqlVersion                   `json:"sql_version,omitempty"`
 	Record                      *WorkflowRecordResV2          `json:"record"`
 	RecordHistory               []*WorkflowRecordResV2        `json:"record_history_list,omitempty"`
@@ -1099,8 +1102,14 @@ func convertWorkflowToRes(ctx context.Context, workflow *model.Workflow, sqlVers
 		ExecMode:                    workflow.ExecMode,
 		CreateUser:                  dms.GetUserNameWithDelTag(workflow.CreateUserId),
 		CreateTime:                  &workflow.CreatedAt,
+		WorkflowTemplateId:          workflow.WorkflowTemplateId,
 		AssociatedStageWorkflows:    convertAssociatedWorkflowToRes(associatedWorkflows),
 		AssociatedRollbackWorkflows: convertAssociatedRollbackWorkflowToRes(associatedRollbackWorkflows),
+	}
+	if workflow.WorkflowTemplateId != nil {
+		if template, exist, err := model.GetStorage().GetWorkflowTemplateById(*workflow.WorkflowTemplateId); err == nil && exist {
+			workflowRes.WorkflowTemplateName = template.Name
+		}
 	}
 	sqlVersionRes := &SqlVersion{
 		SqlVersionId:   sqlVersion.ID,

--- a/sqle/dms/data_export_workflow_template.go
+++ b/sqle/dms/data_export_workflow_template.go
@@ -1,0 +1,40 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+
+	pkgHttp "github.com/actiontech/dms/pkg/dms-common/pkg/http"
+)
+
+type checkDataExportWorkflowTemplateUsedReply struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    struct {
+		IsUsed bool  `json:"is_used"`
+		Count  int64 `json:"count"`
+	} `json:"data"`
+}
+
+// CheckDataExportWorkflowTemplateUsed asks DMS whether unfinished data-export
+// workflows still reference the given SQLE template.
+func CheckDataExportWorkflowTemplateUsed(ctx context.Context, dmsAddr, projectUID string, templateID uint) (bool, int64, error) {
+	if dmsAddr == "" {
+		return false, 0, nil
+	}
+	header := map[string]string{
+		"Authorization": pkgHttp.DefaultDMSToken,
+	}
+	reply := &checkDataExportWorkflowTemplateUsedReply{}
+	url := fmt.Sprintf(
+		"%s/v1/dms/projects/%s/data_export_workflows/workflow_template_used?workflow_template_id=%d",
+		dmsAddr, projectUID, templateID,
+	)
+	if err := pkgHttp.Get(ctx, url, header, nil, reply); err != nil {
+		return false, 0, fmt.Errorf("failed to check data export workflow template usage: %v", err)
+	}
+	if reply.Code != 0 {
+		return false, 0, fmt.Errorf("http reply code(%v) error: %v", reply.Code, reply.Message)
+	}
+	return reply.Data.IsUsed, reply.Data.Count, nil
+}

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -7557,7 +7557,7 @@ var doc = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "get workflow template detail",
+                "description": "get workflow template detail; query by workflow_template_id or by workflow_type default template",
                 "tags": [
                     "workflow"
                 ],
@@ -7579,8 +7579,13 @@ var doc = `{
                         "type": "string",
                         "description": "filter workflow type",
                         "name": "workflow_type",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "workflow template id",
+                        "name": "workflow_template_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -7671,6 +7676,16 @@ var doc = `{
                         "name": "project_name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "workflow",
+                            "data_export"
+                        ],
+                        "type": "string",
+                        "description": "filter workflow type",
+                        "name": "workflow_type",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -7678,6 +7693,179 @@ var doc = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/v1.GetWorkflowTemplateListResV1"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "create workflow template",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "创建审批流程模板",
+                "operationId": "createWorkflowTemplateV1",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "create workflow template",
+                        "name": "instance",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.CreateWorkflowTemplateReqV1"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.GetWorkflowTemplateResV1"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/projects/{project_name}/workflow_templates/{workflow_template_id}/": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get workflow template by id",
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "根据ID获取审批流程模板详情",
+                "operationId": "getWorkflowTemplateByIdV1",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "workflow template id",
+                        "name": "workflow_template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.GetWorkflowTemplateResV1"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "delete workflow template by id",
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "删除审批流程模板",
+                "operationId": "deleteWorkflowTemplateV1",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "workflow template id",
+                        "name": "workflow_template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.BaseRes"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "update workflow template by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "根据ID更新审批流程模板",
+                "operationId": "updateWorkflowTemplateByIdV1",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "workflow template id",
+                        "name": "workflow_template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "update workflow template",
+                        "name": "instance",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.UpdateWorkflowTemplateByIdReqV1"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.BaseRes"
                         }
                     }
                 }
@@ -7776,6 +7964,12 @@ var doc = `{
                         "type": "string",
                         "description": "filter sql version id",
                         "name": "filter_sql_version_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "filter workflow template id",
+                        "name": "filter_workflow_template_id",
                         "in": "query"
                     },
                     {
@@ -15970,6 +16164,9 @@ var doc = `{
                 },
                 "workflow_subject": {
                     "type": "string"
+                },
+                "workflow_template_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -16124,6 +16321,42 @@ var doc = `{
                 },
                 "workflow_subject": {
                     "type": "string"
+                }
+            }
+        },
+        "v1.CreateWorkflowTemplateReqV1": {
+            "type": "object",
+            "properties": {
+                "allow_submit_when_less_audit_level": {
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "notice",
+                        "warn",
+                        "error"
+                    ]
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "workflow_step_template_list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1.WorkFlowStepTemplateReqV1"
+                    }
+                },
+                "workflow_template_name": {
+                    "type": "string"
+                },
+                "workflow_type": {
+                    "type": "string",
+                    "enum": [
+                        "workflow",
+                        "data_export"
+                    ]
                 }
             }
         },
@@ -22645,6 +22878,35 @@ var doc = `{
                 }
             }
         },
+        "v1.UpdateWorkflowTemplateByIdReqV1": {
+            "type": "object",
+            "properties": {
+                "allow_submit_when_less_audit_level": {
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "notice",
+                        "warn",
+                        "error"
+                    ]
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "workflow_step_template_list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1.WorkFlowStepTemplateReqV1"
+                    }
+                },
+                "workflow_template_name": {
+                    "type": "string"
+                }
+            }
+        },
         "v1.UpdateWorkflowTemplateReqV1": {
             "type": "object",
             "properties": {
@@ -22869,6 +23131,12 @@ var doc = `{
                     "type": "string"
                 },
                 "workflow_name": {
+                    "type": "string"
+                },
+                "workflow_template_id": {
+                    "type": "integer"
+                },
+                "workflow_template_name": {
                     "type": "string"
                 }
             }
@@ -23189,6 +23457,9 @@ var doc = `{
                 "desc": {
                     "type": "string"
                 },
+                "is_default": {
+                    "type": "boolean"
+                },
                 "update_time": {
                     "type": "string"
                 },
@@ -23197,6 +23468,9 @@ var doc = `{
                     "items": {
                         "$ref": "#/definitions/v1.WorkFlowStepTemplateResV1"
                     }
+                },
+                "workflow_template_id": {
+                    "type": "integer"
                 },
                 "workflow_template_name": {
                     "type": "string"
@@ -23932,6 +24206,9 @@ var doc = `{
                 },
                 "workflow_subject": {
                     "type": "string"
+                },
+                "workflow_template_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -25246,6 +25523,12 @@ var doc = `{
                     "type": "string"
                 },
                 "workflow_name": {
+                    "type": "string"
+                },
+                "workflow_template_id": {
+                    "type": "integer"
+                },
+                "workflow_template_name": {
                     "type": "string"
                 }
             }

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -7541,7 +7541,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "get workflow template detail",
+                "description": "get workflow template detail; query by workflow_template_id or by workflow_type default template",
                 "tags": [
                     "workflow"
                 ],
@@ -7563,8 +7563,13 @@
                         "type": "string",
                         "description": "filter workflow type",
                         "name": "workflow_type",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "workflow template id",
+                        "name": "workflow_template_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -7655,6 +7660,16 @@
                         "name": "project_name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "workflow",
+                            "data_export"
+                        ],
+                        "type": "string",
+                        "description": "filter workflow type",
+                        "name": "workflow_type",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -7662,6 +7677,179 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/v1.GetWorkflowTemplateListResV1"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "create workflow template",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "创建审批流程模板",
+                "operationId": "createWorkflowTemplateV1",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "create workflow template",
+                        "name": "instance",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.CreateWorkflowTemplateReqV1"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.GetWorkflowTemplateResV1"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/projects/{project_name}/workflow_templates/{workflow_template_id}/": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get workflow template by id",
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "根据ID获取审批流程模板详情",
+                "operationId": "getWorkflowTemplateByIdV1",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "workflow template id",
+                        "name": "workflow_template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.GetWorkflowTemplateResV1"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "delete workflow template by id",
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "删除审批流程模板",
+                "operationId": "deleteWorkflowTemplateV1",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "workflow template id",
+                        "name": "workflow_template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.BaseRes"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "update workflow template by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workflow"
+                ],
+                "summary": "根据ID更新审批流程模板",
+                "operationId": "updateWorkflowTemplateByIdV1",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "project_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "workflow template id",
+                        "name": "workflow_template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "update workflow template",
+                        "name": "instance",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.UpdateWorkflowTemplateByIdReqV1"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.BaseRes"
                         }
                     }
                 }
@@ -7760,6 +7948,12 @@
                         "type": "string",
                         "description": "filter sql version id",
                         "name": "filter_sql_version_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "filter workflow template id",
+                        "name": "filter_workflow_template_id",
                         "in": "query"
                     },
                     {
@@ -15954,6 +16148,9 @@
                 },
                 "workflow_subject": {
                     "type": "string"
+                },
+                "workflow_template_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -16108,6 +16305,42 @@
                 },
                 "workflow_subject": {
                     "type": "string"
+                }
+            }
+        },
+        "v1.CreateWorkflowTemplateReqV1": {
+            "type": "object",
+            "properties": {
+                "allow_submit_when_less_audit_level": {
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "notice",
+                        "warn",
+                        "error"
+                    ]
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "workflow_step_template_list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1.WorkFlowStepTemplateReqV1"
+                    }
+                },
+                "workflow_template_name": {
+                    "type": "string"
+                },
+                "workflow_type": {
+                    "type": "string",
+                    "enum": [
+                        "workflow",
+                        "data_export"
+                    ]
                 }
             }
         },
@@ -22629,6 +22862,35 @@
                 }
             }
         },
+        "v1.UpdateWorkflowTemplateByIdReqV1": {
+            "type": "object",
+            "properties": {
+                "allow_submit_when_less_audit_level": {
+                    "type": "string",
+                    "enum": [
+                        "normal",
+                        "notice",
+                        "warn",
+                        "error"
+                    ]
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "workflow_step_template_list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1.WorkFlowStepTemplateReqV1"
+                    }
+                },
+                "workflow_template_name": {
+                    "type": "string"
+                }
+            }
+        },
         "v1.UpdateWorkflowTemplateReqV1": {
             "type": "object",
             "properties": {
@@ -22853,6 +23115,12 @@
                     "type": "string"
                 },
                 "workflow_name": {
+                    "type": "string"
+                },
+                "workflow_template_id": {
+                    "type": "integer"
+                },
+                "workflow_template_name": {
                     "type": "string"
                 }
             }
@@ -23173,6 +23441,9 @@
                 "desc": {
                     "type": "string"
                 },
+                "is_default": {
+                    "type": "boolean"
+                },
                 "update_time": {
                     "type": "string"
                 },
@@ -23181,6 +23452,9 @@
                     "items": {
                         "$ref": "#/definitions/v1.WorkFlowStepTemplateResV1"
                     }
+                },
+                "workflow_template_id": {
+                    "type": "integer"
                 },
                 "workflow_template_name": {
                     "type": "string"
@@ -23916,6 +24190,9 @@
                 },
                 "workflow_subject": {
                     "type": "string"
+                },
+                "workflow_template_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -25230,6 +25507,12 @@
                     "type": "string"
                 },
                 "workflow_name": {
+                    "type": "string"
+                },
+                "workflow_template_id": {
+                    "type": "integer"
+                },
+                "workflow_template_name": {
                     "type": "string"
                 }
             }

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -1557,6 +1557,8 @@ definitions:
         type: array
       workflow_subject:
         type: string
+      workflow_template_id:
+        type: integer
     type: object
   v1.CreateRollbackWorkflowRes:
     properties:
@@ -1659,6 +1661,31 @@ definitions:
           type: integer
         type: array
       workflow_subject:
+        type: string
+    type: object
+  v1.CreateWorkflowTemplateReqV1:
+    properties:
+      allow_submit_when_less_audit_level:
+        enum:
+        - normal
+        - notice
+        - warn
+        - error
+        type: string
+      desc:
+        type: string
+      is_default:
+        type: boolean
+      workflow_step_template_list:
+        items:
+          $ref: '#/definitions/v1.WorkFlowStepTemplateReqV1'
+        type: array
+      workflow_template_name:
+        type: string
+      workflow_type:
+        enum:
+        - workflow
+        - data_export
         type: string
     type: object
   v1.CustomRuleResV1:
@@ -6131,6 +6158,26 @@ definitions:
       schedule_time:
         type: string
     type: object
+  v1.UpdateWorkflowTemplateByIdReqV1:
+    properties:
+      allow_submit_when_less_audit_level:
+        enum:
+        - normal
+        - notice
+        - warn
+        - error
+        type: string
+      desc:
+        type: string
+      is_default:
+        type: boolean
+      workflow_step_template_list:
+        items:
+          $ref: '#/definitions/v1.WorkFlowStepTemplateReqV1'
+        type: array
+      workflow_template_name:
+        type: string
+    type: object
   v1.UpdateWorkflowTemplateReqV1:
     properties:
       allow_submit_when_less_audit_level:
@@ -6284,6 +6331,10 @@ definitions:
       workflow_id:
         type: string
       workflow_name:
+        type: string
+      workflow_template_id:
+        type: integer
+      workflow_template_name:
         type: string
     type: object
   v1.WorkflowDetailWithInstance:
@@ -6500,12 +6551,16 @@ definitions:
         type: string
       desc:
         type: string
+      is_default:
+        type: boolean
       update_time:
         type: string
       workflow_step_template_list:
         items:
           $ref: '#/definitions/v1.WorkFlowStepTemplateResV1'
         type: array
+      workflow_template_id:
+        type: integer
       workflow_template_name:
         type: string
       workflow_type:
@@ -7022,6 +7077,8 @@ definitions:
         type: array
       workflow_subject:
         type: string
+      workflow_template_id:
+        type: integer
     type: object
   v2.CreateWorkflowResV2:
     properties:
@@ -7937,6 +7994,10 @@ definitions:
       workflow_id:
         type: string
       workflow_name:
+        type: string
+      workflow_template_id:
+        type: integer
+      workflow_template_name:
         type: string
     type: object
   v2.WorkflowStepResV2:
@@ -12971,7 +13032,8 @@ paths:
       - task
   /v1/projects/{project_name}/workflow_template:
     get:
-      description: get workflow template detail
+      description: get workflow template detail; query by workflow_template_id or
+        by workflow_type default template
       operationId: getWorkflowTemplateV1
       parameters:
       - description: project name
@@ -12985,8 +13047,11 @@ paths:
         - data_export
         in: query
         name: workflow_type
-        required: true
         type: string
+      - description: workflow template id
+        in: query
+        name: workflow_template_id
+        type: integer
       responses:
         "200":
           description: OK
@@ -13045,6 +13110,13 @@ paths:
         name: project_name
         required: true
         type: string
+      - description: filter workflow type
+        enum:
+        - workflow
+        - data_export
+        in: query
+        name: workflow_type
+        type: string
       responses:
         "200":
           description: OK
@@ -13053,6 +13125,118 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 获取审批流程模板列表
+      tags:
+      - workflow
+    post:
+      consumes:
+      - application/json
+      description: create workflow template
+      operationId: createWorkflowTemplateV1
+      parameters:
+      - description: project name
+        in: path
+        name: project_name
+        required: true
+        type: string
+      - description: create workflow template
+        in: body
+        name: instance
+        required: true
+        schema:
+          $ref: '#/definitions/v1.CreateWorkflowTemplateReqV1'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.GetWorkflowTemplateResV1'
+      security:
+      - ApiKeyAuth: []
+      summary: 创建审批流程模板
+      tags:
+      - workflow
+  /v1/projects/{project_name}/workflow_templates/{workflow_template_id}/:
+    delete:
+      description: delete workflow template by id
+      operationId: deleteWorkflowTemplateV1
+      parameters:
+      - description: project name
+        in: path
+        name: project_name
+        required: true
+        type: string
+      - description: workflow template id
+        in: path
+        name: workflow_template_id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controller.BaseRes'
+      security:
+      - ApiKeyAuth: []
+      summary: 删除审批流程模板
+      tags:
+      - workflow
+    get:
+      description: get workflow template by id
+      operationId: getWorkflowTemplateByIdV1
+      parameters:
+      - description: project name
+        in: path
+        name: project_name
+        required: true
+        type: string
+      - description: workflow template id
+        in: path
+        name: workflow_template_id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.GetWorkflowTemplateResV1'
+      security:
+      - ApiKeyAuth: []
+      summary: 根据ID获取审批流程模板详情
+      tags:
+      - workflow
+    patch:
+      consumes:
+      - application/json
+      description: update workflow template by id
+      operationId: updateWorkflowTemplateByIdV1
+      parameters:
+      - description: project name
+        in: path
+        name: project_name
+        required: true
+        type: string
+      - description: workflow template id
+        in: path
+        name: workflow_template_id
+        required: true
+        type: integer
+      - description: update workflow template
+        in: body
+        name: instance
+        required: true
+        schema:
+          $ref: '#/definitions/v1.UpdateWorkflowTemplateByIdReqV1'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controller.BaseRes'
+      security:
+      - ApiKeyAuth: []
+      summary: 根据ID更新审批流程模板
       tags:
       - workflow
   /v1/projects/{project_name}/workflows:
@@ -13116,6 +13300,10 @@ paths:
         in: query
         name: filter_sql_version_id
         type: string
+      - description: filter workflow template id
+        in: query
+        name: filter_workflow_template_id
+        type: integer
       - description: page index
         in: query
         name: page_index

--- a/sqle/model/utils.go
+++ b/sqle/model/utils.go
@@ -499,6 +499,66 @@ func (s *Storage) CreateDefaultWorkflowTemplatesIfNotExist() error {
 	if err := s.CreateDefaultDataExportTemplatesIfNotExist(); err != nil {
 		return fmt.Errorf("create default data export templates failed: %v", err)
 	}
+	if err := s.MigrateWorkflowTemplateDefaults(); err != nil {
+		return fmt.Errorf("migrate workflow template defaults failed: %v", err)
+	}
+	return nil
+}
+
+// MigrateWorkflowTemplateDefaults ensures each project/type has exactly one default template.
+// Existing templates without is_default are initialized by marking the oldest row as default.
+func (s *Storage) MigrateWorkflowTemplateDefaults() error {
+	type projectTypePair struct {
+		ProjectId    string
+		WorkflowType string
+	}
+	var pairs []projectTypePair
+	err := s.db.Model(&WorkflowTemplate{}).
+		Select("project_id, workflow_type").
+		Group("project_id, workflow_type").
+		Find(&pairs).Error
+	if err != nil {
+		return err
+	}
+	for _, pair := range pairs {
+		var defaultCount int64
+		err = s.db.Model(&WorkflowTemplate{}).
+			Where("project_id = ? AND workflow_type = ? AND is_default = ?", pair.ProjectId, pair.WorkflowType, true).
+			Count(&defaultCount).Error
+		if err != nil {
+			return err
+		}
+		if defaultCount == 1 {
+			continue
+		}
+		if defaultCount > 1 {
+			var keep WorkflowTemplate
+			err = s.db.Where("project_id = ? AND workflow_type = ? AND is_default = ?", pair.ProjectId, pair.WorkflowType, true).
+				Order("id asc").First(&keep).Error
+			if err != nil {
+				return err
+			}
+			err = s.db.Model(&WorkflowTemplate{}).
+				Where("project_id = ? AND workflow_type = ? AND is_default = ? AND id <> ?",
+					pair.ProjectId, pair.WorkflowType, true, keep.ID).
+				Update("is_default", false).Error
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		var oldest WorkflowTemplate
+		err = s.db.Where("project_id = ? AND workflow_type = ?", pair.ProjectId, pair.WorkflowType).
+			Order("id asc").First(&oldest).Error
+		if err != nil {
+			return err
+		}
+		err = s.db.Model(&WorkflowTemplate{}).Where("id = ?", oldest.ID).Update("is_default", true).Error
+		if err != nil {
+			return err
+		}
+		log.NewEntry().Infof("migrated default workflow template id=%d for project=%s type=%s", oldest.ID, pair.ProjectId, pair.WorkflowType)
+	}
 	return nil
 }
 

--- a/sqle/model/workflow.go
+++ b/sqle/model/workflow.go
@@ -25,6 +25,7 @@ type WorkflowTemplate struct {
 	WorkflowType                  string     `json:"workflow_type" gorm:"type:varchar(64); not null; default:'workflow'; column:workflow_type"`
 	Desc                          string     `gorm:"type:varchar(255)"`
 	AllowSubmitWhenLessAuditLevel string     `gorm:"type:varchar(255)"`
+	IsDefault                     bool       `json:"is_default" gorm:"column:is_default; not null; default:false"`
 
 	Steps []*WorkflowStepTemplate `json:"-" gorm:"foreignkey:WorkflowTemplateId"`
 	// Instances []*Instance             `gorm:"foreignkey:WorkflowTemplateId"`
@@ -70,6 +71,7 @@ func DefaultWorkflowTemplate(projectId string) *WorkflowTemplate {
 		Name:                          fmt.Sprintf("%s-WorkflowTemplate", projectId),
 		WorkflowType:                  WorkflowTemplateTypeWorkflow,
 		AllowSubmitWhenLessAuditLevel: string(driverV2.RuleLevelWarn),
+		IsDefault:                     true,
 		Steps: []*WorkflowStepTemplate{
 			{
 				Number: 1,
@@ -96,6 +98,7 @@ func DefaultDataExportWorkflowTemplate(projectId string) *WorkflowTemplate {
 		ProjectId:    ProjectUID(projectId),
 		Name:         fmt.Sprintf("%s-DataExportWorkflowTemplate", projectId),
 		WorkflowType: WorkflowTemplateTypeDataExport,
+		IsDefault:    true,
 		Steps: []*WorkflowStepTemplate{
 			{
 				Number: 1,
@@ -136,27 +139,170 @@ func (s *Storage) GetWorkflowTemplateById(id uint) (*WorkflowTemplate, bool, err
 }
 
 func (s *Storage) GetWorkflowTemplateByProjectId(projectId ProjectUID) (*WorkflowTemplate, bool, error) {
-	workflowTemplate := &WorkflowTemplate{}
-	err := s.db.Where("project_id = ?", projectId).First(workflowTemplate).Error
-	if err == gorm.ErrRecordNotFound {
-		return workflowTemplate, false, nil
-	}
-	return workflowTemplate, true, errors.New(errors.ConnectStorageError, err)
+	return s.GetDefaultWorkflowTemplateByProjectIdAndType(projectId, WorkflowTemplateTypeWorkflow)
 }
 
 func (s *Storage) GetWorkflowTemplateByProjectIdAndType(projectId ProjectUID, workflowType string) (*WorkflowTemplate, bool, error) {
+	return s.GetDefaultWorkflowTemplateByProjectIdAndType(projectId, workflowType)
+}
+
+func (s *Storage) GetDefaultWorkflowTemplateByProjectIdAndType(projectId ProjectUID, workflowType string) (*WorkflowTemplate, bool, error) {
 	workflowTemplate := &WorkflowTemplate{}
-	err := s.db.Where("project_id = ? AND workflow_type = ?", projectId, workflowType).First(workflowTemplate).Error
+	err := s.db.Where("project_id = ? AND workflow_type = ? AND is_default = ?", projectId, workflowType, true).
+		First(workflowTemplate).Error
+	if err == nil {
+		return workflowTemplate, true, nil
+	}
+	if err != gorm.ErrRecordNotFound {
+		return workflowTemplate, false, errors.New(errors.ConnectStorageError, err)
+	}
+	// Fallback for legacy rows before is_default migration.
+	err = s.db.Where("project_id = ? AND workflow_type = ?", projectId, workflowType).
+		Order("id asc").First(workflowTemplate).Error
 	if err == gorm.ErrRecordNotFound {
 		return workflowTemplate, false, nil
 	}
-	return workflowTemplate, true, errors.New(errors.ConnectStorageError, err)
+	if err != nil {
+		return workflowTemplate, false, errors.New(errors.ConnectStorageError, err)
+	}
+	return workflowTemplate, true, nil
 }
 
 func (s *Storage) GetWorkflowTemplatesByProjectId(projectId ProjectUID) ([]*WorkflowTemplate, error) {
 	templates := []*WorkflowTemplate{}
-	err := s.db.Where("project_id = ?", projectId).Find(&templates).Error
+	err := s.db.Where("project_id = ?", projectId).Order("workflow_type asc, is_default desc, id asc").Find(&templates).Error
 	return templates, errors.New(errors.ConnectStorageError, err)
+}
+
+func (s *Storage) GetWorkflowTemplatesByProjectIdAndType(projectId ProjectUID, workflowType string) ([]*WorkflowTemplate, error) {
+	templates := []*WorkflowTemplate{}
+	db := s.db.Where("project_id = ?", projectId)
+	if workflowType != "" {
+		db = db.Where("workflow_type = ?", workflowType)
+	}
+	err := db.Order("workflow_type asc, is_default desc, id asc").Find(&templates).Error
+	return templates, errors.New(errors.ConnectStorageError, err)
+}
+
+func (s *Storage) GetWorkflowTemplateByProjectIdAndId(projectId ProjectUID, templateId uint) (*WorkflowTemplate, bool, error) {
+	workflowTemplate := &WorkflowTemplate{}
+	err := s.db.Where("project_id = ? AND id = ?", projectId, templateId).First(workflowTemplate).Error
+	if err == gorm.ErrRecordNotFound {
+		return workflowTemplate, false, nil
+	}
+	if err != nil {
+		return workflowTemplate, false, errors.New(errors.ConnectStorageError, err)
+	}
+	return workflowTemplate, true, nil
+}
+
+func (s *Storage) IsWorkflowTemplateNameExist(projectId ProjectUID, workflowType, name string, excludeID uint) (bool, error) {
+	var count int64
+	db := s.db.Model(&WorkflowTemplate{}).Where("project_id = ? AND workflow_type = ? AND name = ?", projectId, workflowType, name)
+	if excludeID > 0 {
+		db = db.Where("id <> ?", excludeID)
+	}
+	err := db.Count(&count).Error
+	return count > 0, errors.New(errors.ConnectStorageError, err)
+}
+
+func (s *Storage) CountWorkflowTemplatesByProjectIdAndType(projectId ProjectUID, workflowType string) (int64, error) {
+	var count int64
+	err := s.db.Model(&WorkflowTemplate{}).Where("project_id = ? AND workflow_type = ?", projectId, workflowType).Count(&count).Error
+	return count, errors.New(errors.ConnectStorageError, err)
+}
+
+// ValidateWorkflowTemplateForCreate checks that an explicit template ID belongs to the project and type=workflow.
+// When templateId is nil/zero, returns the project default workflow template.
+func ValidateWorkflowTemplateForCreate(template *WorkflowTemplate, projectId ProjectUID) error {
+	if template == nil {
+		return errors.New(errors.DataNotExist, fmt.Errorf("workflow template not found"))
+	}
+	if template.ProjectId != projectId {
+		return errors.New(errors.DataInvalid, fmt.Errorf("workflow template does not belong to the project"))
+	}
+	if template.WorkflowType != WorkflowTemplateTypeWorkflow {
+		return errors.New(errors.DataInvalid, fmt.Errorf("workflow template type must be %s", WorkflowTemplateTypeWorkflow))
+	}
+	return nil
+}
+
+func (s *Storage) ResolveWorkflowTemplateForCreate(projectId ProjectUID, templateId *uint) (*WorkflowTemplate, error) {
+	if templateId != nil && *templateId != 0 {
+		template, exist, err := s.GetWorkflowTemplateById(*templateId)
+		if err != nil {
+			return nil, err
+		}
+		if !exist {
+			return nil, errors.New(errors.DataNotExist, fmt.Errorf("workflow template not found"))
+		}
+		if err := ValidateWorkflowTemplateForCreate(template, projectId); err != nil {
+			return nil, err
+		}
+		return template, nil
+	}
+	template, exist, err := s.GetDefaultWorkflowTemplateByProjectIdAndType(projectId, WorkflowTemplateTypeWorkflow)
+	if err != nil {
+		return nil, err
+	}
+	if !exist {
+		return nil, errors.New(errors.DataNotExist, fmt.Errorf("the task instance is not bound workflow template"))
+	}
+	return template, nil
+}
+
+func CanDeleteWorkflowTemplate(isDefault bool, sameTypeCount int64, hasUnfinishedWorkflows bool) error {
+	if isDefault {
+		return errors.New(errors.DataInvalid, fmt.Errorf("default workflow template cannot be deleted"))
+	}
+	if sameTypeCount <= 1 {
+		return errors.New(errors.DataInvalid, fmt.Errorf("the only workflow template of this type cannot be deleted"))
+	}
+	if hasUnfinishedWorkflows {
+		return errors.New(errors.DataConflict, fmt.Errorf("workflow template is referenced by unfinished workflows"))
+	}
+	return nil
+}
+
+func (s *Storage) HasUnfinishedWorkflowByTemplateId(templateId uint) (bool, error) {
+	endStatus := []string{WorkflowStatusExecFailed, WorkflowStatusFinish, WorkflowStatusCancel}
+	var count int64
+	err := s.db.Table("workflows").
+		Joins("LEFT JOIN workflow_records ON workflows.workflow_record_id = workflow_records.id").
+		Where("workflows.workflow_template_id = ?", templateId).
+		Where("workflows.deleted_at IS NULL").
+		Where("workflow_records.status NOT IN (?)", endStatus).
+		Count(&count).Error
+	return count > 0, errors.New(errors.ConnectStorageError, err)
+}
+
+func (s *Storage) SetDefaultWorkflowTemplate(projectId ProjectUID, workflowType string, templateId uint) error {
+	return s.Tx(func(tx *gorm.DB) error {
+		if err := tx.Model(&WorkflowTemplate{}).
+			Where("project_id = ? AND workflow_type = ? AND is_default = ?", projectId, workflowType, true).
+			Update("is_default", false).Error; err != nil {
+			return err
+		}
+		result := tx.Model(&WorkflowTemplate{}).
+			Where("id = ? AND project_id = ? AND workflow_type = ?", templateId, projectId, workflowType).
+			Update("is_default", true)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return fmt.Errorf("workflow template not found")
+		}
+		return nil
+	})
+}
+
+func (s *Storage) DeleteWorkflowTemplate(template *WorkflowTemplate) error {
+	return s.Tx(func(tx *gorm.DB) error {
+		if err := tx.Where("workflow_template_id = ?", template.ID).Delete(&WorkflowStepTemplate{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(template).Error
+	})
 }
 
 func (s *Storage) GetWorkflowStepsByTemplateId(id uint) ([]*WorkflowStepTemplate, error) {
@@ -179,8 +325,8 @@ func (s *Storage) SaveWorkflowTemplate(template *WorkflowTemplate) error {
 }
 
 func saveWorkflowTemplate(template *WorkflowTemplate, tx *sql.Tx) (templateId int64, err error) {
-	result, err := tx.Exec("INSERT INTO workflow_templates (name, `desc`, `allow_submit_when_less_audit_level`, `project_id`, `workflow_type`) values (?, ?, ?, ?, ?)",
-		template.Name, template.Desc, template.AllowSubmitWhenLessAuditLevel, template.ProjectId, template.WorkflowType)
+	result, err := tx.Exec("INSERT INTO workflow_templates (name, `desc`, `allow_submit_when_less_audit_level`, `project_id`, `workflow_type`, `is_default`) values (?, ?, ?, ?, ?, ?)",
+		template.Name, template.Desc, template.AllowSubmitWhenLessAuditLevel, template.ProjectId, template.WorkflowType, template.IsDefault)
 	if err != nil {
 		return 0, err
 	}
@@ -241,12 +387,13 @@ func (s *Storage) GetWorkflowTemplateTip() ([]*WorkflowTemplate, error) {
 
 type Workflow struct {
 	Model
-	Subject          string `gorm:"type:varchar(255)"`
-	WorkflowId       string `gorm:"index:unique; type:varchar(255)"`
-	Desc             string `gorm:"type:varchar(3000)"`
-	CreateUserId     string `gorm:"type:varchar(255)"`
-	WorkflowRecordId uint
-	ProjectId        ProjectUID `gorm:"index; not null; type:varchar(255)"`
+	Subject            string `gorm:"type:varchar(255)"`
+	WorkflowId         string `gorm:"index:unique; type:varchar(255)"`
+	Desc               string `gorm:"type:varchar(3000)"`
+	CreateUserId       string `gorm:"type:varchar(255)"`
+	WorkflowRecordId   uint
+	ProjectId          ProjectUID `gorm:"index; not null; type:varchar(255)"`
+	WorkflowTemplateId *uint      `json:"workflow_template_id" gorm:"index; column:workflow_template_id"`
 
 	Record *WorkflowRecord `gorm:"foreignkey:WorkflowRecordId"`
 	// Project       *Project          `gorm:"foreignkey:ProjectId"`
@@ -560,7 +707,7 @@ func (w *Workflow) GetNeedSendOATaskIds(entry *logrus.Entry) ([]uint, error) {
 	return taskIds, nil
 }
 
-func (s *Storage) CreateWorkflowV2(subject, workflowId, desc string, user *User, tasks []*Task, stepTemplates []*WorkflowStepTemplate, projectId ProjectUID, sqlVersionId, versionStageId *uint, workflowStageSequence *int, getOpExecUser func([]*Task) (canAuditUsers [][]*User, canExecUsers [][]*User)) error {
+func (s *Storage) CreateWorkflowV2(subject, workflowId, desc string, user *User, tasks []*Task, stepTemplates []*WorkflowStepTemplate, projectId ProjectUID, sqlVersionId, versionStageId *uint, workflowStageSequence *int, workflowTemplateId *uint, getOpExecUser func([]*Task) (canAuditUsers [][]*User, canExecUsers [][]*User)) error {
 	if len(tasks) <= 0 {
 		return errors.New(errors.DataConflict, fmt.Errorf("there is no task for creating workflow"))
 	}
@@ -602,14 +749,15 @@ func (s *Storage) CreateWorkflowV2(subject, workflowId, desc string, user *User,
 	}
 
 	workflow := &Workflow{
-		Subject:          subject,
-		WorkflowId:       workflowId,
-		Desc:             desc,
-		ProjectId:        projectId,
-		CreateUserId:     user.GetIDStr(),
-		ExecMode:         execMode,
-		Mode:             workflowMode,
-		WorkflowRecordId: record.ID,
+		Subject:            subject,
+		WorkflowId:         workflowId,
+		Desc:               desc,
+		ProjectId:          projectId,
+		CreateUserId:       user.GetIDStr(),
+		ExecMode:           execMode,
+		Mode:               workflowMode,
+		WorkflowRecordId:   record.ID,
+		WorkflowTemplateId: workflowTemplateId,
 	}
 
 	err = tx.Save(workflow).Error

--- a/sqle/model/workflow_list.go
+++ b/sqle/model/workflow_list.go
@@ -20,6 +20,8 @@ type WorkflowListDetail struct {
 	TaskInstanceType           RowList        `json:"task_instance_type"` // unused
 	SqlVersionNames            RowList        `json:"versions"`
 	InstanceIds                RowList        `json:"instance_ids"`
+	WorkflowTemplateId         sql.NullInt64  `json:"workflow_template_id"`
+	WorkflowTemplateName       sql.NullString `json:"workflow_template_name"`
 }
 
 func (w *WorkflowListDetail) CurrentAssigneeUser() []string {
@@ -45,7 +47,9 @@ SELECT
        IF(wr.status = 'rejected', w.create_user_id, curr_ws.assignees) AS current_step_assignee_user_id_list,
        wr.status,
 	   GROUP_CONCAT(DISTINCT wir.instance_id SEPARATOR ',') AS instance_ids,
-	   GROUP_CONCAT(DISTINCT versions.version SEPARATOR ',') AS versions
+	   GROUP_CONCAT(DISTINCT versions.version SEPARATOR ',') AS versions,
+	   w.workflow_template_id AS workflow_template_id,
+	   wt.name AS workflow_template_name
 {{- template "body" . -}}
 GROUP BY w.id
 {{- if .filter_instance_id }}
@@ -81,6 +85,7 @@ LEFT JOIN workflow_steps AS curr_ws ON wr.current_workflow_step_id = curr_ws.id
 LEFT JOIN workflow_step_templates AS curr_wst ON curr_ws.workflow_step_template_id = curr_wst.id
 LEFT JOIN workflow_version_stages AS stages ON stages.workflow_id = w.workflow_id
 LEFT JOIN sql_versions AS versions ON stages.sql_version_id = versions.id AND versions.deleted_at IS NULL
+LEFT JOIN workflow_templates AS wt ON w.workflow_template_id = wt.id
 
 {{- if .check_user_can_access }}
 LEFT JOIN workflow_steps AS all_ws ON w.workflow_id = all_ws.workflow_id AND all_ws.state !='initialized'
@@ -161,6 +166,10 @@ AND w.workflow_id = :filter_workflow_id
 
 {{- if .filter_sql_version_id }}
 AND versions.id = :filter_sql_version_id
+{{- end }}
+
+{{- if .filter_workflow_template_id }}
+AND w.workflow_template_id = :filter_workflow_template_id
 {{- end }}
 
 {{- if .filter_project_id }}

--- a/sqle/model/workflow_template_test.go
+++ b/sqle/model/workflow_template_test.go
@@ -1,0 +1,99 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultWorkflowTemplateIsDefault(t *testing.T) {
+	tpl := DefaultWorkflowTemplate("proj-1")
+	assert.True(t, tpl.IsDefault)
+	assert.Equal(t, WorkflowTemplateTypeWorkflow, tpl.WorkflowType)
+}
+
+func TestDefaultDataExportWorkflowTemplateIsDefault(t *testing.T) {
+	tpl := DefaultDataExportWorkflowTemplate("proj-1")
+	assert.True(t, tpl.IsDefault)
+	assert.Equal(t, WorkflowTemplateTypeDataExport, tpl.WorkflowType)
+}
+
+func TestValidateWorkflowTemplateForCreate(t *testing.T) {
+	projectId := ProjectUID("p1")
+
+	t.Run("nil template", func(t *testing.T) {
+		err := ValidateWorkflowTemplateForCreate(nil, projectId)
+		assert.Error(t, err)
+	})
+
+	t.Run("project mismatch", func(t *testing.T) {
+		err := ValidateWorkflowTemplateForCreate(&WorkflowTemplate{
+			ProjectId:    "other",
+			WorkflowType: WorkflowTemplateTypeWorkflow,
+		}, projectId)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to the project")
+	})
+
+	t.Run("type must be workflow", func(t *testing.T) {
+		err := ValidateWorkflowTemplateForCreate(&WorkflowTemplate{
+			ProjectId:    projectId,
+			WorkflowType: WorkflowTemplateTypeDataExport,
+		}, projectId)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be workflow")
+	})
+
+	t.Run("valid template", func(t *testing.T) {
+		err := ValidateWorkflowTemplateForCreate(&WorkflowTemplate{
+			ProjectId:    projectId,
+			WorkflowType: WorkflowTemplateTypeWorkflow,
+		}, projectId)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCanDeleteWorkflowTemplate(t *testing.T) {
+	t.Run("cannot delete default", func(t *testing.T) {
+		err := CanDeleteWorkflowTemplate(true, 2, false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "default")
+	})
+
+	t.Run("cannot delete only template", func(t *testing.T) {
+		err := CanDeleteWorkflowTemplate(false, 1, false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only")
+	})
+
+	t.Run("cannot delete referenced unfinished", func(t *testing.T) {
+		err := CanDeleteWorkflowTemplate(false, 2, true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unfinished")
+	})
+
+	t.Run("can delete non-default unused", func(t *testing.T) {
+		err := CanDeleteWorkflowTemplate(false, 2, false)
+		assert.NoError(t, err)
+	})
+}
+
+func TestResolveWorkflowTemplateSelection(t *testing.T) {
+	zero := uint(0)
+	explicit := uint(9)
+	cases := []struct {
+		name        string
+		explicitID  *uint
+		useExplicit bool
+	}{
+		{name: "nil means default", explicitID: nil, useExplicit: false},
+		{name: "zero means default", explicitID: &zero, useExplicit: false},
+		{name: "explicit id", explicitID: &explicit, useExplicit: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useExplicit := tc.explicitID != nil && *tc.explicitID != 0
+			assert.Equal(t, tc.useExplicit, useExplicit)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Allow multiple approval templates per project for `workflow` and `data_export` types, with `is_default` and template name uniqueness.
- Persist `workflow_template_id` on SQL workflows; create/list APIs accept optional template ID and filter.
- Keep CE stubs / shared model-API paths here; enterprise handlers land via EE PR.

## Test plan
- [x] Cherry-picked CE commits only (no `*_ee.go`)
- [x] Model/API unit tests in EE workspace before split
- [x] CI lint + test
- [x] E2E validation in actiontech/sqle-ee#3025

Fixes actiontech/sqle-ee#3025