### PR TITLE
feat: support workflow desc update on resubmit

### DIFF
--- a/sqle/api/controller/v2/workflow.go
+++ b/sqle/api/controller/v2/workflow.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	dmsV1 "github.com/actiontech/dms/pkg/dms-common/api/dms/v1"
 
@@ -663,7 +664,8 @@ func CreateWorkflowV2(c echo.Context) error {
 }
 
 type UpdateWorkflowReqV2 struct {
-	TaskIds []uint `json:"task_ids" form:"task_ids" valid:"required"`
+	TaskIds []uint  `json:"task_ids" form:"task_ids" valid:"required"`
+	Desc    *string `json:"desc" form:"desc"`
 }
 
 // UpdateWorkflowV2
@@ -683,6 +685,10 @@ func UpdateWorkflowV2(c echo.Context) error {
 	req := new(UpdateWorkflowReqV2)
 	if err := controller.BindAndValidateReq(c, req); err != nil {
 		return controller.JSONBaseErrorReq(c, err)
+	}
+	if req.Desc != nil && utf8.RuneCountInString(*req.Desc) > 3000 {
+		return controller.JSONBaseErrorReq(c, errors.New(errors.DataInvalid,
+			fmt.Errorf("desc length must be less than or equal to 3000 characters")))
 	}
 
 	projectUid, err := dms.GetProjectUIDByName(context.TODO(), c.Param("project_name"), true)
@@ -786,7 +792,7 @@ func UpdateWorkflowV2(c echo.Context) error {
 			fmt.Errorf("you are not allow to operate the workflow")))
 	}
 
-	err = s.UpdateWorkflowRecord(workflow, tasks)
+	err = s.UpdateWorkflowRecordWithDesc(workflow, tasks, req.Desc)
 	if err != nil {
 		return c.JSON(http.StatusOK, controller.NewBaseReq(err))
 	}

