### PR TITLE
feat: support Redis cluster connection mode

### DIFF
--- a/sqle/api/controller/v1/instance.go
+++ b/sqle/api/controller/v1/instance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	baseV1 "github.com/actiontech/dms/pkg/dms-common/api/base/v1"
 	v1 "github.com/actiontech/dms/pkg/dms-common/api/dms/v1"
@@ -230,13 +231,37 @@ type GetInstanceConnectableReqV1 struct {
 	AdditionalParams []*InstanceAdditionalParamReqV1 `json:"additional_params" from:"additional_params"`
 }
 
+type checkDbConnectableReq struct {
+	DBType           string                `json:"db_type" form:"db_type" example:"mysql"`
+	User             string                `json:"user" form:"db_user" example:"root"`
+	Host             string                `json:"host" form:"db_host" example:"10.10.10.10" valid:"required,ip_addr|uri|hostname|hostname_rfc1123"`
+	Port             string                `json:"port" form:"db_port" example:"3306" valid:"required,port"`
+	Password         string                `json:"password" form:"db_password" example:"123456"`
+	AdditionalParams []*v1.AdditionalParam `json:"additional_params" from:"additional_params"`
+}
+
+func isRedisClusterConnectReq(dbType string, additionalParams []*v1.AdditionalParam) bool {
+	if !strings.EqualFold(dbType, "Redis") {
+		return false
+	}
+	for _, item := range additionalParams {
+		if item != nil && item.Name == "connection_mode" {
+			return item.Value == "cluster"
+		}
+	}
+	return false
+}
+
 func CheckInstanceIsConnectable(c echo.Context) error {
-	req := new(v1.CheckDbConnectable)
+	req := new(checkDbConnectableReq)
 	if err := controller.BindAndValidateReq(c, req); err != nil {
 		return err
 	}
 	if req.DBType == "" {
 		req.DBType = driverV2.DriverTypeMySQL
+	}
+	if req.User == "" && !isRedisClusterConnectReq(req.DBType, req.AdditionalParams) {
+		return controller.JSONBaseErrorReq(c, errors.New(errors.DataInvalid, fmt.Errorf("db service user can't be empty")))
 	}
 
 	additionalParams := driver.GetPluginManager().AllAdditionalParams()[req.DBType]


### PR DESCRIPTION
### **User description**
## Related issue

https://github.com/actiontech/dms-ee/issues/937

## Changes

- Support Redis standalone and Cluster connection mode submission scope for `sqle`.
- Preserve standalone compatibility while enabling explicit Cluster mode.


___

### **Description**
- 新增 Redis Cluster 连接模式判定逻辑

- 新增 checkDbConnectableReq 结构用于请求校验

- 添加 isRedisClusterConnectReq 函数检测连接模式

- 改进用户为空时的错误处理逻辑


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["新增 checkDbConnectableReq 结构"] -- "用于请求校验" --> B["修改 CheckInstanceIsConnectable 函数"]
  B -- "调用校验逻辑" --> C["调用 isRedisClusterConnectReq 函数"]
  C -- "返回判断结果" --> D["执行错误处理"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>instance.go</strong><dd><code>新增 Redis Cluster 连接模式检测及错误处理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/api/controller/v1/instance.go

<ul><li>引入 strings 包支持忽略大小写比较<br> <li> 新增 checkDbConnectableReq 请求结构<br> <li> 添加 isRedisClusterConnectReq 函数检测 Redis Cluster 模式<br> <li> 修改 CheckInstanceIsConnectable 中的用户为空校验逻辑</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3347/files#diff-0d0a0d89be43b48160436c3ca41e5c095b4fcdf51e5a58b00b7cc1f7e623ac50">+26/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

