### PR TITLE
fix: support MySQL CTE audit via conservative splitter fallback

### DIFF
--- a/sqle/driver/mysql/mysql_test.go
+++ b/sqle/driver/mysql/mysql_test.go
@@ -220,6 +220,54 @@ CREATEaa TABLE new_tbl AS SELECT * FROM orig_tbl;`,
 			`SELECT id, ROW_NUMBER() OVER (PARTITION BY nominate_app_id ORDER BY create_date ASC) AS rn FROM sourcing.tt_nomi_record`,
 			driverV2.SQLTypeDQL,
 		},
+		// AC-007：CTE 稳健性 — sql_type 按外层语义归类
+		{
+			"cte_minimal_dql",
+			`WITH cte AS (SELECT 1 AS id) SELECT * FROM cte`,
+			driverV2.SQLTypeDQL,
+		},
+		{
+			"cte_with_recursive",
+			`WITH RECURSIVE t AS (
+  SELECT 1 AS n
+  UNION ALL
+  SELECT n + 1 FROM t WHERE n < 3
+)
+SELECT * FROM t`,
+			driverV2.SQLTypeDQL,
+		},
+		{
+			"cte_multi",
+			`WITH cte1 AS (SELECT 1 AS id),
+cte2 AS (SELECT id FROM cte1)
+SELECT * FROM cte2`,
+			driverV2.SQLTypeDQL,
+		},
+		{
+			"cte_insert",
+			`WITH cte AS (SELECT 1 AS id) INSERT INTO t (id) SELECT id FROM cte`,
+			driverV2.SQLTypeDML,
+		},
+		{
+			"cte_update",
+			`WITH cte AS (SELECT 1 AS id) UPDATE t SET v = 1 WHERE id IN (SELECT id FROM cte)`,
+			driverV2.SQLTypeDML,
+		},
+		{
+			"cte_delete",
+			`WITH cte AS (SELECT id FROM exist_tb_1 WHERE id = 1) DELETE FROM exist_tb_1 WHERE id IN (SELECT id FROM cte)`,
+			driverV2.SQLTypeDML,
+		},
+		{
+			"cte_ctrl_real_ddl",
+			`CREATE TABLE t_cte_ctrl (id INT PRIMARY KEY)`,
+			driverV2.SQLTypeDDL,
+		},
+		{
+			"cte_ctrl_illegal_sql",
+			`SELECTxxx FROM nowhere WHERE`,
+			driverV2.SQLTypeDDL,
+		},
 	}
 	i := &MysqlDriverImpl{}
 	for _, arg := range args {

--- a/sqle/driver/mysql/splitter/cte.go
+++ b/sqle/driver/mysql/splitter/cte.go
@@ -1,0 +1,287 @@
+package splitter
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/pingcap/parser"
+	"github.com/pingcap/parser/ast"
+)
+
+// tryParseMySQLCTE 在 pingcap parser 无法识别 CTE 时，保守剥离
+// WITH [RECURSIVE] name AS (...) [, ...] 后解析外层语句。
+// 仅当确认 CTE 形态且外层解析成功时返回 (stmt, true)；否则 (nil, false)。
+// 禁止匹配裸首词 WITH（如 WITH GRANT OPTION）。
+func tryParseMySQLCTE(p *parser.Parser, originSQL string) (ast.StmtNode, bool) {
+	outer, ok := extractOuterSQLAfterCTE(originSQL)
+	if !ok {
+		return nil, false
+	}
+	stmt, err := p.ParseOneStmt(outer, "", "")
+	if err != nil {
+		return nil, false
+	}
+	return stmt, true
+}
+
+// extractOuterSQLAfterCTE 识别 MySQL CTE 前缀并返回外层 SQL。
+// 形态：WITH [RECURSIVE] cte_name [(cols)] AS (subquery) [, ...] <outer>
+func extractOuterSQLAfterCTE(sql string) (string, bool) {
+	s := strings.TrimSpace(sql)
+	if s == "" {
+		return "", false
+	}
+	i := skipSQLTrivia(s, 0)
+	if i >= len(s) {
+		return "", false
+	}
+	if !hasKeywordAt(s, i, "WITH") {
+		return "", false
+	}
+	i += len("WITH")
+	i = skipSQLTrivia(s, i)
+	if hasKeywordAt(s, i, "RECURSIVE") {
+		i += len("RECURSIVE")
+		i = skipSQLTrivia(s, i)
+	}
+
+	for {
+		nameEnd, ok := readSQLIdent(s, i)
+		if !ok {
+			return "", false
+		}
+		i = skipSQLTrivia(s, nameEnd)
+
+		// optional column list
+		if i < len(s) && s[i] == '(' {
+			end, ok := skipBalancedParens(s, i)
+			if !ok {
+				return "", false
+			}
+			i = skipSQLTrivia(s, end)
+		}
+
+		if !hasKeywordAt(s, i, "AS") {
+			return "", false
+		}
+		i += len("AS")
+		i = skipSQLTrivia(s, i)
+		if i >= len(s) || s[i] != '(' {
+			return "", false
+		}
+		end, ok := skipBalancedParens(s, i)
+		if !ok {
+			return "", false
+		}
+		i = skipSQLTrivia(s, end)
+
+		if i < len(s) && s[i] == ',' {
+			i++
+			i = skipSQLTrivia(s, i)
+			continue
+		}
+		break
+	}
+
+	if i >= len(s) {
+		return "", false
+	}
+	outer := strings.TrimSpace(s[i:])
+	if outer == "" {
+		return "", false
+	}
+	return outer, true
+}
+
+func hasKeywordAt(s string, i int, keyword string) bool {
+	if i+len(keyword) > len(s) {
+		return false
+	}
+	if !strings.EqualFold(s[i:i+len(keyword)], keyword) {
+		return false
+	}
+	end := i + len(keyword)
+	if end < len(s) {
+		r := rune(s[end])
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func skipSQLTrivia(s string, i int) int {
+	for i < len(s) {
+		switch {
+		case unicode.IsSpace(rune(s[i])):
+			i++
+		case i+1 < len(s) && s[i] == '-' && s[i+1] == '-':
+			i += 2
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+		case s[i] == '#':
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+		case i+1 < len(s) && s[i] == '/' && s[i+1] == '*':
+			i += 2
+			for i+1 < len(s) && !(s[i] == '*' && s[i+1] == '/') {
+				i++
+			}
+			if i+1 < len(s) {
+				i += 2
+			}
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func readSQLIdent(s string, i int) (int, bool) {
+	if i >= len(s) {
+		return i, false
+	}
+	switch s[i] {
+	case '`':
+		j := i + 1
+		for j < len(s) {
+			if s[j] == '`' {
+				if j+1 < len(s) && s[j+1] == '`' {
+					j += 2
+					continue
+				}
+				return j + 1, j > i+1
+			}
+			j++
+		}
+		return i, false
+	case '"', '\'':
+		// MySQL ansi_quotes / rare; treat quoted as ident if double-quoted
+		quote := s[i]
+		if quote == '\'' {
+			return i, false
+		}
+		j := i + 1
+		for j < len(s) {
+			if s[j] == '\\' && j+1 < len(s) {
+				j += 2
+				continue
+			}
+			if s[j] == quote {
+				return j + 1, j > i+1
+			}
+			j++
+		}
+		return i, false
+	default:
+		if !isIdentStart(rune(s[i])) {
+			return i, false
+		}
+		j := i + 1
+		for j < len(s) && isIdentPart(rune(s[j])) {
+			j++
+		}
+		return j, true
+	}
+}
+
+func isIdentStart(r rune) bool {
+	return unicode.IsLetter(r) || r == '_' || r == '$'
+}
+
+func isIdentPart(r rune) bool {
+	return isIdentStart(r) || unicode.IsDigit(r)
+}
+
+// skipBalancedParens starts at '(' and returns index after matching ')'.
+func skipBalancedParens(s string, i int) (int, bool) {
+	if i >= len(s) || s[i] != '(' {
+		return i, false
+	}
+	depth := 0
+	for i < len(s) {
+		c := s[i]
+		switch c {
+		case '(':
+			depth++
+			i++
+		case ')':
+			depth--
+			i++
+			if depth == 0 {
+				return i, true
+			}
+		case '\'', '"', '`':
+			end, ok := skipQuoted(s, i)
+			if !ok {
+				return i, false
+			}
+			i = end
+		case '-':
+			if i+1 < len(s) && s[i+1] == '-' {
+				i += 2
+				for i < len(s) && s[i] != '\n' {
+					i++
+				}
+			} else {
+				i++
+			}
+		case '#':
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+		case '/':
+			if i+1 < len(s) && s[i+1] == '*' {
+				i += 2
+				for i+1 < len(s) && !(s[i] == '*' && s[i+1] == '/') {
+					i++
+				}
+				if i+1 < len(s) {
+					i += 2
+				}
+			} else {
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	return i, false
+}
+
+func skipQuoted(s string, i int) (int, bool) {
+	if i >= len(s) {
+		return i, false
+	}
+	quote := s[i]
+	j := i + 1
+	for j < len(s) {
+		if quote == '`' {
+			if s[j] == '`' {
+				if j+1 < len(s) && s[j+1] == '`' {
+					j += 2
+					continue
+				}
+				return j + 1, true
+			}
+			j++
+			continue
+		}
+		if s[j] == '\\' && j+1 < len(s) {
+			j += 2
+			continue
+		}
+		if s[j] == quote {
+			// MySQL '' escape inside strings
+			if quote == '\'' && j+1 < len(s) && s[j+1] == '\'' {
+				j += 2
+				continue
+			}
+			return j + 1, true
+		}
+		j++
+	}
+	return i, false
+}

--- a/sqle/driver/mysql/splitter/cte_test.go
+++ b/sqle/driver/mysql/splitter/cte_test.go
@@ -1,0 +1,155 @@
+package splitter
+
+import (
+	"testing"
+
+	"github.com/pingcap/parser/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractOuterSQLAfterCTE(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantOuter string
+		wantOK    bool
+	}{
+		{
+			name: "minimal_dql_cte",
+			sql: `WITH cte AS (
+  SELECT 1 AS id
+)
+SELECT * FROM cte`,
+			wantOuter: "SELECT * FROM cte",
+			wantOK:    true,
+		},
+		{
+			name: "with_recursive",
+			sql: `WITH RECURSIVE t AS (
+  SELECT 1 AS n
+  UNION ALL
+  SELECT n + 1 FROM t WHERE n < 3
+)
+SELECT * FROM t`,
+			wantOuter: "SELECT * FROM t",
+			wantOK:    true,
+		},
+		{
+			name: "multi_cte",
+			sql: `WITH cte1 AS (SELECT 1 AS id),
+cte2 AS (SELECT 2 AS id)
+SELECT * FROM cte1 JOIN cte2`,
+			wantOuter: "SELECT * FROM cte1 JOIN cte2",
+			wantOK:    true,
+		},
+		{
+			name: "cte_with_column_list",
+			sql: `WITH cte (id) AS (SELECT 1)
+SELECT id FROM cte`,
+			wantOuter: "SELECT id FROM cte",
+			wantOK:    true,
+		},
+		{
+			name:   "not_cte_with_grant_option",
+			sql:    `GRANT SELECT ON t TO u WITH GRANT OPTION`,
+			wantOK: false,
+		},
+		{
+			name:   "plain_select",
+			sql:    `SELECT 1`,
+			wantOK: false,
+		},
+		{
+			name:   "incomplete_cte_no_outer",
+			sql:    `WITH cte AS (SELECT 1)`,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outer, ok := extractOuterSQLAfterCTE(tt.sql)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantOuter, outer)
+			}
+		})
+	}
+}
+
+// TestParseSqlText_MySQLCTE 覆盖 AC-007：合法 CTE 不因 CTE 语法本身落成 UnparsedStmt。
+func TestParseSqlText_MySQLCTE(t *testing.T) {
+	p := NewSplitter()
+
+	tests := []struct {
+		name     string
+		sql      string
+		wantType interface{} // concrete AST type expected
+	}{
+		{
+			name:     "minimal_dql_cte",
+			sql:      "WITH cte AS (SELECT 1 AS id) SELECT * FROM cte",
+			wantType: &ast.SelectStmt{},
+		},
+		{
+			name: "with_recursive",
+			sql: `WITH RECURSIVE t AS (
+  SELECT 1 AS n
+  UNION ALL
+  SELECT n + 1 FROM t WHERE n < 3
+)
+SELECT * FROM t`,
+			wantType: &ast.SelectStmt{},
+		},
+		{
+			name: "multi_cte",
+			sql: `WITH cte1 AS (SELECT 1 AS id),
+cte2 AS (SELECT id FROM cte1)
+SELECT * FROM cte2`,
+			wantType: &ast.SelectStmt{},
+		},
+		{
+			name:     "cte_insert",
+			sql:      "WITH cte AS (SELECT 1 AS id) INSERT INTO t (id) SELECT id FROM cte",
+			wantType: &ast.InsertStmt{},
+		},
+		{
+			name:     "cte_update",
+			sql:      "WITH cte AS (SELECT 1 AS id) UPDATE t SET v = 1 WHERE id IN (SELECT id FROM cte)",
+			wantType: &ast.UpdateStmt{},
+		},
+		{
+			name:     "cte_delete",
+			sql:      "WITH cte AS (SELECT id FROM exist_tb_1 WHERE id = 1) DELETE FROM exist_tb_1 WHERE id IN (SELECT id FROM cte)",
+			wantType: &ast.DeleteStmt{},
+		},
+		{
+			name:     "real_ddl_create_table",
+			sql:      "CREATE TABLE t_cte_ctrl (id INT PRIMARY KEY)",
+			wantType: &ast.CreateTableStmt{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmts, err := p.ParseSqlText(tt.sql)
+			assert.NoError(t, err)
+			if !assert.Len(t, stmts, 1) {
+				return
+			}
+			_, isUnparsed := stmts[0].(*ast.UnparsedStmt)
+			assert.False(t, isUnparsed, "合法 CTE/对照 SQL 不应落成 UnparsedStmt, got %T", stmts[0])
+			assert.IsType(t, tt.wantType, stmts[0])
+			assert.Equal(t, tt.sql, stmts[0].Text())
+		})
+	}
+
+	t.Run("illegal_sql_still_unparsed", func(t *testing.T) {
+		stmts, err := p.ParseSqlText("SELECTxxx FROM nowhere WHERE")
+		assert.NoError(t, err)
+		if !assert.Len(t, stmts, 1) {
+			return
+		}
+		_, ok := stmts[0].(*ast.UnparsedStmt)
+		assert.True(t, ok, "明显非法 SQL 应仍为 UnparsedStmt, got %T", stmts[0])
+	})
+}