--- a/sqle/docs/docs.go
+++ b/sqle/docs/docs.go
@@ -25106,6 +25106,9 @@ var doc = `{
         "v2.UpdateWorkflowReqV2": {
             "type": "object",
             "properties": {
+                "desc": {
+                    "type": "string"
+                },
                 "task_ids": {
                     "type": "array",
                     "items": {

--- a/sqle/docs/swagger.json
+++ b/sqle/docs/swagger.json
@@ -25090,6 +25090,9 @@
         "v2.UpdateWorkflowReqV2": {
             "type": "object",
             "properties": {
+                "desc": {
+                    "type": "string"
+                },
                 "task_ids": {
                     "type": "array",
                     "items": {

--- a/sqle/docs/swagger.yaml
+++ b/sqle/docs/swagger.yaml
@@ -7841,6 +7841,8 @@ definitions:
     type: object
   v2.UpdateWorkflowReqV2:
     properties:
+      desc:
+        type: string
       task_ids:
         items:
           type: integer

--- a/sqle/model/workflow.go
+++ b/sqle/model/workflow.go
@@ -772,6 +772,10 @@ func UpdateInstanceRecord(stepTemplates []*WorkflowStepTemplate, tasks []*Task, 
 }
 
 func (s *Storage) UpdateWorkflowRecord(w *Workflow, tasks []*Task) error {
+	return s.UpdateWorkflowRecordWithDesc(w, tasks, nil)
+}
+
+func (s *Storage) UpdateWorkflowRecordWithDesc(w *Workflow, tasks []*Task, desc *string) error {
 	instRecords := w.Record.InstanceRecords
 	if len(instRecords) != len(tasks) {
 		return e.New("task and instRecord are not equal in length")
@@ -828,12 +832,22 @@ func (s *Storage) UpdateWorkflowRecord(w *Workflow, tasks []*Task) error {
 
 	// update workflow record to new
 	if err := tx.Model(&Workflow{}).Where("workflow_id = ?", w.WorkflowId).
-		Update("workflow_record_id", record.ID).Error; err != nil {
+		Updates(workflowRecordUpdateValues(record.ID, desc)).Error; err != nil {
 		tx.Rollback()
 		return errors.New(errors.ConnectStorageError, err)
 	}
 
 	return errors.New(errors.ConnectStorageError, tx.Commit().Error)
+}
+
+func workflowRecordUpdateValues(recordID uint, desc *string) map[string]interface{} {
+	updates := map[string]interface{}{
+		"workflow_record_id": recordID,
+	}
+	if desc != nil {
+		updates["desc"] = *desc
+	}
+	return updates
 }
 
 // UpdateWorkflowStatus, 仅改变工单状态，用于关闭工单

--- a/sqle/model/workflow_test.go
+++ b/sqle/model/workflow_test.go
@@ -111,3 +111,29 @@ func TestWorkflowStepTypesByWorkflowType(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkflowRecordUpdateValues(t *testing.T) {
+	t.Run("keeps desc unchanged when desc is omitted", func(t *testing.T) {
+		updates := workflowRecordUpdateValues(12, nil)
+
+		assert.Equal(t, uint(12), updates["workflow_record_id"])
+		_, exists := updates["desc"]
+		assert.False(t, exists)
+	})
+
+	t.Run("updates desc when new value is provided", func(t *testing.T) {
+		desc := "new workflow desc"
+		updates := workflowRecordUpdateValues(13, &desc)
+
+		assert.Equal(t, uint(13), updates["workflow_record_id"])
+		assert.Equal(t, "new workflow desc", updates["desc"])
+	})
+
+	t.Run("clears desc when empty string is provided", func(t *testing.T) {
+		desc := ""
+		updates := workflowRecordUpdateValues(14, &desc)
+
+		assert.Equal(t, uint(14), updates["workflow_record_id"])
+		assert.Equal(t, "", updates["desc"])
+	})
+}


### PR DESCRIPTION
### **User description**
## Related issue

https://github.com/actiontech/sqle-ee/issues/3031

## Changes

- UpdateWorkflowV2 accepts and persists desc during resubmit.
- Sync swagger/OpenAPI docs and workflow model tests.


___

### **Description**
- 在 UpdateWorkflowReqV2 结构体中增加了可选描述字段 `desc`

- 在控制器中增加描述长度校验逻辑（最多3000字符）

- 模型中新增 UpdateWorkflowRecordWithDesc 函数处理描述更新

- 同步更新 Swagger 文档和测试用例以支持新功能


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UpdateWorkflowReqV2新增desc字段"] --> B["控制器校验描述长度"]
  B --> C["调用UpdateWorkflowRecordWithDesc"]
  C --> D["数据库更新记录包含可选描述"]
  C --> E["更新Swagger文档及测试用例"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow.go</strong><dd><code>更新工单控制器支持描述更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/api/controller/v2/workflow.go

<ul><li>新增 <code>desc</code> 字段到 UpdateWorkflowReqV2 结构体<br> <li> 添加描述长度校验（utf8字符校验 ≤3000）<br> <li> 调整调用逻辑，使用 UpdateWorkflowRecordWithDesc 进行更新</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3346/files#diff-65f005bb59a47d4478c385314f5af57a355ce32c5df79f5639225b5d6f9938e6">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflow.go</strong><dd><code>模型更新函数添加描述参数支持</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/model/workflow.go

<ul><li>新增 UpdateWorkflowRecordWithDesc 函数支持描述参数<br> <li> 添加 workflowRecordUpdateValues 辅助函数处理更新参数<br> <li> 调整旧函数调用以兼容新逻辑</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3346/files#diff-d94f236664e1fd810e77c57c7ebde41e6467546a8bee1ad14d4617a83d897ff6">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs.go</strong><dd><code>文档中新增描述字段说明</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/docs/docs.go

- 为 v2.UpdateWorkflowReqV2 添加属性 `desc` 的文档描述
- 更新 Swagger 文档示例配置


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3346/files#diff-d409074c2e7738eac2f332ed23472fb5180d8fea7b8eef9bdf605b08e8da57c4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>swagger.json</strong><dd><code>Swagger JSON 添加描述字段</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/docs/swagger.json

- 更新 JSON 格式的 Swagger 文档，添加 `desc` 字段定义
- 确保 API 描述与请求参数一致


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3346/files#diff-4fce51683e84474df0e33f37b222b1f169a06ab4872a0c708ded278fe59d19ea">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>swagger.yaml</strong><dd><code>Swagger YAML 添加描述字段</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/docs/swagger.yaml

- 更新 YAML 格式的 Swagger 配置，增加 `desc` 字段说明
- 保持文档与 JSON 版本同步


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3346/files#diff-45c3ed733c2869b216d3dacf0b2c39a4ce0842d293ce0f0e9de6aaf281c7cd04">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow_test.go</strong><dd><code>新增工作流记录更新测试用例</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/model/workflow_test.go

- 增加测试用例验证 workflowRecordUpdateValues 在不同描述传递下的行为
- 覆盖描述为空、不传及非空情况


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3346/files#diff-f269c1fbc4d077034401ae283c2a406401aa984e0ad62a866dfa17b87b32c2e1">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

