### PR TITLE
feat: skip immediate first collect on scan task start

### DIFF
--- a/sqle/server/auditplan/task_wrap.go
+++ b/sqle/server/auditplan/task_wrap.go
@@ -278,7 +278,6 @@ func (at *TaskWrapper) loop(cancel chan struct{}, interval time.Duration) {
 		at.logger.Warnf("task(%v) loop interval can not be zero", at.ap.Name)
 		return
 	}
-	at.extractSQL()
 
 	tk := time.NewTicker(interval)
 	for {


### PR DESCRIPTION
### **User description**
## 关联的 issue

https://github.com/actiontech/sqle-ee/issues/3053

## 描述你的变更

- 删除 `TaskWrapper.loop` 入口处立刻调用的 `extractSQL()`，启动/重建只注册周期 ticker
- 保留 `interval==0` 告警返回与 tick 分支内采集；Manager / startAuditPlan 路径不变
- 产品接受重启到下一周期之间的采集空窗；「立即采集」另开任务

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------

Made with [Cursor](https://cursor.com)


___

### **Description**
- 移除 TaskWrapper.loop 中 extractSQL() 的即时调用

- 延迟采集，等待周期性定时器启动


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["检查任务间隔是否为零"] -- 否 --> B["跳过 extractSQL() 调用"]
  B -- 注册定时器 --> C["开始周期性采集"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task_wrap.go</strong><dd><code>删除即时采集调用</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sqle/server/auditplan/task_wrap.go

- 删除即时调用 extractSQL() 以推迟采集
- 保留定时器注册逻辑


</details>


  </td>
  <td><a href="https://github.com/actiontech/sqle/pull/3356/files#diff-2b7c095b05a4ccaf4fc53856e4ec5f65095d284ce2e939eccc0f42beeab9d568">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