--- a/sqle/driver/mysql/splitter/splitter.go
+++ b/sqle/driver/mysql/splitter/splitter.go
@@ -43,6 +43,13 @@ func (s *splitter) processToExecutableNodes(results []*singleSQL) ([]ast.StmtNod
 		// 根据解析结果生成得到sql的抽象语法树
 		stmt, err := s.parser.ParseOneStmt(result.originSql, "", "")
 		if err != nil {
+			// pingcap parser 不识别 MySQL CTE：保守剥离 WITH … AS (…) 后解析外层语句
+			if cteStmt, ok := tryParseMySQLCTE(s.parser, result.originSql); ok {
+				cteStmt.SetStartLine(result.lineNumber)
+				cteStmt.SetText(result.originSql)
+				executableNodes = append(executableNodes, cteStmt)
+				continue
+			}
 			// 若解析结果为错误，则将分割后的SQL作为不可解析的SQL添加到executableNodes中
 			unParsedStmt := &ast.UnparsedStmt{}
 			unParsedStmt.SetStartLine(result.lineNumber)


### PR DESCRIPTION
### **User description**
## 关联的 issue

https://github.com/actiontech/sqle-ee/issues/3050

## 描述你的变更

- MySQL splitter 在 pingcap 解析失败时，对合法 `WITH [RECURSIVE] name AS (...)` 形态保守剥离 CTE 前缀并解析外层语句，保留原文 Text
- 使合法 CTE 可审核，且 `sql_type` 按外层语义为 dql/dml，不再因 Unparsed 默认 ddl
- 非法 SQL / 裸 WITH（如 WITH GRANT OPTION）仍走原 Unparsed 路径；本期无 EE 专有文件，仅 CE 通用改动

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------

Made with [Cursor](https://cursor.com)


___

### **Description**
- 增加 MySQL CTE 保守解析处理

- 添加多种 CTE 测试用例验证解析结果

- 修改 splitter 调用逻辑支持 CTE 解析


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["新增 CTE 解析模块"]
  B["添加单元测试用例"]
  C["修改 splitter 调用逻辑"]
  A -- "整合解析" --> C
  B -- "验证功能" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mysql_test.go</strong><dd><code>增加 CTE 测试验证</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/mysql_test.go

- 添加 CTE 相关测试案例
- 验证 DQL、DML、DDL 类型识别


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3355/files#diff-b3775d19b204b3aa70811a143991b827fbdbb31c21e25fde726e1591d0d043c1">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cte_test.go</strong><dd><code>增加 CTE 解析单元测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/splitter/cte_test.go

- 编写 CTE 解析单元测试
- 覆盖多场景 CTE 测试案例


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3355/files#diff-6ee205bcba87f60a4fb1b2959cec8cb12f5f9c4024557b39947a8d8b4f8509fc">+155/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cte.go</strong><dd><code>新增 CTE 解析模块</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/splitter/cte.go

- 实现 MySQL CTE 保守剥离解析
- 定义多种辅助解析函数


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3355/files#diff-7c5a996008cff7f5cea9a3487d9ead5e3b7a9ec0d52f02f6287bbd474623efea">+287/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>splitter.go</strong><dd><code>集成 CTE 保守解析逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/driver/mysql/splitter/splitter.go

- 在 splitter 中调用 tryParseMySQLCTE
- 优化错误解析时的处理逻辑


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3355/files#diff-2f9331d7a87a888a209e41f541ebc83b530b70b943a85d0f0b61f6e9a97bd24f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

