### PR TITLE
feat: default SM2 login encryption for username and password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/swaggo/echo-swagger v1.0.0
 	github.com/swaggo/swag v1.6.7
+	github.com/tjfoc/gmsm v1.4.1
 	github.com/ungerik/go-dry v0.0.0-20210209114055-a3e162a9e62e
 	github.com/urfave/cli/v2 v2.8.1
 	github.com/vektah/gqlparser/v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -1801,3 +1801,5 @@ sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.m
 storj.io/drpc v0.0.21/go.mod h1:OSJH7wvH3yKlhnMHwblKJioaaeyI6X8xbXT1SG9woe8=
 vitess.io/vitess v0.12.0 h1:pzQpNHLqBG/3JZnZ5A0U25017b81CuxeR+s6ry9/wl4=
 vitess.io/vitess v0.12.0/go.mod h1:QKt1VKLbuFqSi39giZa3z2i+ZG7/uSasnahoYjSB/go=
+github.com/tjfoc/gmsm v1.4.1/go.mod h1:j4INPkHWMrhJb38G+J6W4Tw0AbuN8Thu3PbdVYhVcTE=
+github.com/tjfoc/gmsm v1.4.1 h1:aMe1GlZb+0bLjn+cKTPEvvn9oUEBlJitaZiiBwsbgho=

--- a/sqle/api/app.go
+++ b/sqle/api/app.go
@@ -63,6 +63,7 @@ func StartApi(net *gracenet.Net, exitChan chan struct{}, config config.SqleConfi
 
 	e.POST("/v1/login", v1.LoginV1)
 	e.POST("/v2/login", v2.LoginV2)
+	e.GET("/v1/login/encryption", v1.GetLoginEncryption)
 
 	// the operation of obtaining the basic information of the platform should be for all users, not the users who log in to the platform
 	e.GET("/v1/basic_info", v1.GetSQLEInfo)

--- a/sqle/api/controller/v1/auth.go
+++ b/sqle/api/controller/v1/auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/actiontech/sqle/sqle/api/controller"
 	"github.com/actiontech/sqle/sqle/errors"
 	"github.com/actiontech/sqle/sqle/model"
+	"github.com/actiontech/sqle/sqle/pkg/loginencryption"
 	"github.com/actiontech/sqle/sqle/utils"
 
 	"github.com/go-ldap/ldap/v3"
@@ -18,8 +19,11 @@ import (
 )
 
 type UserLoginReqV1 struct {
-	UserName string `json:"username" form:"username" example:"test" valid:"required"`
-	Password string `json:"password" form:"password" example:"123456" valid:"required"`
+	UserName          string `json:"username" form:"username" example:"test"`
+	Password          string `json:"password" form:"password" example:"123456"`
+	EncryptedUsername string `json:"encrypted_username" form:"encrypted_username"`
+	EncryptedPassword string `json:"encrypted_password" form:"encrypted_password"`
+	KeyID             string `json:"key_id" form:"key_id"`
 }
 
 type GetUserLoginResV1 struct {
@@ -29,6 +33,25 @@ type GetUserLoginResV1 struct {
 
 type UserLoginResV1 struct {
 	Token string `json:"token" example:"this is a jwt token string"`
+}
+
+type GetLoginEncryptionResV1 struct {
+	controller.BaseRes
+	Data loginencryption.PublicInfo `json:"data"`
+}
+
+// GetLoginEncryption
+// @Summary 获取登录密码加密配置
+// @Description get login password encryption public info
+// @Tags user
+// @Id getLoginEncryptionV1
+// @Success 200 {object} v1.GetLoginEncryptionResV1
+// @router /v1/login/encryption [get]
+func GetLoginEncryption(c echo.Context) error {
+	return c.JSON(http.StatusOK, &GetLoginEncryptionResV1{
+		BaseRes: controller.NewBaseReq(nil),
+		Data:    loginencryption.GetManager().PublicInfo(),
+	})
 }
 
 // @Summary 用户登录
@@ -44,7 +67,17 @@ func LoginV1(c echo.Context) error {
 		return err
 	}
 
-	t, err := Login(c, req.UserName, req.Password)
+	userName, err := ResolveLoginUsername(req.UserName, req.EncryptedUsername, req.KeyID)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+
+	password, err := ResolveLoginPassword(req.Password, req.EncryptedPassword, req.KeyID)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+
+	t, err := Login(c, userName, password)
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}
@@ -55,6 +88,24 @@ func LoginV1(c echo.Context) error {
 			Token: t, // this token won't be used any more
 		},
 	})
+}
+
+// ResolveLoginUsername decrypts encrypted username when login encryption is enabled.
+func ResolveLoginUsername(plainUsername, encryptedUsername, keyID string) (string, error) {
+	userName, err := loginencryption.GetManager().ResolveUsername(plainUsername, encryptedUsername, keyID)
+	if err != nil {
+		return "", errors.New(errors.DataInvalid, err)
+	}
+	return userName, nil
+}
+
+// ResolveLoginPassword decrypts encrypted password when login encryption is enabled.
+func ResolveLoginPassword(plainPassword, encryptedPassword, keyID string) (string, error) {
+	password, err := loginencryption.GetManager().ResolvePassword(plainPassword, encryptedPassword, keyID)
+	if err != nil {
+		return "", errors.New(errors.DataInvalid, err)
+	}
+	return password, nil
 }
 
 func Login(c echo.Context, userName, password string) (token string, err error) {

--- a/sqle/api/controller/v2/auth.go
+++ b/sqle/api/controller/v2/auth.go
@@ -9,15 +9,18 @@ import (
 )
 
 type UserLoginReqV2 struct {
-	UserName string `json:"username" form:"username" example:"test" valid:"required"`
-	Password string `json:"password" form:"password" example:"123456" valid:"required"`
+	UserName          string `json:"username" form:"username" example:"test"`
+	Password          string `json:"password" form:"password" example:"123456"`
+	EncryptedUsername string `json:"encrypted_username" form:"encrypted_username"`
+	EncryptedPassword string `json:"encrypted_password" form:"encrypted_password"`
+	KeyID             string `json:"key_id" form:"key_id"`
 }
 
 // @Summary 用户登录
 // @Description user login
 // @Tags user
 // @Id loginV2
-// @Param user body v1.UserLoginReqV1 true "user login request"
+// @Param user body v2.UserLoginReqV2 true "user login request"
 // @Success 200 {object} controller.BaseRes
 // @router /v2/login [post]
 func LoginV2(c echo.Context) error {
@@ -26,7 +29,17 @@ func LoginV2(c echo.Context) error {
 		return err
 	}
 
-	_, err := v1.Login(c, req.UserName, req.Password)
+	userName, err := v1.ResolveLoginUsername(req.UserName, req.EncryptedUsername, req.KeyID)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+
+	password, err := v1.ResolveLoginPassword(req.Password, req.EncryptedPassword, req.KeyID)
+	if err != nil {
+		return controller.JSONBaseErrorReq(c, err)
+	}
+
+	_, err = v1.Login(c, userName, password)
 	if err != nil {
 		return controller.JSONBaseErrorReq(c, err)
 	}

--- a/sqle/config/config.go
+++ b/sqle/config/config.go
@@ -25,6 +25,10 @@ type SqleConfig struct {
 	LogMaxBackupNumber int    `yaml:"log_max_backup_number"`
 	PluginPath         string `yaml:"plugin_path"`
 	SecretKey          string `yaml:"secret_key"`
+	// LoginEncryptionMode: disabled | compatible | required；未配置视为 required
+	LoginEncryptionMode string `yaml:"login_encryption_mode"`
+	// LoginEncryptionPrivateKeyPath points to SM2 private key file (PEM or hex)；未配置用默认 path 并可自动生成
+	LoginEncryptionPrivateKeyPath string `yaml:"login_encryption_private_key_path"`
 }
 
 type DatabaseConfig struct {

--- a/sqle/pkg/loginencryption/loginencryption.go
+++ b/sqle/pkg/loginencryption/loginencryption.go
@@ -1,0 +1,333 @@
+package loginencryption
+
+import (
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/tjfoc/gmsm/sm2"
+	"github.com/tjfoc/gmsm/x509"
+)
+
+const (
+	ModeDisabled   = "disabled"
+	ModeCompatible = "compatible"
+	ModeRequired   = "required"
+
+	AlgorithmSM2     = "SM2"
+	CipherModeC1C3C2 = "C1C3C2"
+
+	// DefaultPrivateKeyPath is used when login_encryption_private_key_path is unset.
+	DefaultPrivateKeyPath = "./etc/login_sm2_private.pem"
+
+	// maxCipherHexLen limits SM2 ciphertext hex length to avoid oversized payloads.
+	maxCipherHexLen = 2048
+)
+
+// PublicInfo is returned by GET /v1/login/encryption.
+type PublicInfo struct {
+	Enable     bool   `json:"enable"`
+	Algorithm  string `json:"algorithm"`
+	CipherMode string `json:"cipher_mode"`
+	PublicKey  string `json:"public_key"`
+	KeyID      string `json:"key_id"`
+}
+
+// Manager holds login password encryption state.
+type Manager struct {
+	mode         string
+	privateKey   *sm2.PrivateKey
+	publicKeyHex string
+	keyID        string
+}
+
+var (
+	globalMu sync.RWMutex
+	global   = &Manager{mode: ModeDisabled}
+)
+
+// Init loads SM2 private key according to mode.
+// Empty mode is treated as required (zero-config default).
+// Empty privateKeyPath uses DefaultPrivateKeyPath and auto-generates PEM 0600 if missing.
+// An explicitly configured path that does not exist fails startup (no auto-generate).
+func Init(mode, privateKeyPath string) error {
+	mode = strings.TrimSpace(strings.ToLower(mode))
+	if mode == "" {
+		mode = ModeRequired
+	}
+
+	switch mode {
+	case ModeDisabled:
+		setGlobal(&Manager{mode: ModeDisabled})
+		return nil
+	case ModeCompatible, ModeRequired:
+		path := strings.TrimSpace(privateKeyPath)
+		allowGenerate := false
+		if path == "" {
+			path = DefaultPrivateKeyPath
+			allowGenerate = true
+		}
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				if !allowGenerate {
+					// Explicit path: never auto-generate; fail startup (S2).
+					return fmt.Errorf("login encryption private key path invalid or not readable: %s", path)
+				}
+				if err := generateAndSavePrivateKey(path); err != nil {
+					return fmt.Errorf("generate login encryption private key failed: %v", err)
+				}
+			} else {
+				return fmt.Errorf("stat login encryption private key failed: %v", err)
+			}
+		}
+		priv, err := loadPrivateKey(path)
+		if err != nil {
+			return fmt.Errorf("load login encryption private key failed: %v", err)
+		}
+		pubHex := publicKeyToHex(&priv.PublicKey)
+		m := &Manager{
+			mode:         mode,
+			privateKey:   priv,
+			publicKeyHex: pubHex,
+			keyID:        deriveKeyID(pubHex),
+		}
+		setGlobal(m)
+		return nil
+	default:
+		return fmt.Errorf("invalid login encryption mode: %s", mode)
+	}
+}
+
+// GetManager returns the current login encryption manager.
+func GetManager() *Manager {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return global
+}
+
+func setGlobal(m *Manager) {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	global = m
+}
+
+// PublicInfo returns public encryption metadata for clients.
+func (m *Manager) PublicInfo() PublicInfo {
+	if m == nil || m.mode == ModeDisabled || m.privateKey == nil {
+		return PublicInfo{Enable: false}
+	}
+	return PublicInfo{
+		Enable:     true,
+		Algorithm:  AlgorithmSM2,
+		CipherMode: CipherModeC1C3C2,
+		PublicKey:  m.publicKeyHex,
+		KeyID:      m.keyID,
+	}
+}
+
+// Enabled reports whether login encryption is active.
+func (m *Manager) Enabled() bool {
+	return m != nil && m.mode != ModeDisabled && m.privateKey != nil
+}
+
+// Mode returns current encryption mode.
+func (m *Manager) Mode() string {
+	if m == nil {
+		return ModeDisabled
+	}
+	return m.mode
+}
+
+// ResolveUsername returns plaintext username according to encryption mode.
+// Same key / algorithm / key_id rules as ResolvePassword.
+// It never returns ciphertext, plaintext username, or private key material in error messages.
+func (m *Manager) ResolveUsername(plainUsername, encryptedUsername, keyID string) (string, error) {
+	if m == nil || m.mode == ModeDisabled {
+		if plainUsername == "" {
+			return "", fmt.Errorf("username is required")
+		}
+		return plainUsername, nil
+	}
+
+	if m.mode == ModeRequired && strings.TrimSpace(plainUsername) != "" {
+		return "", fmt.Errorf("plaintext username is not allowed")
+	}
+
+	encryptedUsername = strings.TrimSpace(encryptedUsername)
+	if encryptedUsername == "" {
+		if m.mode == ModeRequired {
+			return "", fmt.Errorf("encrypted username is required")
+		}
+		if plainUsername == "" {
+			return "", fmt.Errorf("username is required")
+		}
+		return plainUsername, nil
+	}
+
+	if keyID != "" && keyID != m.keyID {
+		return "", fmt.Errorf("invalid key_id")
+	}
+	if len(encryptedUsername) > maxCipherHexLen {
+		return "", fmt.Errorf("encrypted username is too long")
+	}
+
+	plain, err := m.decryptCipher(encryptedUsername)
+	if err != nil {
+		return "", fmt.Errorf("decrypt username failed")
+	}
+	if plain == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	return plain, nil
+}
+
+// ResolvePassword returns plaintext password according to encryption mode.
+// It never returns ciphertext or private key material in error messages.
+func (m *Manager) ResolvePassword(plainPassword, encryptedPassword, keyID string) (string, error) {
+	if m == nil || m.mode == ModeDisabled {
+		if plainPassword == "" {
+			return "", fmt.Errorf("password is required")
+		}
+		return plainPassword, nil
+	}
+
+	if m.mode == ModeRequired && strings.TrimSpace(plainPassword) != "" {
+		return "", fmt.Errorf("plaintext password is not allowed")
+	}
+
+	encryptedPassword = strings.TrimSpace(encryptedPassword)
+	if encryptedPassword == "" {
+		if m.mode == ModeRequired {
+			return "", fmt.Errorf("encrypted password is required")
+		}
+		if plainPassword == "" {
+			return "", fmt.Errorf("password is required")
+		}
+		return plainPassword, nil
+	}
+
+	if keyID != "" && keyID != m.keyID {
+		return "", fmt.Errorf("invalid key_id")
+	}
+	if len(encryptedPassword) > maxCipherHexLen {
+		return "", fmt.Errorf("encrypted password is too long")
+	}
+
+	plain, err := m.decryptCipher(encryptedPassword)
+	if err != nil {
+		return "", fmt.Errorf("decrypt password failed")
+	}
+	if plain == "" {
+		return "", fmt.Errorf("password is required")
+	}
+	return plain, nil
+}
+
+func (m *Manager) decryptCipher(cipherHex string) (string, error) {
+	raw, err := hex.DecodeString(cipherHex)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) == 0 {
+		return "", fmt.Errorf("empty ciphertext")
+	}
+	// sm-crypto omits the leading 0x04; gmsm Decrypt(C1C3C2) expects it.
+	if raw[0] != 0x04 {
+		raw = append([]byte{0x04}, raw...)
+	}
+	// C1(64) + C3(32) + C2(>=1) + leading 0x04 => at least 98 bytes
+	if len(raw) < 98 {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	plain, err := sm2.Decrypt(m.privateKey, raw, sm2.C1C3C2)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+func generateAndSavePrivateKey(path string) error {
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return err
+		}
+	}
+	priv, err := sm2.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	pemBytes, err := x509.WritePrivateKeyToPem(priv, nil)
+	if err != nil {
+		return err
+	}
+	// O_EXCL: never overwrite an existing key file.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(pemBytes); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+func loadPrivateKey(path string) (*sm2.PrivateKey, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(string(content))
+	if trimmed == "" {
+		return nil, fmt.Errorf("private key file is empty")
+	}
+
+	if strings.Contains(trimmed, "BEGIN") {
+		priv, err := x509.ReadPrivateKeyFromPem([]byte(trimmed), nil)
+		if err != nil {
+			return nil, err
+		}
+		return priv, nil
+	}
+
+	hexKey := strings.ReplaceAll(trimmed, "\n", "")
+	hexKey = strings.ReplaceAll(hexKey, "\r", "")
+	hexKey = strings.ReplaceAll(hexKey, " ", "")
+	dBytes, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("private key must be PEM or hex")
+	}
+	if len(dBytes) == 0 || len(dBytes) > 32 {
+		return nil, fmt.Errorf("invalid private key length")
+	}
+	padded := make([]byte, 32)
+	copy(padded[32-len(dBytes):], dBytes)
+
+	curve := sm2.P256Sm2()
+	priv := new(sm2.PrivateKey)
+	priv.PublicKey.Curve = curve
+	priv.D = new(big.Int).SetBytes(padded)
+	priv.PublicKey.X, priv.PublicKey.Y = curve.ScalarBaseMult(padded)
+	if priv.PublicKey.X == nil || !curve.IsOnCurve(priv.PublicKey.X, priv.PublicKey.Y) {
+		return nil, fmt.Errorf("invalid private key")
+	}
+	return priv, nil
+}
+
+func publicKeyToHex(pub *sm2.PublicKey) string {
+	return hex.EncodeToString(elliptic.Marshal(pub.Curve, pub.X, pub.Y))
+}
+
+func deriveKeyID(publicKeyHex string) string {
+	sum := sha256.Sum256([]byte(publicKeyHex))
+	return hex.EncodeToString(sum[:8])
+}

--- a/sqle/pkg/loginencryption/loginencryption_test.go
+++ b/sqle/pkg/loginencryption/loginencryption_test.go
@@ -1,0 +1,298 @@
+package loginencryption
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tjfoc/gmsm/sm2"
+)
+
+// encryptForTest encrypts plaintext with current manager public key (test helper; was EncryptForTest).
+func encryptForTest(plain string) (cipherHex string, keyID string, err error) {
+	m := GetManager()
+	if !m.Enabled() {
+		return "", "", fmt.Errorf("encryption is disabled")
+	}
+	cipher, err := sm2.Encrypt(&m.privateKey.PublicKey, []byte(plain), rand.Reader, sm2.C1C3C2)
+	if err != nil {
+		return "", "", err
+	}
+	return hex.EncodeToString(cipher), m.keyID, nil
+}
+
+func resetManager(t *testing.T) {
+	t.Helper()
+	setGlobal(&Manager{mode: ModeDisabled})
+	t.Cleanup(func() {
+		setGlobal(&Manager{mode: ModeDisabled})
+	})
+}
+
+func mustWriteKey(t *testing.T, path string) []byte {
+	t.Helper()
+	if err := generateAndSavePrivateKey(path); err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	raw, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	return raw
+}
+
+func TestInit(t *testing.T) {
+	t.Run("empty_mode_equals_required", func(t *testing.T) {
+		resetManager(t)
+		dir := t.TempDir()
+		oldWD, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+		if err := Init("", ""); err != nil {
+			t.Fatalf("Init: %v", err)
+		}
+		m := GetManager()
+		if m.Mode() != ModeRequired {
+			t.Fatalf("mode=%q, want %q", m.Mode(), ModeRequired)
+		}
+		if !m.Enabled() {
+			t.Fatal("expected enabled")
+		}
+		info := m.PublicInfo()
+		if !info.Enable || info.PublicKey == "" || info.KeyID == "" {
+			t.Fatalf("PublicInfo incomplete: %+v", info)
+		}
+		if _, err := os.Stat(DefaultPrivateKeyPath); err != nil {
+			t.Fatalf("default key not created: %v", err)
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		resetManager(t)
+		if err := Init(ModeDisabled, "/nonexistent/should-be-ignored.pem"); err != nil {
+			t.Fatalf("Init: %v", err)
+		}
+		m := GetManager()
+		if m.Mode() != ModeDisabled || m.Enabled() {
+			t.Fatalf("mode=%q enabled=%v", m.Mode(), m.Enabled())
+		}
+		info := m.PublicInfo()
+		if info.Enable {
+			t.Fatalf("PublicInfo.Enable=true in disabled mode")
+		}
+	})
+
+	t.Run("explicit_path_missing_fails", func(t *testing.T) {
+		resetManager(t)
+		missing := filepath.Join(t.TempDir(), "missing", "key.pem")
+		err := Init(ModeRequired, missing)
+		if err == nil {
+			t.Fatal("expected error for missing explicit path")
+		}
+		if _, statErr := os.Stat(missing); !os.IsNotExist(statErr) {
+			t.Fatalf("must not create explicit missing path; stat=%v", statErr)
+		}
+		if GetManager().Enabled() {
+			t.Fatal("manager must stay disabled after failed Init")
+		}
+	})
+
+	t.Run("o_excl_does_not_overwrite_existing_key", func(t *testing.T) {
+		resetManager(t)
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "login_sm2_private.pem")
+		before := mustWriteKey(t, keyPath)
+
+		// Second generate must fail with O_EXCL (file exists).
+		if err := generateAndSavePrivateKey(keyPath); err == nil {
+			t.Fatal("expected O_EXCL failure on existing key")
+		}
+		afterGen, err := ioutil.ReadFile(keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(afterGen) != string(before) {
+			t.Fatal("generateAndSavePrivateKey overwrote existing key")
+		}
+
+		if err := Init(ModeCompatible, keyPath); err != nil {
+			t.Fatalf("Init: %v", err)
+		}
+		afterInit, err := ioutil.ReadFile(keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(afterInit) != string(before) {
+			t.Fatal("Init overwrote existing key")
+		}
+		if GetManager().Mode() != ModeCompatible || !GetManager().Enabled() {
+			t.Fatalf("mode=%q enabled=%v", GetManager().Mode(), GetManager().Enabled())
+		}
+	})
+}
+
+func TestResolveUsername(t *testing.T) {
+	resetManager(t)
+	keyPath := filepath.Join(t.TempDir(), "key.pem")
+	mustWriteKey(t, keyPath)
+	if err := Init(ModeRequired, keyPath); err != nil {
+		t.Fatalf("Init required: %v", err)
+	}
+	cipher, keyID, err := encryptForTest("admin")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T)
+		plain     string
+		encrypted string
+		keyID     string
+		want      string
+		wantErr   string
+	}{
+		{
+			name:    "required_rejects_plaintext",
+			plain:   "admin",
+			wantErr: "plaintext username is not allowed",
+		},
+		{
+			name:    "required_missing_ciphertext",
+			wantErr: "encrypted username is required",
+		},
+		{
+			name:      "required_key_id_mismatch",
+			encrypted: cipher,
+			keyID:     "deadbeefdeadbeef",
+			wantErr:   "invalid key_id",
+		},
+		{
+			name:      "required_ok",
+			encrypted: cipher,
+			keyID:     keyID,
+			want:      "admin",
+		},
+		{
+			name: "compatible_plaintext_escape",
+			setup: func(t *testing.T) {
+				if err := Init(ModeCompatible, keyPath); err != nil {
+					t.Fatalf("Init compatible: %v", err)
+				}
+			},
+			plain: "legacy-user",
+			want:  "legacy-user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			} else if err := Init(ModeRequired, keyPath); err != nil {
+				t.Fatalf("Init required: %v", err)
+			}
+			got, err := GetManager().ResolveUsername(tt.plain, tt.encrypted, tt.keyID)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("err=%v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvePassword(t *testing.T) {
+	resetManager(t)
+	keyPath := filepath.Join(t.TempDir(), "key.pem")
+	mustWriteKey(t, keyPath)
+	if err := Init(ModeRequired, keyPath); err != nil {
+		t.Fatalf("Init required: %v", err)
+	}
+	cipher, keyID, err := encryptForTest("secret")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T)
+		plain     string
+		encrypted string
+		keyID     string
+		want      string
+		wantErr   string
+	}{
+		{
+			name:    "required_rejects_plaintext",
+			plain:   "secret",
+			wantErr: "plaintext password is not allowed",
+		},
+		{
+			name:    "required_missing_ciphertext",
+			wantErr: "encrypted password is required",
+		},
+		{
+			name:      "required_key_id_mismatch",
+			encrypted: cipher,
+			keyID:     "deadbeefdeadbeef",
+			wantErr:   "invalid key_id",
+		},
+		{
+			name:      "required_ok",
+			encrypted: cipher,
+			keyID:     keyID,
+			want:      "secret",
+		},
+		{
+			name: "compatible_plaintext_escape",
+			setup: func(t *testing.T) {
+				if err := Init(ModeCompatible, keyPath); err != nil {
+					t.Fatalf("Init compatible: %v", err)
+				}
+			},
+			plain: "legacy-pass",
+			want:  "legacy-pass",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			} else if err := Init(ModeRequired, keyPath); err != nil {
+				t.Fatalf("Init required: %v", err)
+			}
+			got, err := GetManager().ResolvePassword(tt.plain, tt.encrypted, tt.keyID)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("err=%v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/sqle/sqled.go
+++ b/sqle/sqled.go
@@ -13,6 +13,7 @@ import (
 	"github.com/actiontech/sqle/sqle/log"
 	"github.com/actiontech/sqle/sqle/model"
 	"github.com/actiontech/sqle/sqle/notification/webhook"
+	"github.com/actiontech/sqle/sqle/pkg/loginencryption"
 	"github.com/actiontech/sqle/sqle/server"
 	"github.com/actiontech/sqle/sqle/server/cluster"
 	"github.com/actiontech/sqle/sqle/utils"
@@ -38,6 +39,10 @@ func Run(config *config.Config) error {
 		if err := utils.SetSecretKey([]byte(secretKey)); err != nil {
 			return fmt.Errorf("set secret key error, %v, check your secret key in config file", err)
 		}
+	}
+
+	if err := loginencryption.Init(sqleCnf.LoginEncryptionMode, sqleCnf.LoginEncryptionPrivateKeyPath); err != nil {
+		return fmt.Errorf("init login encryption error: %v", err)
 	}
 
 	defer driver.GetPluginManager().Stop()

--- a/vendor/github.com/tjfoc/gmsm/sm2/p256.go
+++ b/vendor/github.com/tjfoc/gmsm/sm2/p256.go
@@ -1,0 +1,1182 @@
+/*
+Copyright Suzhou Tongji Fintech Research Institute 2017 All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sm2
+
+import (
+	"crypto/elliptic"
+	"math/big"
+	"sync"
+)
+
+/** 学习标准库p256的优化方法实现sm2的快速版本
+ * 标准库的p256的代码实现有些晦涩难懂，当然sm2的同样如此，有兴趣的大家可以研究研究，最后神兽压阵。。。
+ *
+ * ━━━━━━animal━━━━━━
+ * 　　　┏┓　　　┏┓
+ * 　　┏┛┻━━━┛┻┓
+ * 　　┃　　　　　　　┃
+ * 　　┃　　　━　　　┃
+ * 　　┃　┳┛　┗┳　┃
+ * 　　┃　　　　　　　┃
+ * 　　┃　　　┻　　　┃
+ * 　　┃　　　　　　　┃
+ * 　　┗━┓　　　┏━┛
+ * 　　　┃　　　┃
+ *　　 　┃　　　┃
+ *　　　 ┃　　　┗━━━┓
+ *	   　┃　　　　　┣┓
+ *   　　┃　　　　　┏┛
+ *　　 　┗┓┓┏━┳┓┏┛
+ *　　　　┃┫┫ ┃┫┫
+ *　　　　┗┻┛ ┗┻┛
+ *
+ * ━━━━━Kawaii ━━━━━━
+ */
+
+type sm2P256Curve struct {
+	RInverse *big.Int
+	*elliptic.CurveParams
+	a, b, gx, gy sm2P256FieldElement
+}
+
+var initonce sync.Once
+var sm2P256 sm2P256Curve
+
+type sm2P256FieldElement [9]uint32
+type sm2P256LargeFieldElement [17]uint64
+
+const (
+	bottom28Bits = 0xFFFFFFF
+	bottom29Bits = 0x1FFFFFFF
+)
+
+func initP256Sm2() {
+	sm2P256.CurveParams = &elliptic.CurveParams{Name: "SM2-P-256"} // sm2
+	A, _ := new(big.Int).SetString("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFC", 16)
+	//SM2椭	椭 圆 曲 线 公 钥 密 码 算 法 推 荐 曲 线 参 数
+	sm2P256.P, _ = new(big.Int).SetString("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFF", 16)
+	sm2P256.N, _ = new(big.Int).SetString("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFF7203DF6B21C6052B53BBF40939D54123", 16)
+	sm2P256.B, _ = new(big.Int).SetString("28E9FA9E9D9F5E344D5A9E4BCF6509A7F39789F515AB8F92DDBCBD414D940E93", 16)
+	sm2P256.Gx, _ = new(big.Int).SetString("32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7", 16)
+	sm2P256.Gy, _ = new(big.Int).SetString("BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0", 16)
+	sm2P256.RInverse, _ = new(big.Int).SetString("7ffffffd80000002fffffffe000000017ffffffe800000037ffffffc80000002", 16)
+	sm2P256.BitSize = 256
+	sm2P256FromBig(&sm2P256.a, A)
+	sm2P256FromBig(&sm2P256.gx, sm2P256.Gx)
+	sm2P256FromBig(&sm2P256.gy, sm2P256.Gy)
+	sm2P256FromBig(&sm2P256.b, sm2P256.B)
+}
+
+func P256Sm2() elliptic.Curve {
+	initonce.Do(initP256Sm2)
+	return sm2P256
+}
+
+func (curve sm2P256Curve) Params() *elliptic.CurveParams {
+	return sm2P256.CurveParams
+}
+
+// y^2 = x^3 + ax + b
+func (curve sm2P256Curve) IsOnCurve(X, Y *big.Int) bool {
+	var a, x, y, y2, x3 sm2P256FieldElement
+
+	sm2P256FromBig(&x, X)
+	sm2P256FromBig(&y, Y)
+
+	sm2P256Square(&x3, &x)       // x3 = x ^ 2
+	sm2P256Mul(&x3, &x3, &x)     // x3 = x ^ 2 * x
+	sm2P256Mul(&a, &curve.a, &x) // a = a * x
+	sm2P256Add(&x3, &x3, &a)
+	sm2P256Add(&x3, &x3, &curve.b)
+
+	sm2P256Square(&y2, &y) // y2 = y ^ 2
+	return sm2P256ToBig(&x3).Cmp(sm2P256ToBig(&y2)) == 0
+}
+
+func zForAffine(x, y *big.Int) *big.Int {
+	z := new(big.Int)
+	if x.Sign() != 0 || y.Sign() != 0 {
+		z.SetInt64(1)
+	}
+	return z
+}
+
+func (curve sm2P256Curve) Add(x1, y1, x2, y2 *big.Int) (*big.Int, *big.Int) {
+	var X1, Y1, Z1, X2, Y2, Z2, X3, Y3, Z3 sm2P256FieldElement
+
+	z1 := zForAffine(x1, y1)
+	z2 := zForAffine(x2, y2)
+	sm2P256FromBig(&X1, x1)
+	sm2P256FromBig(&Y1, y1)
+	sm2P256FromBig(&Z1, z1)
+	sm2P256FromBig(&X2, x2)
+	sm2P256FromBig(&Y2, y2)
+	sm2P256FromBig(&Z2, z2)
+	sm2P256PointAdd(&X1, &Y1, &Z1, &X2, &Y2, &Z2, &X3, &Y3, &Z3)
+	return sm2P256ToAffine(&X3, &Y3, &Z3)
+}
+
+func (curve sm2P256Curve) Double(x1, y1 *big.Int) (*big.Int, *big.Int) {
+	var X1, Y1, Z1 sm2P256FieldElement
+
+	z1 := zForAffine(x1, y1)
+	sm2P256FromBig(&X1, x1)
+	sm2P256FromBig(&Y1, y1)
+	sm2P256FromBig(&Z1, z1)
+	sm2P256PointDouble(&X1, &Y1, &Z1, &X1, &Y1, &Z1)
+	return sm2P256ToAffine(&X1, &Y1, &Z1)
+}
+
+func (curve sm2P256Curve) ScalarMult(x1, y1 *big.Int, k []byte) (*big.Int, *big.Int) {
+	var X, Y, Z, X1, Y1 sm2P256FieldElement
+	sm2P256FromBig(&X1, x1)
+	sm2P256FromBig(&Y1, y1)
+	scalar := sm2GenrateWNaf(k)
+	scalarReversed := WNafReversed(scalar)
+	sm2P256ScalarMult(&X, &Y, &Z, &X1, &Y1, scalarReversed)
+	return sm2P256ToAffine(&X, &Y, &Z)
+}
+
+func (curve sm2P256Curve) ScalarBaseMult(k []byte) (*big.Int, *big.Int) {
+	var scalarReversed [32]byte
+	var X, Y, Z sm2P256FieldElement
+
+	sm2P256GetScalar(&scalarReversed, k)
+	sm2P256ScalarBaseMult(&X, &Y, &Z, &scalarReversed)
+	return sm2P256ToAffine(&X, &Y, &Z)
+}
+
+var sm2P256Precomputed = [9 * 2 * 15 * 2]uint32{
+	0x830053d, 0x328990f, 0x6c04fe1, 0xc0f72e5, 0x1e19f3c, 0x666b093, 0x175a87b, 0xec38276, 0x222cf4b,
+	0x185a1bba, 0x354e593, 0x1295fac1, 0xf2bc469, 0x47c60fa, 0xc19b8a9, 0xf63533e, 0x903ae6b, 0xc79acba,
+	0x15b061a4, 0x33e020b, 0xdffb34b, 0xfcf2c8, 0x16582e08, 0x262f203, 0xfb34381, 0xa55452, 0x604f0ff,
+	0x41f1f90, 0xd64ced2, 0xee377bf, 0x75f05f0, 0x189467ae, 0xe2244e, 0x1e7700e8, 0x3fbc464, 0x9612d2e,
+	0x1341b3b8, 0xee84e23, 0x1edfa5b4, 0x14e6030, 0x19e87be9, 0x92f533c, 0x1665d96c, 0x226653e, 0xa238d3e,
+	0xf5c62c, 0x95bb7a, 0x1f0e5a41, 0x28789c3, 0x1f251d23, 0x8726609, 0xe918910, 0x8096848, 0xf63d028,
+	0x152296a1, 0x9f561a8, 0x14d376fb, 0x898788a, 0x61a95fb, 0xa59466d, 0x159a003d, 0x1ad1698, 0x93cca08,
+	0x1b314662, 0x706e006, 0x11ce1e30, 0x97b710, 0x172fbc0d, 0x8f50158, 0x11c7ffe7, 0xd182cce, 0xc6ad9e8,
+	0x12ea31b2, 0xc4e4f38, 0x175b0d96, 0xec06337, 0x75a9c12, 0xb001fdf, 0x93e82f5, 0x34607de, 0xb8035ed,
+	0x17f97924, 0x75cf9e6, 0xdceaedd, 0x2529924, 0x1a10c5ff, 0xb1a54dc, 0x19464d8, 0x2d1997, 0xde6a110,
+	0x1e276ee5, 0x95c510c, 0x1aca7c7a, 0xfe48aca, 0x121ad4d9, 0xe4132c6, 0x8239b9d, 0x40ea9cd, 0x816c7b,
+	0x632d7a4, 0xa679813, 0x5911fcf, 0x82b0f7c, 0x57b0ad5, 0xbef65, 0xd541365, 0x7f9921f, 0xc62e7a,
+	0x3f4b32d, 0x58e50e1, 0x6427aed, 0xdcdda67, 0xe8c2d3e, 0x6aa54a4, 0x18df4c35, 0x49a6a8e, 0x3cd3d0c,
+	0xd7adf2, 0xcbca97, 0x1bda5f2d, 0x3258579, 0x606b1e6, 0x6fc1b5b, 0x1ac27317, 0x503ca16, 0xa677435,
+	0x57bc73, 0x3992a42, 0xbab987b, 0xfab25eb, 0x128912a4, 0x90a1dc4, 0x1402d591, 0x9ffbcfc, 0xaa48856,
+	0x7a7c2dc, 0xcefd08a, 0x1b29bda6, 0xa785641, 0x16462d8c, 0x76241b7, 0x79b6c3b, 0x204ae18, 0xf41212b,
+	0x1f567a4d, 0xd6ce6db, 0xedf1784, 0x111df34, 0x85d7955, 0x55fc189, 0x1b7ae265, 0xf9281ac, 0xded7740,
+	0xf19468b, 0x83763bb, 0x8ff7234, 0x3da7df8, 0x9590ac3, 0xdc96f2a, 0x16e44896, 0x7931009, 0x99d5acc,
+	0x10f7b842, 0xaef5e84, 0xc0310d7, 0xdebac2c, 0x2a7b137, 0x4342344, 0x19633649, 0x3a10624, 0x4b4cb56,
+	0x1d809c59, 0xac007f, 0x1f0f4bcd, 0xa1ab06e, 0xc5042cf, 0x82c0c77, 0x76c7563, 0x22c30f3, 0x3bf1568,
+	0x7a895be, 0xfcca554, 0x12e90e4c, 0x7b4ab5f, 0x13aeb76b, 0x5887e2c, 0x1d7fe1e3, 0x908c8e3, 0x95800ee,
+	0xb36bd54, 0xf08905d, 0x4e73ae8, 0xf5a7e48, 0xa67cb0, 0x50e1067, 0x1b944a0a, 0xf29c83a, 0xb23cfb9,
+	0xbe1db1, 0x54de6e8, 0xd4707f2, 0x8ebcc2d, 0x2c77056, 0x1568ce4, 0x15fcc849, 0x4069712, 0xe2ed85f,
+	0x2c5ff09, 0x42a6929, 0x628e7ea, 0xbd5b355, 0xaf0bd79, 0xaa03699, 0xdb99816, 0x4379cef, 0x81d57b,
+	0x11237f01, 0xe2a820b, 0xfd53b95, 0x6beb5ee, 0x1aeb790c, 0xe470d53, 0x2c2cfee, 0x1c1d8d8, 0xa520fc4,
+	0x1518e034, 0xa584dd4, 0x29e572b, 0xd4594fc, 0x141a8f6f, 0x8dfccf3, 0x5d20ba3, 0x2eb60c3, 0x9f16eb0,
+	0x11cec356, 0xf039f84, 0x1b0990c1, 0xc91e526, 0x10b65bae, 0xf0616e8, 0x173fa3ff, 0xec8ccf9, 0xbe32790,
+	0x11da3e79, 0xe2f35c7, 0x908875c, 0xdacf7bd, 0x538c165, 0x8d1487f, 0x7c31aed, 0x21af228, 0x7e1689d,
+	0xdfc23ca, 0x24f15dc, 0x25ef3c4, 0x35248cd, 0x99a0f43, 0xa4b6ecc, 0xd066b3, 0x2481152, 0x37a7688,
+	0x15a444b6, 0xb62300c, 0x4b841b, 0xa655e79, 0xd53226d, 0xbeb348a, 0x127f3c2, 0xb989247, 0x71a277d,
+	0x19e9dfcb, 0xb8f92d0, 0xe2d226c, 0x390a8b0, 0x183cc462, 0x7bd8167, 0x1f32a552, 0x5e02db4, 0xa146ee9,
+	0x1a003957, 0x1c95f61, 0x1eeec155, 0x26f811f, 0xf9596ba, 0x3082bfb, 0x96df083, 0x3e3a289, 0x7e2d8be,
+	0x157a63e0, 0x99b8941, 0x1da7d345, 0xcc6cd0, 0x10beed9a, 0x48e83c0, 0x13aa2e25, 0x7cad710, 0x4029988,
+	0x13dfa9dd, 0xb94f884, 0x1f4adfef, 0xb88543, 0x16f5f8dc, 0xa6a67f4, 0x14e274e2, 0x5e56cf4, 0x2f24ef,
+	0x1e9ef967, 0xfe09bad, 0xfe079b3, 0xcc0ae9e, 0xb3edf6d, 0x3e961bc, 0x130d7831, 0x31043d6, 0xba986f9,
+	0x1d28055, 0x65240ca, 0x4971fa3, 0x81b17f8, 0x11ec34a5, 0x8366ddc, 0x1471809, 0xfa5f1c6, 0xc911e15,
+	0x8849491, 0xcf4c2e2, 0x14471b91, 0x39f75be, 0x445c21e, 0xf1585e9, 0x72cc11f, 0x4c79f0c, 0xe5522e1,
+	0x1874c1ee, 0x4444211, 0x7914884, 0x3d1b133, 0x25ba3c, 0x4194f65, 0x1c0457ef, 0xac4899d, 0xe1fa66c,
+	0x130a7918, 0x9b8d312, 0x4b1c5c8, 0x61ccac3, 0x18c8aa6f, 0xe93cb0a, 0xdccb12c, 0xde10825, 0x969737d,
+	0xf58c0c3, 0x7cee6a9, 0xc2c329a, 0xc7f9ed9, 0x107b3981, 0x696a40e, 0x152847ff, 0x4d88754, 0xb141f47,
+	0x5a16ffe, 0x3a7870a, 0x18667659, 0x3b72b03, 0xb1c9435, 0x9285394, 0xa00005a, 0x37506c, 0x2edc0bb,
+	0x19afe392, 0xeb39cac, 0x177ef286, 0xdf87197, 0x19f844ed, 0x31fe8, 0x15f9bfd, 0x80dbec, 0x342e96e,
+	0x497aced, 0xe88e909, 0x1f5fa9ba, 0x530a6ee, 0x1ef4e3f1, 0x69ffd12, 0x583006d, 0x2ecc9b1, 0x362db70,
+	0x18c7bdc5, 0xf4bb3c5, 0x1c90b957, 0xf067c09, 0x9768f2b, 0xf73566a, 0x1939a900, 0x198c38a, 0x202a2a1,
+	0x4bbf5a6, 0x4e265bc, 0x1f44b6e7, 0x185ca49, 0xa39e81b, 0x24aff5b, 0x4acc9c2, 0x638bdd3, 0xb65b2a8,
+	0x6def8be, 0xb94537a, 0x10b81dee, 0xe00ec55, 0x2f2cdf7, 0xc20622d, 0x2d20f36, 0xe03c8c9, 0x898ea76,
+	0x8e3921b, 0x8905bff, 0x1e94b6c8, 0xee7ad86, 0x154797f2, 0xa620863, 0x3fbd0d9, 0x1f3caab, 0x30c24bd,
+	0x19d3892f, 0x59c17a2, 0x1ab4b0ae, 0xf8714ee, 0x90c4098, 0xa9c800d, 0x1910236b, 0xea808d3, 0x9ae2f31,
+	0x1a15ad64, 0xa48c8d1, 0x184635a4, 0xb725ef1, 0x11921dcc, 0x3f866df, 0x16c27568, 0xbdf580a, 0xb08f55c,
+	0x186ee1c, 0xb1627fa, 0x34e82f6, 0x933837e, 0xf311be5, 0xfedb03b, 0x167f72cd, 0xa5469c0, 0x9c82531,
+	0xb92a24b, 0x14fdc8b, 0x141980d1, 0xbdc3a49, 0x7e02bb1, 0xaf4e6dd, 0x106d99e1, 0xd4616fc, 0x93c2717,
+	0x1c0a0507, 0xc6d5fed, 0x9a03d8b, 0xa1d22b0, 0x127853e3, 0xc4ac6b8, 0x1a048cf7, 0x9afb72c, 0x65d485d,
+	0x72d5998, 0xe9fa744, 0xe49e82c, 0x253cf80, 0x5f777ce, 0xa3799a5, 0x17270cbb, 0xc1d1ef0, 0xdf74977,
+	0x114cb859, 0xfa8e037, 0xb8f3fe5, 0xc734cc6, 0x70d3d61, 0xeadac62, 0x12093dd0, 0x9add67d, 0x87200d6,
+	0x175bcbb, 0xb29b49f, 0x1806b79c, 0x12fb61f, 0x170b3a10, 0x3aaf1cf, 0xa224085, 0x79d26af, 0x97759e2,
+	0x92e19f1, 0xb32714d, 0x1f00d9f1, 0xc728619, 0x9e6f627, 0xe745e24, 0x18ea4ace, 0xfc60a41, 0x125f5b2,
+	0xc3cf512, 0x39ed486, 0xf4d15fa, 0xf9167fd, 0x1c1f5dd5, 0xc21a53e, 0x1897930, 0x957a112, 0x21059a0,
+	0x1f9e3ddc, 0xa4dfced, 0x8427f6f, 0x726fbe7, 0x1ea658f8, 0x2fdcd4c, 0x17e9b66f, 0xb2e7c2e, 0x39923bf,
+	0x1bae104, 0x3973ce5, 0xc6f264c, 0x3511b84, 0x124195d7, 0x11996bd, 0x20be23d, 0xdc437c4, 0x4b4f16b,
+	0x11902a0, 0x6c29cc9, 0x1d5ffbe6, 0xdb0b4c7, 0x10144c14, 0x2f2b719, 0x301189, 0x2343336, 0xa0bf2ac,
+}
+
+func sm2P256GetScalar(b *[32]byte, a []byte) {
+	var scalarBytes []byte
+
+	n := new(big.Int).SetBytes(a)
+	if n.Cmp(sm2P256.N) >= 0 {
+		n.Mod(n, sm2P256.N)
+		scalarBytes = n.Bytes()
+	} else {
+		scalarBytes = a
+	}
+	for i, v := range scalarBytes {
+		b[len(scalarBytes)-(1+i)] = v
+	}
+}
+
+func sm2P256PointAddMixed(xOut, yOut, zOut, x1, y1, z1, x2, y2 *sm2P256FieldElement) {
+	var z1z1, z1z1z1, s2, u2, h, i, j, r, rr, v, tmp sm2P256FieldElement
+
+	sm2P256Square(&z1z1, z1)
+	sm2P256Add(&tmp, z1, z1)
+
+	sm2P256Mul(&u2, x2, &z1z1)
+	sm2P256Mul(&z1z1z1, z1, &z1z1)
+	sm2P256Mul(&s2, y2, &z1z1z1)
+	sm2P256Sub(&h, &u2, x1)
+	sm2P256Add(&i, &h, &h)
+	sm2P256Square(&i, &i)
+	sm2P256Mul(&j, &h, &i)
+	sm2P256Sub(&r, &s2, y1)
+	sm2P256Add(&r, &r, &r)
+	sm2P256Mul(&v, x1, &i)
+
+	sm2P256Mul(zOut, &tmp, &h)
+	sm2P256Square(&rr, &r)
+	sm2P256Sub(xOut, &rr, &j)
+	sm2P256Sub(xOut, xOut, &v)
+	sm2P256Sub(xOut, xOut, &v)
+
+	sm2P256Sub(&tmp, &v, xOut)
+	sm2P256Mul(yOut, &tmp, &r)
+	sm2P256Mul(&tmp, y1, &j)
+	sm2P256Sub(yOut, yOut, &tmp)
+	sm2P256Sub(yOut, yOut, &tmp)
+}
+
+// sm2P256CopyConditional sets out=in if mask = 0xffffffff in constant time.
+//
+// On entry: mask is either 0 or 0xffffffff.
+func sm2P256CopyConditional(out, in *sm2P256FieldElement, mask uint32) {
+	for i := 0; i < 9; i++ {
+		tmp := mask & (in[i] ^ out[i])
+		out[i] ^= tmp
+	}
+}
+
+// sm2P256SelectAffinePoint sets {out_x,out_y} to the index'th entry of table.
+// On entry: index < 16, table[0] must be zero.
+func sm2P256SelectAffinePoint(xOut, yOut *sm2P256FieldElement, table []uint32, index uint32) {
+	for i := range xOut {
+		xOut[i] = 0
+	}
+	for i := range yOut {
+		yOut[i] = 0
+	}
+
+	for i := uint32(1); i < 16; i++ {
+		mask := i ^ index
+		mask |= mask >> 2
+		mask |= mask >> 1
+		mask &= 1
+		mask--
+		for j := range xOut {
+			xOut[j] |= table[0] & mask
+			table = table[1:]
+		}
+		for j := range yOut {
+			yOut[j] |= table[0] & mask
+			table = table[1:]
+		}
+	}
+}
+
+// sm2P256SelectJacobianPoint sets {out_x,out_y,out_z} to the index'th entry of
+// table.
+// On entry: index < 16, table[0] must be zero.
+func sm2P256SelectJacobianPoint(xOut, yOut, zOut *sm2P256FieldElement, table *[16][3]sm2P256FieldElement, index uint32) {
+	for i := range xOut {
+		xOut[i] = 0
+	}
+	for i := range yOut {
+		yOut[i] = 0
+	}
+	for i := range zOut {
+		zOut[i] = 0
+	}
+
+	// The implicit value at index 0 is all zero. We don't need to perform that
+	// iteration of the loop because we already set out_* to zero.
+	for i := uint32(1); i < 16; i++ {
+		mask := i ^ index
+		mask |= mask >> 2
+		mask |= mask >> 1
+		mask &= 1
+		mask--
+		for j := range xOut {
+			xOut[j] |= table[i][0][j] & mask
+		}
+		for j := range yOut {
+			yOut[j] |= table[i][1][j] & mask
+		}
+		for j := range zOut {
+			zOut[j] |= table[i][2][j] & mask
+		}
+	}
+}
+
+// sm2P256GetBit returns the bit'th bit of scalar.
+func sm2P256GetBit(scalar *[32]uint8, bit uint) uint32 {
+	return uint32(((scalar[bit>>3]) >> (bit & 7)) & 1)
+}
+
+// sm2P256ScalarBaseMult sets {xOut,yOut,zOut} = scalar*G where scalar is a
+// little-endian number. Note that the value of scalar must be less than the
+// order of the group.
+func sm2P256ScalarBaseMult(xOut, yOut, zOut *sm2P256FieldElement, scalar *[32]uint8) {
+	nIsInfinityMask := ^uint32(0)
+	var px, py, tx, ty, tz sm2P256FieldElement
+	var pIsNoninfiniteMask, mask, tableOffset uint32
+
+	for i := range xOut {
+		xOut[i] = 0
+	}
+	for i := range yOut {
+		yOut[i] = 0
+	}
+	for i := range zOut {
+		zOut[i] = 0
+	}
+
+	// The loop adds bits at positions 0, 64, 128 and 192, followed by
+	// positions 32,96,160 and 224 and does this 32 times.
+	for i := uint(0); i < 32; i++ {
+		if i != 0 {
+			sm2P256PointDouble(xOut, yOut, zOut, xOut, yOut, zOut)
+		}
+		tableOffset = 0
+		for j := uint(0); j <= 32; j += 32 {
+			bit0 := sm2P256GetBit(scalar, 31-i+j)
+			bit1 := sm2P256GetBit(scalar, 95-i+j)
+			bit2 := sm2P256GetBit(scalar, 159-i+j)
+			bit3 := sm2P256GetBit(scalar, 223-i+j)
+			index := bit0 | (bit1 << 1) | (bit2 << 2) | (bit3 << 3)
+
+			sm2P256SelectAffinePoint(&px, &py, sm2P256Precomputed[tableOffset:], index)
+			tableOffset += 30 * 9
+
+			// Since scalar is less than the order of the group, we know that
+			// {xOut,yOut,zOut} != {px,py,1}, unless both are zero, which we handle
+			// below.
+			sm2P256PointAddMixed(&tx, &ty, &tz, xOut, yOut, zOut, &px, &py)
+			// The result of pointAddMixed is incorrect if {xOut,yOut,zOut} is zero
+			// (a.k.a.  the point at infinity). We handle that situation by
+			// copying the point from the table.
+			sm2P256CopyConditional(xOut, &px, nIsInfinityMask)
+			sm2P256CopyConditional(yOut, &py, nIsInfinityMask)
+			sm2P256CopyConditional(zOut, &sm2P256Factor[1], nIsInfinityMask)
+
+			// Equally, the result is also wrong if the point from the table is
+			// zero, which happens when the index is zero. We handle that by
+			// only copying from {tx,ty,tz} to {xOut,yOut,zOut} if index != 0.
+			pIsNoninfiniteMask = nonZeroToAllOnes(index)
+			mask = pIsNoninfiniteMask & ^nIsInfinityMask
+			sm2P256CopyConditional(xOut, &tx, mask)
+			sm2P256CopyConditional(yOut, &ty, mask)
+			sm2P256CopyConditional(zOut, &tz, mask)
+			// If p was not zero, then n is now non-zero.
+			nIsInfinityMask &^= pIsNoninfiniteMask
+		}
+	}
+}
+
+func sm2P256PointToAffine(xOut, yOut, x, y, z *sm2P256FieldElement) {
+	var zInv, zInvSq sm2P256FieldElement
+
+	zz := sm2P256ToBig(z)
+	zz.ModInverse(zz, sm2P256.P)
+	sm2P256FromBig(&zInv, zz)
+
+	sm2P256Square(&zInvSq, &zInv)
+	sm2P256Mul(xOut, x, &zInvSq)
+	sm2P256Mul(&zInv, &zInv, &zInvSq)
+	sm2P256Mul(yOut, y, &zInv)
+}
+
+func sm2P256ToAffine(x, y, z *sm2P256FieldElement) (xOut, yOut *big.Int) {
+	var xx, yy sm2P256FieldElement
+
+	sm2P256PointToAffine(&xx, &yy, x, y, z)
+	return sm2P256ToBig(&xx), sm2P256ToBig(&yy)
+}
+
+var sm2P256Factor = []sm2P256FieldElement{
+	sm2P256FieldElement{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	sm2P256FieldElement{0x2, 0x0, 0x1FFFFF00, 0x7FF, 0x0, 0x0, 0x0, 0x2000000, 0x0},
+	sm2P256FieldElement{0x4, 0x0, 0x1FFFFE00, 0xFFF, 0x0, 0x0, 0x0, 0x4000000, 0x0},
+	sm2P256FieldElement{0x6, 0x0, 0x1FFFFD00, 0x17FF, 0x0, 0x0, 0x0, 0x6000000, 0x0},
+	sm2P256FieldElement{0x8, 0x0, 0x1FFFFC00, 0x1FFF, 0x0, 0x0, 0x0, 0x8000000, 0x0},
+	sm2P256FieldElement{0xA, 0x0, 0x1FFFFB00, 0x27FF, 0x0, 0x0, 0x0, 0xA000000, 0x0},
+	sm2P256FieldElement{0xC, 0x0, 0x1FFFFA00, 0x2FFF, 0x0, 0x0, 0x0, 0xC000000, 0x0},
+	sm2P256FieldElement{0xE, 0x0, 0x1FFFF900, 0x37FF, 0x0, 0x0, 0x0, 0xE000000, 0x0},
+	sm2P256FieldElement{0x10, 0x0, 0x1FFFF800, 0x3FFF, 0x0, 0x0, 0x0, 0x0, 0x01},
+}
+
+func sm2P256Scalar(b *sm2P256FieldElement, a int) {
+	sm2P256Mul(b, b, &sm2P256Factor[a])
+}
+
+// (x3, y3, z3) = (x1, y1, z1) + (x2, y2, z2)
+func sm2P256PointAdd(x1, y1, z1, x2, y2, z2, x3, y3, z3 *sm2P256FieldElement) {
+	var u1, u2, z22, z12, z23, z13, s1, s2, h, h2, r, r2, tm sm2P256FieldElement
+
+	if sm2P256ToBig(z1).Sign() == 0 {
+		sm2P256Dup(x3, x2)
+		sm2P256Dup(y3, y2)
+		sm2P256Dup(z3, z2)
+		return
+	}
+
+	if sm2P256ToBig(z2).Sign() == 0 {
+		sm2P256Dup(x3, x1)
+		sm2P256Dup(y3, y1)
+		sm2P256Dup(z3, z1)
+		return
+	}
+
+	sm2P256Square(&z12, z1) // z12 = z1 ^ 2
+	sm2P256Square(&z22, z2) // z22 = z2 ^ 2
+
+	sm2P256Mul(&z13, &z12, z1) // z13 = z1 ^ 3
+	sm2P256Mul(&z23, &z22, z2) // z23 = z2 ^ 3
+
+	sm2P256Mul(&u1, x1, &z22) // u1 = x1 * z2 ^ 2
+	sm2P256Mul(&u2, x2, &z12) // u2 = x2 * z1 ^ 2
+
+	sm2P256Mul(&s1, y1, &z23) // s1 = y1 * z2 ^ 3
+	sm2P256Mul(&s2, y2, &z13) // s2 = y2 * z1 ^ 3
+
+	if sm2P256ToBig(&u1).Cmp(sm2P256ToBig(&u2)) == 0 &&
+		sm2P256ToBig(&s1).Cmp(sm2P256ToBig(&s2)) == 0 {
+		sm2P256PointDouble(x1, y1, z1, x1, y1, z1)
+	}
+
+	sm2P256Sub(&h, &u2, &u1) // h = u2 - u1
+	sm2P256Sub(&r, &s2, &s1) // r = s2 - s1
+
+	sm2P256Square(&r2, &r) // r2 = r ^ 2
+	sm2P256Square(&h2, &h) // h2 = h ^ 2
+
+	sm2P256Mul(&tm, &h2, &h) // tm = h ^ 3
+	sm2P256Sub(x3, &r2, &tm)
+	sm2P256Mul(&tm, &u1, &h2)
+	sm2P256Scalar(&tm, 2)   // tm = 2 * (u1 * h ^ 2)
+	sm2P256Sub(x3, x3, &tm) // x3 = r ^ 2 - h ^ 3 - 2 * u1 * h ^ 2
+
+	sm2P256Mul(&tm, &u1, &h2) // tm = u1 * h ^ 2
+	sm2P256Sub(&tm, &tm, x3)  // tm = u1 * h ^ 2 - x3
+	sm2P256Mul(y3, &r, &tm)
+	sm2P256Mul(&tm, &h2, &h)  // tm = h ^ 3
+	sm2P256Mul(&tm, &tm, &s1) // tm = s1 * h ^ 3
+	sm2P256Sub(y3, y3, &tm)   // y3 = r * (u1 * h ^ 2 - x3) - s1 * h ^ 3
+
+	sm2P256Mul(z3, z1, z2)
+	sm2P256Mul(z3, z3, &h) // z3 = z1 * z3 * h
+}
+
+// (x3, y3, z3) = (x1, y1, z1)- (x2, y2, z2)
+func sm2P256PointSub(x1, y1, z1, x2, y2, z2, x3, y3, z3 *sm2P256FieldElement) {
+	var u1, u2, z22, z12, z23, z13, s1, s2, h, h2, r, r2, tm sm2P256FieldElement
+	y:=sm2P256ToBig(y2)
+	zero:=new(big.Int).SetInt64(0)
+	y.Sub(zero,y)
+	sm2P256FromBig(y2,y)
+
+	if sm2P256ToBig(z1).Sign() == 0 {
+		sm2P256Dup(x3, x2)
+		sm2P256Dup(y3, y2)
+		sm2P256Dup(z3, z2)
+		return
+	}
+
+	if sm2P256ToBig(z2).Sign() == 0 {
+		sm2P256Dup(x3, x1)
+		sm2P256Dup(y3, y1)
+		sm2P256Dup(z3, z1)
+		return
+	}
+
+	sm2P256Square(&z12, z1) // z12 = z1 ^ 2
+	sm2P256Square(&z22, z2) // z22 = z2 ^ 2
+
+	sm2P256Mul(&z13, &z12, z1) // z13 = z1 ^ 3
+	sm2P256Mul(&z23, &z22, z2) // z23 = z2 ^ 3
+
+	sm2P256Mul(&u1, x1, &z22) // u1 = x1 * z2 ^ 2
+	sm2P256Mul(&u2, x2, &z12) // u2 = x2 * z1 ^ 2
+
+	sm2P256Mul(&s1, y1, &z23) // s1 = y1 * z2 ^ 3
+	sm2P256Mul(&s2, y2, &z13) // s2 = y2 * z1 ^ 3
+
+	if sm2P256ToBig(&u1).Cmp(sm2P256ToBig(&u2)) == 0 &&
+		sm2P256ToBig(&s1).Cmp(sm2P256ToBig(&s2)) == 0 {
+		sm2P256PointDouble(x1, y1, z1, x1, y1, z1)
+	}
+
+	sm2P256Sub(&h, &u2, &u1) // h = u2 - u1
+	sm2P256Sub(&r, &s2, &s1) // r = s2 - s1
+
+	sm2P256Square(&r2, &r) // r2 = r ^ 2
+	sm2P256Square(&h2, &h) // h2 = h ^ 2
+
+	sm2P256Mul(&tm, &h2, &h) // tm = h ^ 3
+	sm2P256Sub(x3, &r2, &tm)
+	sm2P256Mul(&tm, &u1, &h2)
+	sm2P256Scalar(&tm, 2)   // tm = 2 * (u1 * h ^ 2)
+	sm2P256Sub(x3, x3, &tm) // x3 = r ^ 2 - h ^ 3 - 2 * u1 * h ^ 2
+
+	sm2P256Mul(&tm, &u1, &h2) // tm = u1 * h ^ 2
+	sm2P256Sub(&tm, &tm, x3)  // tm = u1 * h ^ 2 - x3
+	sm2P256Mul(y3, &r, &tm)
+	sm2P256Mul(&tm, &h2, &h)  // tm = h ^ 3
+	sm2P256Mul(&tm, &tm, &s1) // tm = s1 * h ^ 3
+	sm2P256Sub(y3, y3, &tm)   // y3 = r * (u1 * h ^ 2 - x3) - s1 * h ^ 3
+
+	sm2P256Mul(z3, z1, z2)
+	sm2P256Mul(z3, z3, &h) // z3 = z1 * z3 * h
+}
+
+func sm2P256PointDouble(x3, y3, z3, x, y, z *sm2P256FieldElement) {
+	var s, m, m2, x2, y2, z2, z4, y4, az4 sm2P256FieldElement
+
+	sm2P256Square(&x2, x) // x2 = x ^ 2
+	sm2P256Square(&y2, y) // y2 = y ^ 2
+	sm2P256Square(&z2, z) // z2 = z ^ 2
+
+	sm2P256Square(&z4, z)   // z4 = z ^ 2
+	sm2P256Mul(&z4, &z4, z) // z4 = z ^ 3
+	sm2P256Mul(&z4, &z4, z) // z4 = z ^ 4
+
+	sm2P256Square(&y4, y)   // y4 = y ^ 2
+	sm2P256Mul(&y4, &y4, y) // y4 = y ^ 3
+	sm2P256Mul(&y4, &y4, y) // y4 = y ^ 4
+	sm2P256Scalar(&y4, 8)   // y4 = 8 * y ^ 4
+
+	sm2P256Mul(&s, x, &y2)
+	sm2P256Scalar(&s, 4) // s = 4 * x * y ^ 2
+
+	sm2P256Dup(&m, &x2)
+	sm2P256Scalar(&m, 3)
+	sm2P256Mul(&az4, &sm2P256.a, &z4)
+	sm2P256Add(&m, &m, &az4) // m = 3 * x ^ 2 + a * z ^ 4
+
+	sm2P256Square(&m2, &m) // m2 = m ^ 2
+
+	sm2P256Add(z3, y, z)
+	sm2P256Square(z3, z3)
+	sm2P256Sub(z3, z3, &z2)
+	sm2P256Sub(z3, z3, &y2) // z' = (y + z) ^2 - z ^ 2 - y ^ 2
+
+	sm2P256Sub(x3, &m2, &s)
+	sm2P256Sub(x3, x3, &s) // x' = m2 - 2 * s
+
+	sm2P256Sub(y3, &s, x3)
+	sm2P256Mul(y3, y3, &m)
+	sm2P256Sub(y3, y3, &y4) // y' = m * (s - x') - 8 * y ^ 4
+}
+
+// p256Zero31 is 0 mod p.
+var sm2P256Zero31 = sm2P256FieldElement{0x7FFFFFF8, 0x3FFFFFFC, 0x800003FC, 0x3FFFDFFC, 0x7FFFFFFC, 0x3FFFFFFC, 0x7FFFFFFC, 0x37FFFFFC, 0x7FFFFFFC}
+
+// c = a + b
+func sm2P256Add(c, a, b *sm2P256FieldElement) {
+	carry := uint32(0)
+	for i := 0; ; i++ {
+		c[i] = a[i] + b[i]
+		c[i] += carry
+		carry = c[i] >> 29
+		c[i] &= bottom29Bits
+		i++
+		if i == 9 {
+			break
+		}
+		c[i] = a[i] + b[i]
+		c[i] += carry
+		carry = c[i] >> 28
+		c[i] &= bottom28Bits
+	}
+	sm2P256ReduceCarry(c, carry)
+}
+
+// c = a - b
+func sm2P256Sub(c, a, b *sm2P256FieldElement) {
+	var carry uint32
+
+	for i := 0; ; i++ {
+		c[i] = a[i] - b[i]
+		c[i] += sm2P256Zero31[i]
+		c[i] += carry
+		carry = c[i] >> 29
+		c[i] &= bottom29Bits
+		i++
+		if i == 9 {
+			break
+		}
+		c[i] = a[i] - b[i]
+		c[i] += sm2P256Zero31[i]
+		c[i] += carry
+		carry = c[i] >> 28
+		c[i] &= bottom28Bits
+	}
+	sm2P256ReduceCarry(c, carry)
+}
+
+// c = a * b
+func sm2P256Mul(c, a, b *sm2P256FieldElement) {
+	var tmp sm2P256LargeFieldElement
+
+	tmp[0] = uint64(a[0]) * uint64(b[0])
+	tmp[1] = uint64(a[0])*(uint64(b[1])<<0) +
+		uint64(a[1])*(uint64(b[0])<<0)
+	tmp[2] = uint64(a[0])*(uint64(b[2])<<0) +
+		uint64(a[1])*(uint64(b[1])<<1) +
+		uint64(a[2])*(uint64(b[0])<<0)
+	tmp[3] = uint64(a[0])*(uint64(b[3])<<0) +
+		uint64(a[1])*(uint64(b[2])<<0) +
+		uint64(a[2])*(uint64(b[1])<<0) +
+		uint64(a[3])*(uint64(b[0])<<0)
+	tmp[4] = uint64(a[0])*(uint64(b[4])<<0) +
+		uint64(a[1])*(uint64(b[3])<<1) +
+		uint64(a[2])*(uint64(b[2])<<0) +
+		uint64(a[3])*(uint64(b[1])<<1) +
+		uint64(a[4])*(uint64(b[0])<<0)
+	tmp[5] = uint64(a[0])*(uint64(b[5])<<0) +
+		uint64(a[1])*(uint64(b[4])<<0) +
+		uint64(a[2])*(uint64(b[3])<<0) +
+		uint64(a[3])*(uint64(b[2])<<0) +
+		uint64(a[4])*(uint64(b[1])<<0) +
+		uint64(a[5])*(uint64(b[0])<<0)
+	tmp[6] = uint64(a[0])*(uint64(b[6])<<0) +
+		uint64(a[1])*(uint64(b[5])<<1) +
+		uint64(a[2])*(uint64(b[4])<<0) +
+		uint64(a[3])*(uint64(b[3])<<1) +
+		uint64(a[4])*(uint64(b[2])<<0) +
+		uint64(a[5])*(uint64(b[1])<<1) +
+		uint64(a[6])*(uint64(b[0])<<0)
+	tmp[7] = uint64(a[0])*(uint64(b[7])<<0) +
+		uint64(a[1])*(uint64(b[6])<<0) +
+		uint64(a[2])*(uint64(b[5])<<0) +
+		uint64(a[3])*(uint64(b[4])<<0) +
+		uint64(a[4])*(uint64(b[3])<<0) +
+		uint64(a[5])*(uint64(b[2])<<0) +
+		uint64(a[6])*(uint64(b[1])<<0) +
+		uint64(a[7])*(uint64(b[0])<<0)
+	// tmp[8] has the greatest value but doesn't overflow. See logic in
+	// p256Square.
+	tmp[8] = uint64(a[0])*(uint64(b[8])<<0) +
+		uint64(a[1])*(uint64(b[7])<<1) +
+		uint64(a[2])*(uint64(b[6])<<0) +
+		uint64(a[3])*(uint64(b[5])<<1) +
+		uint64(a[4])*(uint64(b[4])<<0) +
+		uint64(a[5])*(uint64(b[3])<<1) +
+		uint64(a[6])*(uint64(b[2])<<0) +
+		uint64(a[7])*(uint64(b[1])<<1) +
+		uint64(a[8])*(uint64(b[0])<<0)
+	tmp[9] = uint64(a[1])*(uint64(b[8])<<0) +
+		uint64(a[2])*(uint64(b[7])<<0) +
+		uint64(a[3])*(uint64(b[6])<<0) +
+		uint64(a[4])*(uint64(b[5])<<0) +
+		uint64(a[5])*(uint64(b[4])<<0) +
+		uint64(a[6])*(uint64(b[3])<<0) +
+		uint64(a[7])*(uint64(b[2])<<0) +
+		uint64(a[8])*(uint64(b[1])<<0)
+	tmp[10] = uint64(a[2])*(uint64(b[8])<<0) +
+		uint64(a[3])*(uint64(b[7])<<1) +
+		uint64(a[4])*(uint64(b[6])<<0) +
+		uint64(a[5])*(uint64(b[5])<<1) +
+		uint64(a[6])*(uint64(b[4])<<0) +
+		uint64(a[7])*(uint64(b[3])<<1) +
+		uint64(a[8])*(uint64(b[2])<<0)
+	tmp[11] = uint64(a[3])*(uint64(b[8])<<0) +
+		uint64(a[4])*(uint64(b[7])<<0) +
+		uint64(a[5])*(uint64(b[6])<<0) +
+		uint64(a[6])*(uint64(b[5])<<0) +
+		uint64(a[7])*(uint64(b[4])<<0) +
+		uint64(a[8])*(uint64(b[3])<<0)
+	tmp[12] = uint64(a[4])*(uint64(b[8])<<0) +
+		uint64(a[5])*(uint64(b[7])<<1) +
+		uint64(a[6])*(uint64(b[6])<<0) +
+		uint64(a[7])*(uint64(b[5])<<1) +
+		uint64(a[8])*(uint64(b[4])<<0)
+	tmp[13] = uint64(a[5])*(uint64(b[8])<<0) +
+		uint64(a[6])*(uint64(b[7])<<0) +
+		uint64(a[7])*(uint64(b[6])<<0) +
+		uint64(a[8])*(uint64(b[5])<<0)
+	tmp[14] = uint64(a[6])*(uint64(b[8])<<0) +
+		uint64(a[7])*(uint64(b[7])<<1) +
+		uint64(a[8])*(uint64(b[6])<<0)
+	tmp[15] = uint64(a[7])*(uint64(b[8])<<0) +
+		uint64(a[8])*(uint64(b[7])<<0)
+	tmp[16] = uint64(a[8]) * (uint64(b[8]) << 0)
+	sm2P256ReduceDegree(c, &tmp)
+}
+
+// b = a * a
+func sm2P256Square(b, a *sm2P256FieldElement) {
+	var tmp sm2P256LargeFieldElement
+
+	tmp[0] = uint64(a[0]) * uint64(a[0])
+	tmp[1] = uint64(a[0]) * (uint64(a[1]) << 1)
+	tmp[2] = uint64(a[0])*(uint64(a[2])<<1) +
+		uint64(a[1])*(uint64(a[1])<<1)
+	tmp[3] = uint64(a[0])*(uint64(a[3])<<1) +
+		uint64(a[1])*(uint64(a[2])<<1)
+	tmp[4] = uint64(a[0])*(uint64(a[4])<<1) +
+		uint64(a[1])*(uint64(a[3])<<2) +
+		uint64(a[2])*uint64(a[2])
+	tmp[5] = uint64(a[0])*(uint64(a[5])<<1) +
+		uint64(a[1])*(uint64(a[4])<<1) +
+		uint64(a[2])*(uint64(a[3])<<1)
+	tmp[6] = uint64(a[0])*(uint64(a[6])<<1) +
+		uint64(a[1])*(uint64(a[5])<<2) +
+		uint64(a[2])*(uint64(a[4])<<1) +
+		uint64(a[3])*(uint64(a[3])<<1)
+	tmp[7] = uint64(a[0])*(uint64(a[7])<<1) +
+		uint64(a[1])*(uint64(a[6])<<1) +
+		uint64(a[2])*(uint64(a[5])<<1) +
+		uint64(a[3])*(uint64(a[4])<<1)
+	// tmp[8] has the greatest value of 2**61 + 2**60 + 2**61 + 2**60 + 2**60,
+	// which is < 2**64 as required.
+	tmp[8] = uint64(a[0])*(uint64(a[8])<<1) +
+		uint64(a[1])*(uint64(a[7])<<2) +
+		uint64(a[2])*(uint64(a[6])<<1) +
+		uint64(a[3])*(uint64(a[5])<<2) +
+		uint64(a[4])*uint64(a[4])
+	tmp[9] = uint64(a[1])*(uint64(a[8])<<1) +
+		uint64(a[2])*(uint64(a[7])<<1) +
+		uint64(a[3])*(uint64(a[6])<<1) +
+		uint64(a[4])*(uint64(a[5])<<1)
+	tmp[10] = uint64(a[2])*(uint64(a[8])<<1) +
+		uint64(a[3])*(uint64(a[7])<<2) +
+		uint64(a[4])*(uint64(a[6])<<1) +
+		uint64(a[5])*(uint64(a[5])<<1)
+	tmp[11] = uint64(a[3])*(uint64(a[8])<<1) +
+		uint64(a[4])*(uint64(a[7])<<1) +
+		uint64(a[5])*(uint64(a[6])<<1)
+	tmp[12] = uint64(a[4])*(uint64(a[8])<<1) +
+		uint64(a[5])*(uint64(a[7])<<2) +
+		uint64(a[6])*uint64(a[6])
+	tmp[13] = uint64(a[5])*(uint64(a[8])<<1) +
+		uint64(a[6])*(uint64(a[7])<<1)
+	tmp[14] = uint64(a[6])*(uint64(a[8])<<1) +
+		uint64(a[7])*(uint64(a[7])<<1)
+	tmp[15] = uint64(a[7]) * (uint64(a[8]) << 1)
+	tmp[16] = uint64(a[8]) * uint64(a[8])
+	sm2P256ReduceDegree(b, &tmp)
+}
+
+// nonZeroToAllOnes returns:
+//   0xffffffff for 0 < x <= 2**31
+//   0 for x == 0 or x > 2**31.
+func nonZeroToAllOnes(x uint32) uint32 {
+	return ((x - 1) >> 31) - 1
+}
+
+var sm2P256Carry = [8 * 9]uint32{
+	0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+	0x2, 0x0, 0x1FFFFF00, 0x7FF, 0x0, 0x0, 0x0, 0x2000000, 0x0,
+	0x4, 0x0, 0x1FFFFE00, 0xFFF, 0x0, 0x0, 0x0, 0x4000000, 0x0,
+	0x6, 0x0, 0x1FFFFD00, 0x17FF, 0x0, 0x0, 0x0, 0x6000000, 0x0,
+	0x8, 0x0, 0x1FFFFC00, 0x1FFF, 0x0, 0x0, 0x0, 0x8000000, 0x0,
+	0xA, 0x0, 0x1FFFFB00, 0x27FF, 0x0, 0x0, 0x0, 0xA000000, 0x0,
+	0xC, 0x0, 0x1FFFFA00, 0x2FFF, 0x0, 0x0, 0x0, 0xC000000, 0x0,
+	0xE, 0x0, 0x1FFFF900, 0x37FF, 0x0, 0x0, 0x0, 0xE000000, 0x0,
+}
+
+// carry < 2 ^ 3
+func sm2P256ReduceCarry(a *sm2P256FieldElement, carry uint32) {
+	a[0] += sm2P256Carry[carry*9+0]
+	a[2] += sm2P256Carry[carry*9+2]
+	a[3] += sm2P256Carry[carry*9+3]
+	a[7] += sm2P256Carry[carry*9+7]
+}
+
+
+func sm2P256ReduceDegree(a *sm2P256FieldElement, b *sm2P256LargeFieldElement) {
+	var tmp [18]uint32
+	var carry, x, xMask uint32
+
+	// tmp
+	// 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  |  9 | 10 ...
+	// 29 | 28 | 29 | 28 | 29 | 28 | 29 | 28 | 29 | 28 | 29 ...
+	tmp[0] = uint32(b[0]) & bottom29Bits
+	tmp[1] = uint32(b[0]) >> 29
+	tmp[1] |= (uint32(b[0]>>32) << 3) & bottom28Bits
+	tmp[1] += uint32(b[1]) & bottom28Bits
+	carry = tmp[1] >> 28
+	tmp[1] &= bottom28Bits
+	for i := 2; i < 17; i++ {
+		tmp[i] = (uint32(b[i-2] >> 32)) >> 25
+		tmp[i] += (uint32(b[i-1])) >> 28
+		tmp[i] += (uint32(b[i-1]>>32) << 4) & bottom29Bits
+		tmp[i] += uint32(b[i]) & bottom29Bits
+		tmp[i] += carry
+		carry = tmp[i] >> 29
+		tmp[i] &= bottom29Bits
+
+		i++
+		if i == 17 {
+			break
+		}
+		tmp[i] = uint32(b[i-2]>>32) >> 25
+		tmp[i] += uint32(b[i-1]) >> 29
+		tmp[i] += ((uint32(b[i-1] >> 32)) << 3) & bottom28Bits
+		tmp[i] += uint32(b[i]) & bottom28Bits
+		tmp[i] += carry
+		carry = tmp[i] >> 28
+		tmp[i] &= bottom28Bits
+	}
+	tmp[17] = uint32(b[15]>>32) >> 25
+	tmp[17] += uint32(b[16]) >> 29
+	tmp[17] += uint32(b[16]>>32) << 3
+	tmp[17] += carry
+
+	for i := 0; ; i += 2 {
+
+		tmp[i+1] += tmp[i] >> 29
+		x = tmp[i] & bottom29Bits
+		tmp[i] = 0
+		if x > 0 {
+			set4 := uint32(0)
+			set7 := uint32(0)
+			xMask = nonZeroToAllOnes(x)
+			tmp[i+2] += (x << 7) & bottom29Bits
+			tmp[i+3] += x >> 22
+			if tmp[i+3] < 0x10000000 {
+				set4 = 1
+				tmp[i+3] += 0x10000000 & xMask
+				tmp[i+3] -= (x << 10) & bottom28Bits
+			} else {
+				tmp[i+3] -= (x << 10) & bottom28Bits
+			}
+			if tmp[i+4] < 0x20000000 {
+				tmp[i+4] += 0x20000000 & xMask
+				tmp[i+4] -= set4 // 借位
+				tmp[i+4] -= x >> 18
+				if tmp[i+5] < 0x10000000 {
+					tmp[i+5] += 0x10000000 & xMask
+					tmp[i+5] -= 1 // 借位
+					if tmp[i+6] < 0x20000000 {
+						set7 = 1
+						tmp[i+6] += 0x20000000 & xMask
+						tmp[i+6] -= 1 // 借位
+					} else {
+						tmp[i+6] -= 1 // 借位
+					}
+				} else {
+					tmp[i+5] -= 1
+				}
+			} else {
+				tmp[i+4] -= set4 // 借位
+				tmp[i+4] -= x >> 18
+			}
+			if tmp[i+7] < 0x10000000 {
+				tmp[i+7] += 0x10000000 & xMask
+				tmp[i+7] -= set7
+				tmp[i+7] -= (x << 24) & bottom28Bits
+				tmp[i+8] += (x << 28) & bottom29Bits
+				if tmp[i+8] < 0x20000000 {
+					tmp[i+8] += 0x20000000 & xMask
+					tmp[i+8] -= 1
+					tmp[i+8] -= x >> 4
+					tmp[i+9] += ((x >> 1) - 1) & xMask
+				} else {
+					tmp[i+8] -= 1
+					tmp[i+8] -= x >> 4
+					tmp[i+9] += (x >> 1) & xMask
+				}
+			} else {
+				tmp[i+7] -= set7 // 借位
+				tmp[i+7] -= (x << 24) & bottom28Bits
+				tmp[i+8] += (x << 28) & bottom29Bits
+				if tmp[i+8] < 0x20000000 {
+					tmp[i+8] += 0x20000000 & xMask
+					tmp[i+8] -= x >> 4
+					tmp[i+9] += ((x >> 1) - 1) & xMask
+				} else {
+					tmp[i+8] -= x >> 4
+					tmp[i+9] += (x >> 1) & xMask
+				}
+			}
+
+		}
+
+		if i+1 == 9 {
+			break
+		}
+
+		tmp[i+2] += tmp[i+1] >> 28
+		x = tmp[i+1] & bottom28Bits
+		tmp[i+1] = 0
+		if x > 0 {
+			set5 := uint32(0)
+			set8 := uint32(0)
+			set9 := uint32(0)
+			xMask = nonZeroToAllOnes(x)
+			tmp[i+3] += (x << 7) & bottom28Bits
+			tmp[i+4] += x >> 21
+			if tmp[i+4] < 0x20000000 {
+				set5 = 1
+				tmp[i+4] += 0x20000000 & xMask
+				tmp[i+4] -= (x << 11) & bottom29Bits
+			} else {
+				tmp[i+4] -= (x << 11) & bottom29Bits
+			}
+			if tmp[i+5] < 0x10000000 {
+				tmp[i+5] += 0x10000000 & xMask
+				tmp[i+5] -= set5 // 借位
+				tmp[i+5] -= x >> 18
+				if tmp[i+6] < 0x20000000 {
+					tmp[i+6] += 0x20000000 & xMask
+					tmp[i+6] -= 1 // 借位
+					if tmp[i+7] < 0x10000000 {
+						set8 = 1
+						tmp[i+7] += 0x10000000 & xMask
+						tmp[i+7] -= 1 // 借位
+					} else {
+						tmp[i+7] -= 1 // 借位
+					}
+				} else {
+					tmp[i+6] -= 1 // 借位
+				}
+			} else {
+				tmp[i+5] -= set5 // 借位
+				tmp[i+5] -= x >> 18
+			}
+			if tmp[i+8] < 0x20000000 {
+				set9 = 1
+				tmp[i+8] += 0x20000000 & xMask
+				tmp[i+8] -= set8
+				tmp[i+8] -= (x << 25) & bottom29Bits
+			} else {
+				tmp[i+8] -= set8
+				tmp[i+8] -= (x << 25) & bottom29Bits
+			}
+			if tmp[i+9] < 0x10000000 {
+				tmp[i+9] += 0x10000000 & xMask
+				tmp[i+9] -= set9 // 借位
+				tmp[i+9] -= x >> 4
+				tmp[i+10] += (x - 1) & xMask
+			} else {
+				tmp[i+9] -= set9 // 借位
+				tmp[i+9] -= x >> 4
+				tmp[i+10] += x & xMask
+			}
+		}
+	}
+
+	carry = uint32(0)
+	for i := 0; i < 8; i++ {
+		a[i] = tmp[i+9]
+		a[i] += carry
+		a[i] += (tmp[i+10] << 28) & bottom29Bits
+		carry = a[i] >> 29
+		a[i] &= bottom29Bits
+
+		i++
+		a[i] = tmp[i+9] >> 1
+		a[i] += carry
+		carry = a[i] >> 28
+		a[i] &= bottom28Bits
+	}
+	a[8] = tmp[17]
+	a[8] += carry
+	carry = a[8] >> 29
+	a[8] &= bottom29Bits
+	sm2P256ReduceCarry(a, carry)
+}
+
+// b = a
+func sm2P256Dup(b, a *sm2P256FieldElement) {
+	*b = *a
+}
+
+// X = a * R mod P
+func sm2P256FromBig(X *sm2P256FieldElement, a *big.Int) {
+	x := new(big.Int).Lsh(a, 257)
+	x.Mod(x, sm2P256.P)
+	for i := 0; i < 9; i++ {
+		if bits := x.Bits(); len(bits) > 0 {
+			X[i] = uint32(bits[0]) & bottom29Bits
+		} else {
+			X[i] = 0
+		}
+		x.Rsh(x, 29)
+		i++
+		if i == 9 {
+			break
+		}
+		if bits := x.Bits(); len(bits) > 0 {
+			X[i] = uint32(bits[0]) & bottom28Bits
+		} else {
+			X[i] = 0
+		}
+		x.Rsh(x, 28)
+	}
+}
+
+// X = r * R mod P
+// r = X * R' mod P
+func sm2P256ToBig(X *sm2P256FieldElement) *big.Int {
+	r, tm := new(big.Int), new(big.Int)
+	r.SetInt64(int64(X[8]))
+	for i := 7; i >= 0; i-- {
+		if (i & 1) == 0 {
+			r.Lsh(r, 29)
+		} else {
+			r.Lsh(r, 28)
+		}
+		tm.SetInt64(int64(X[i]))
+		r.Add(r, tm)
+	}
+	r.Mul(r, sm2P256.RInverse)
+	r.Mod(r, sm2P256.P)
+	return r
+}
+func WNafReversed(wnaf []int8) []int8 {
+	wnafRev := make([]int8, len(wnaf), len(wnaf))
+	for i, v := range wnaf {
+		wnafRev[len(wnaf)-(1+i)] = v
+	}
+	return wnafRev
+}
+func sm2GenrateWNaf(b []byte) []int8 {
+	n:= new(big.Int).SetBytes(b)
+	var k *big.Int
+	if n.Cmp(sm2P256.N) >= 0 {
+		n.Mod(n, sm2P256.N)
+		k = n
+	} else {
+		k = n
+	}
+	wnaf := make([]int8, k.BitLen()+1, k.BitLen()+1)
+	if k.Sign() == 0 {
+		return wnaf
+	}
+	var width, pow2, sign int
+	width, pow2, sign = 4, 16, 8
+	var mask int64 = 15
+	var carry bool
+	var length, pos int
+	for pos <= k.BitLen() {
+		if k.Bit(pos) == boolToUint(carry) {
+			pos++
+			continue
+		}
+		k.Rsh(k, uint(pos))
+		var digit int
+		digit = int(k.Int64() & mask)
+		if carry {
+			digit++
+		}
+		carry = (digit & sign) != 0
+		if carry {
+			digit -= pow2
+		}
+		length += pos
+		wnaf[length] = int8(digit)
+		pos = int(width)
+	}
+	if len(wnaf) > length+1 {
+		t := make([]int8, length+1, length+1)
+		copy(t, wnaf[0:length+1])
+		wnaf = t
+	}
+	return wnaf
+}
+func boolToUint(b bool) uint {
+	if b {
+		return 1
+	}
+	return 0
+}
+func abs(a int8) uint32{
+	if a<0 {
+		return uint32(-a)
+	}
+	return uint32(a)
+}
+
+func sm2P256ScalarMult(xOut, yOut, zOut, x, y *sm2P256FieldElement, scalar []int8) {
+	var precomp [16][3]sm2P256FieldElement
+	var px, py, pz, tx, ty, tz sm2P256FieldElement
+	var nIsInfinityMask, index, pIsNoninfiniteMask, mask uint32
+
+	// We precompute 0,1,2,... times {x,y}.
+	precomp[1][0] = *x
+	precomp[1][1] = *y
+	precomp[1][2] = sm2P256Factor[1]
+
+	for i := 2; i < 8; i += 2 {
+		sm2P256PointDouble(&precomp[i][0], &precomp[i][1], &precomp[i][2], &precomp[i/2][0], &precomp[i/2][1], &precomp[i/2][2])
+		sm2P256PointAddMixed(&precomp[i+1][0], &precomp[i+1][1], &precomp[i+1][2], &precomp[i][0], &precomp[i][1], &precomp[i][2], x, y)
+	}
+
+	for i := range xOut {
+		xOut[i] = 0
+	}
+	for i := range yOut {
+		yOut[i] = 0
+	}
+	for i := range zOut {
+		zOut[i] = 0
+	}
+	nIsInfinityMask = ^uint32(0)
+	var zeroes int16
+	for i := 0; i<len(scalar); i++ {
+		if scalar[i] ==0{
+			zeroes++
+			continue
+		}
+		if(zeroes>0){
+			for  ;zeroes>0;zeroes-- {
+				sm2P256PointDouble(xOut, yOut, zOut, xOut, yOut, zOut)
+			}
+		}
+		index = abs(scalar[i])
+		sm2P256PointDouble(xOut, yOut, zOut, xOut, yOut, zOut)
+		sm2P256SelectJacobianPoint(&px, &py, &pz, &precomp, index)
+		if scalar[i] > 0 {
+			sm2P256PointAdd(xOut, yOut, zOut, &px, &py, &pz, &tx, &ty, &tz)
+		} else {
+			sm2P256PointSub(xOut, yOut, zOut, &px, &py, &pz, &tx, &ty, &tz)
+		}
+		sm2P256CopyConditional(xOut, &px, nIsInfinityMask)
+		sm2P256CopyConditional(yOut, &py, nIsInfinityMask)
+		sm2P256CopyConditional(zOut, &pz, nIsInfinityMask)
+		pIsNoninfiniteMask = nonZeroToAllOnes(index)
+		mask = pIsNoninfiniteMask & ^nIsInfinityMask
+		sm2P256CopyConditional(xOut, &tx, mask)
+		sm2P256CopyConditional(yOut, &ty, mask)
+		sm2P256CopyConditional(zOut, &tz, mask)
+		nIsInfinityMask &^= pIsNoninfiniteMask
+	}
+	if(zeroes>0){
+		for  ;zeroes>0;zeroes-- {
+			sm2P256PointDouble(xOut, yOut, zOut, xOut, yOut, zOut)
+		}
+	}
+}

--- a/vendor/github.com/tjfoc/gmsm/sm2/sm2.go
+++ b/vendor/github.com/tjfoc/gmsm/sm2/sm2.go
@@ -1,0 +1,674 @@
+/*
+Copyright Suzhou Tongji Fintech Research Institute 2017 All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sm2
+
+// reference to ecdsa
+import (
+	"bytes"
+	"crypto"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/asn1"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math/big"
+
+	"github.com/tjfoc/gmsm/sm3"
+)
+
+var (
+	default_uid = []byte{0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38}
+	C1C3C2=0
+	C1C2C3=1
+)
+
+type PublicKey struct {
+	elliptic.Curve
+	X, Y *big.Int
+}
+
+type PrivateKey struct {
+	PublicKey
+	D *big.Int
+}
+
+type sm2Signature struct {
+	R, S *big.Int
+}
+type sm2Cipher struct {
+	XCoordinate *big.Int
+	YCoordinate *big.Int
+	HASH        []byte
+	CipherText  []byte
+}
+
+// The SM2's private key contains the public key
+func (priv *PrivateKey) Public() crypto.PublicKey {
+	return &priv.PublicKey
+}
+
+var errZeroParam = errors.New("zero parameter")
+var one = new(big.Int).SetInt64(1)
+var two = new(big.Int).SetInt64(2)
+
+// sign format = 30 + len(z) + 02 + len(r) + r + 02 + len(s) + s, z being what follows its size, ie 02+len(r)+r+02+len(s)+s
+func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error) {
+	r, s, err := Sm2Sign(priv, msg, nil, random)
+	if err != nil {
+		return nil, err
+	}
+	return asn1.Marshal(sm2Signature{r, s})
+}
+
+func (pub *PublicKey) Verify(msg []byte, sign []byte) bool {
+	var sm2Sign sm2Signature
+	_, err := asn1.Unmarshal(sign, &sm2Sign)
+	if err != nil {
+		return false
+	}
+	return Sm2Verify(pub, msg, default_uid, sm2Sign.R, sm2Sign.S)
+}
+
+func (pub *PublicKey) Sm3Digest(msg, uid []byte) ([]byte, error) {
+	if len(uid) == 0 {
+		uid = default_uid
+	}
+
+	za, err := ZA(pub, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := msgHash(za, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return e.Bytes(), nil
+}
+
+//****************************Encryption algorithm****************************//
+func (pub *PublicKey) EncryptAsn1(data []byte, random io.Reader) ([]byte, error) {
+	return EncryptAsn1(pub, data, random)
+}
+
+func (priv *PrivateKey) DecryptAsn1(data []byte) ([]byte, error) {
+	return DecryptAsn1(priv, data)
+}
+
+//**************************Key agreement algorithm**************************//
+// KeyExchangeB 协商第二部，用户B调用， 返回共享密钥k
+func KeyExchangeB(klen int, ida, idb []byte, priB *PrivateKey, pubA *PublicKey, rpri *PrivateKey, rpubA *PublicKey) (k, s1, s2 []byte, err error) {
+	return keyExchange(klen, ida, idb, priB, pubA, rpri, rpubA, false)
+}
+
+// KeyExchangeA 协商第二部，用户A调用，返回共享密钥k
+func KeyExchangeA(klen int, ida, idb []byte, priA *PrivateKey, pubB *PublicKey, rpri *PrivateKey, rpubB *PublicKey) (k, s1, s2 []byte, err error) {
+	return keyExchange(klen, ida, idb, priA, pubB, rpri, rpubB, true)
+}
+
+//****************************************************************************//
+
+func Sm2Sign(priv *PrivateKey, msg, uid []byte, random io.Reader) (r, s *big.Int, err error) {
+	digest, err := priv.PublicKey.Sm3Digest(msg, uid)
+	if err != nil {
+		return nil, nil, err
+	}
+	e := new(big.Int).SetBytes(digest)
+	c := priv.PublicKey.Curve
+	N := c.Params().N
+	if N.Sign() == 0 {
+		return nil, nil, errZeroParam
+	}
+	var k *big.Int
+	for { // 调整算法细节以实现SM2
+		for {
+			k, err = randFieldElement(c, random)
+			if err != nil {
+				r = nil
+				return
+			}
+			r, _ = priv.Curve.ScalarBaseMult(k.Bytes())
+			r.Add(r, e)
+			r.Mod(r, N)
+			if r.Sign() != 0 {
+				if t := new(big.Int).Add(r, k); t.Cmp(N) != 0 {
+					break
+				}
+			}
+
+		}
+		rD := new(big.Int).Mul(priv.D, r)
+		s = new(big.Int).Sub(k, rD)
+		d1 := new(big.Int).Add(priv.D, one)
+		d1Inv := new(big.Int).ModInverse(d1, N)
+		s.Mul(s, d1Inv)
+		s.Mod(s, N)
+		if s.Sign() != 0 {
+			break
+		}
+	}
+	return
+}
+func Sm2Verify(pub *PublicKey, msg, uid []byte, r, s *big.Int) bool {
+	c := pub.Curve
+	N := c.Params().N
+	one := new(big.Int).SetInt64(1)
+	if r.Cmp(one) < 0 || s.Cmp(one) < 0 {
+		return false
+	}
+	if r.Cmp(N) >= 0 || s.Cmp(N) >= 0 {
+		return false
+	}
+	if len(uid) == 0 {
+		uid = default_uid
+	}
+	za, err := ZA(pub, uid)
+	if err != nil {
+		return false
+	}
+	e, err := msgHash(za, msg)
+	if err != nil {
+		return false
+	}
+	t := new(big.Int).Add(r, s)
+	t.Mod(t, N)
+	if t.Sign() == 0 {
+		return false
+	}
+	var x *big.Int
+	x1, y1 := c.ScalarBaseMult(s.Bytes())
+	x2, y2 := c.ScalarMult(pub.X, pub.Y, t.Bytes())
+	x, _ = c.Add(x1, y1, x2, y2)
+
+	x.Add(x, e)
+	x.Mod(x, N)
+	return x.Cmp(r) == 0
+}
+
+/*
+    za, err := ZA(pub, uid)
+	if err != nil {
+		return
+	}
+	e, err := msgHash(za, msg)
+	hash=e.getBytes()
+*/
+func Verify(pub *PublicKey, hash []byte, r, s *big.Int) bool {
+	c := pub.Curve
+	N := c.Params().N
+
+	if r.Sign() <= 0 || s.Sign() <= 0 {
+		return false
+	}
+	if r.Cmp(N) >= 0 || s.Cmp(N) >= 0 {
+		return false
+	}
+
+	// 调整算法细节以实现SM2
+	t := new(big.Int).Add(r, s)
+	t.Mod(t, N)
+	if t.Sign() == 0 {
+		return false
+	}
+
+	var x *big.Int
+	x1, y1 := c.ScalarBaseMult(s.Bytes())
+	x2, y2 := c.ScalarMult(pub.X, pub.Y, t.Bytes())
+	x, _ = c.Add(x1, y1, x2, y2)
+
+	e := new(big.Int).SetBytes(hash)
+	x.Add(x, e)
+	x.Mod(x, N)
+	return x.Cmp(r) == 0
+}
+
+/*
+ * sm2密文结构如下:
+ *  x
+ *  y
+ *  hash
+ *  CipherText
+ */
+func Encrypt(pub *PublicKey, data []byte, random io.Reader,mode int) ([]byte, error) {
+	length := len(data)
+	for {
+		c := []byte{}
+		curve := pub.Curve
+		k, err := randFieldElement(curve, random)
+		if err != nil {
+			return nil, err
+		}
+		x1, y1 := curve.ScalarBaseMult(k.Bytes())
+		x2, y2 := curve.ScalarMult(pub.X, pub.Y, k.Bytes())
+		x1Buf := x1.Bytes()
+		y1Buf := y1.Bytes()
+		x2Buf := x2.Bytes()
+		y2Buf := y2.Bytes()
+		if n := len(x1Buf); n < 32 {
+			x1Buf = append(zeroByteSlice()[:32-n], x1Buf...)
+		}
+		if n := len(y1Buf); n < 32 {
+			y1Buf = append(zeroByteSlice()[:32-n], y1Buf...)
+		}
+		if n := len(x2Buf); n < 32 {
+			x2Buf = append(zeroByteSlice()[:32-n], x2Buf...)
+		}
+		if n := len(y2Buf); n < 32 {
+			y2Buf = append(zeroByteSlice()[:32-n], y2Buf...)
+		}
+		c = append(c, x1Buf...) // x分量
+		c = append(c, y1Buf...) // y分量
+		tm := []byte{}
+		tm = append(tm, x2Buf...)
+		tm = append(tm, data...)
+		tm = append(tm, y2Buf...)
+		h := sm3.Sm3Sum(tm)
+		c = append(c, h...)
+		ct, ok := kdf(length, x2Buf, y2Buf) // 密文
+		if !ok {
+			continue
+		}
+		c = append(c, ct...)
+		for i := 0; i < length; i++ {
+			c[96+i] ^= data[i]
+		}
+		switch mode{
+	
+		case C1C3C2:
+			return append([]byte{0x04}, c...), nil
+		case C1C2C3:
+			c1 := make([]byte, 64)
+			c2 := make([]byte, len(c) - 96)
+			c3 := make([]byte, 32)
+			copy(c1, c[:64])//x1,y1
+			copy(c3, c[64:96])//hash
+			copy(c2, c[96:])//密文
+			ciphertext := []byte{}
+			ciphertext = append(ciphertext, c1...)
+			ciphertext = append(ciphertext, c2...)
+			ciphertext = append(ciphertext, c3...)
+			return append([]byte{0x04}, ciphertext...), nil
+    	default:
+			return append([]byte{0x04}, c...), nil
+	}
+}
+}
+
+
+
+func Decrypt(priv *PrivateKey, data []byte,mode int) ([]byte, error) {
+	switch mode {
+	case C1C3C2:
+		data = data[1:]
+	case  C1C2C3:
+		data = data[1:]
+		c1 := make([]byte, 64)
+		c2 := make([]byte, len(data) - 96)
+		c3 := make([]byte, 32)
+		copy(c1, data[:64])//x1,y1
+		copy(c2, data[64:len(data) - 32])//密文
+		copy(c3, data[len(data) - 32:])//hash
+		c := []byte{}
+		c = append(c, c1...)
+		c = append(c, c3...)
+		c = append(c, c2...)
+		data = c
+	default:
+		data = data[1:]
+	}
+	length := len(data) - 96
+	curve := priv.Curve
+	x := new(big.Int).SetBytes(data[:32])
+	y := new(big.Int).SetBytes(data[32:64])
+	x2, y2 := curve.ScalarMult(x, y, priv.D.Bytes())
+	x2Buf := x2.Bytes()
+	y2Buf := y2.Bytes()
+	if n := len(x2Buf); n < 32 {
+		x2Buf = append(zeroByteSlice()[:32-n], x2Buf...)
+	}
+	if n := len(y2Buf); n < 32 {
+		y2Buf = append(zeroByteSlice()[:32-n], y2Buf...)
+	}
+	c, ok := kdf(length, x2Buf, y2Buf)
+	if !ok {
+		return nil, errors.New("Decrypt: failed to decrypt")
+	}
+	for i := 0; i < length; i++ {
+		c[i] ^= data[i+96]
+	}
+	tm := []byte{}
+	tm = append(tm, x2Buf...)
+	tm = append(tm, c...)
+	tm = append(tm, y2Buf...)
+	h := sm3.Sm3Sum(tm)
+	if bytes.Compare(h, data[64:96]) != 0 {
+		return c, errors.New("Decrypt: failed to decrypt")
+	}
+	return c, nil
+}
+
+
+
+// keyExchange 为SM2密钥交换算法的第二部和第三步复用部分，协商的双方均调用此函数计算共同的字节串
+// klen: 密钥长度
+// ida, idb: 协商双方的标识，ida为密钥协商算法发起方标识，idb为响应方标识
+// pri: 函数调用者的密钥
+// pub: 对方的公钥
+// rpri: 函数调用者生成的临时SM2密钥
+// rpub: 对方发来的临时SM2公钥
+// thisIsA: 如果是A调用，文档中的协商第三步，设置为true，否则设置为false
+// 返回 k 为klen长度的字节串
+func keyExchange(klen int, ida, idb []byte, pri *PrivateKey, pub *PublicKey, rpri *PrivateKey, rpub *PublicKey, thisISA bool) (k, s1, s2 []byte, err error) {
+	curve := P256Sm2()
+	N := curve.Params().N
+	x2hat := keXHat(rpri.PublicKey.X)
+	x2rb := new(big.Int).Mul(x2hat, rpri.D)
+	tbt := new(big.Int).Add(pri.D, x2rb)
+	tb := new(big.Int).Mod(tbt, N)
+	if !curve.IsOnCurve(rpub.X, rpub.Y) {
+		err = errors.New("Ra not on curve")
+		return
+	}
+	x1hat := keXHat(rpub.X)
+	ramx1, ramy1 := curve.ScalarMult(rpub.X, rpub.Y, x1hat.Bytes())
+	vxt, vyt := curve.Add(pub.X, pub.Y, ramx1, ramy1)
+
+	vx, vy := curve.ScalarMult(vxt, vyt, tb.Bytes())
+	pza := pub
+	if thisISA {
+		pza = &pri.PublicKey
+	}
+	za, err := ZA(pza, ida)
+	if err != nil {
+		return
+	}
+	zero := new(big.Int)
+	if vx.Cmp(zero) == 0 || vy.Cmp(zero) == 0 {
+		err = errors.New("V is infinite")
+	}
+	pzb := pub
+	if !thisISA {
+		pzb = &pri.PublicKey
+	}
+	zb, err := ZA(pzb, idb)
+	k, ok := kdf(klen, vx.Bytes(), vy.Bytes(), za, zb)
+	if !ok {
+		err = errors.New("kdf: zero key")
+		return
+	}
+	h1 := BytesCombine(vx.Bytes(), za, zb, rpub.X.Bytes(), rpub.Y.Bytes(), rpri.X.Bytes(), rpri.Y.Bytes())
+	if !thisISA {
+		h1 = BytesCombine(vx.Bytes(), za, zb, rpri.X.Bytes(), rpri.Y.Bytes(), rpub.X.Bytes(), rpub.Y.Bytes())
+	}
+	hash := sm3.Sm3Sum(h1)
+	h2 := BytesCombine([]byte{0x02}, vy.Bytes(), hash)
+	S1 := sm3.Sm3Sum(h2)
+	h3 := BytesCombine([]byte{0x03}, vy.Bytes(), hash)
+	S2 := sm3.Sm3Sum(h3)
+	return k, S1, S2, nil
+}
+
+func msgHash(za, msg []byte) (*big.Int, error) {
+	e := sm3.New()
+	e.Write(za)
+	e.Write(msg)
+	return new(big.Int).SetBytes(e.Sum(nil)[:32]), nil
+}
+
+// ZA = H256(ENTLA || IDA || a || b || xG || yG || xA || yA)
+func ZA(pub *PublicKey, uid []byte) ([]byte, error) {
+	za := sm3.New()
+	uidLen := len(uid)
+	if uidLen >= 8192 {
+		return []byte{}, errors.New("SM2: uid too large")
+	}
+	Entla := uint16(8 * uidLen)
+	za.Write([]byte{byte((Entla >> 8) & 0xFF)})
+	za.Write([]byte{byte(Entla & 0xFF)})
+	if uidLen > 0 {
+		za.Write(uid)
+	}
+	za.Write(sm2P256ToBig(&sm2P256.a).Bytes())
+	za.Write(sm2P256.B.Bytes())
+	za.Write(sm2P256.Gx.Bytes())
+	za.Write(sm2P256.Gy.Bytes())
+
+	xBuf := pub.X.Bytes()
+	yBuf := pub.Y.Bytes()
+	if n := len(xBuf); n < 32 {
+		xBuf = append(zeroByteSlice()[:32-n], xBuf...)
+	}
+	if n := len(yBuf); n < 32 {
+		yBuf = append(zeroByteSlice()[:32-n], yBuf...)
+	}
+	za.Write(xBuf)
+	za.Write(yBuf)
+	return za.Sum(nil)[:32], nil
+}
+
+// 32byte
+func zeroByteSlice() []byte {
+	return []byte{
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+	}
+}
+
+/*
+sm2加密，返回asn.1编码格式的密文内容
+*/
+func EncryptAsn1(pub *PublicKey, data []byte, rand io.Reader) ([]byte, error) {
+	cipher, err := Encrypt(pub, data, rand,C1C3C2)
+	if err != nil {
+		return nil, err
+	}
+	return CipherMarshal(cipher)
+}
+
+/*
+sm2解密，解析asn.1编码格式的密文内容
+*/
+func DecryptAsn1(pub *PrivateKey, data []byte) ([]byte, error) {
+	cipher, err := CipherUnmarshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return Decrypt(pub, cipher,C1C3C2)
+}
+
+/*
+*sm2密文转asn.1编码格式
+*sm2密文结构如下:
+*  x
+*  y
+*  hash
+*  CipherText
+ */
+func CipherMarshal(data []byte) ([]byte, error) {
+	data = data[1:]
+	x := new(big.Int).SetBytes(data[:32])
+	y := new(big.Int).SetBytes(data[32:64])
+	hash := data[64:96]
+	cipherText := data[96:]
+	return asn1.Marshal(sm2Cipher{x, y, hash, cipherText})
+}
+
+/*
+sm2密文asn.1编码格式转C1|C3|C2拼接格式
+*/
+func CipherUnmarshal(data []byte) ([]byte, error) {
+	var cipher sm2Cipher
+	_, err := asn1.Unmarshal(data, &cipher)
+	if err != nil {
+		return nil, err
+	}
+	x := cipher.XCoordinate.Bytes()
+	y := cipher.YCoordinate.Bytes()
+	hash := cipher.HASH
+	if err != nil {
+		return nil, err
+	}
+	cipherText := cipher.CipherText
+	if err != nil {
+		return nil, err
+	}
+	if n := len(x); n < 32 {
+		x = append(zeroByteSlice()[:32-n], x...)
+	}
+	if n := len(y); n < 32 {
+		y = append(zeroByteSlice()[:32-n], y...)
+	}
+	c := []byte{}
+	c = append(c, x...)          // x分量
+	c = append(c, y...)          // y分
+	c = append(c, hash...)       // x分量
+	c = append(c, cipherText...) // y分
+	return append([]byte{0x04}, c...), nil
+}
+
+// keXHat 计算 x = 2^w + (x & (2^w-1))
+// 密钥协商算法辅助函数
+func keXHat(x *big.Int) (xul *big.Int) {
+	buf := x.Bytes()
+	for i := 0; i < len(buf)-16; i++ {
+		buf[i] = 0
+	}
+	if len(buf) >= 16 {
+		c := buf[len(buf)-16]
+		buf[len(buf)-16] = c & 0x7f
+	}
+
+	r := new(big.Int).SetBytes(buf)
+	_2w := new(big.Int).SetBytes([]byte{
+		0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+	return r.Add(r, _2w)
+}
+
+func BytesCombine(pBytes ...[]byte) []byte {
+	len := len(pBytes)
+	s := make([][]byte, len)
+	for index := 0; index < len; index++ {
+		s[index] = pBytes[index]
+	}
+	sep := []byte("")
+	return bytes.Join(s, sep)
+}
+
+func intToBytes(x int) []byte {
+	var buf = make([]byte, 4)
+
+	binary.BigEndian.PutUint32(buf, uint32(x))
+	return buf
+}
+
+func kdf(length int, x ...[]byte) ([]byte, bool) {
+	var c []byte
+
+	ct := 1
+	h := sm3.New()
+	for i, j := 0, (length+31)/32; i < j; i++ {
+		h.Reset()
+		for _, xx := range x {
+			h.Write(xx)
+		}
+		h.Write(intToBytes(ct))
+		hash := h.Sum(nil)
+		if i+1 == j && length%32 != 0 {
+			c = append(c, hash[:length%32]...)
+		} else {
+			c = append(c, hash...)
+		}
+		ct++
+	}
+	for i := 0; i < length; i++ {
+		if c[i] != 0 {
+			return c, true
+		}
+	}
+	return c, false
+}
+
+func randFieldElement(c elliptic.Curve, random io.Reader) (k *big.Int, err error) {
+	if random == nil {
+		random = rand.Reader //If there is no external trusted random source,please use rand.Reader to instead of it.
+	}
+	params := c.Params()
+	b := make([]byte, params.BitSize/8+8)
+	_, err = io.ReadFull(random, b)
+	if err != nil {
+		return
+	}
+	k = new(big.Int).SetBytes(b)
+	n := new(big.Int).Sub(params.N, one)
+	k.Mod(k, n)
+	k.Add(k, one)
+	return
+}
+
+func GenerateKey(random io.Reader) (*PrivateKey, error) {
+	c := P256Sm2()
+	if random == nil {
+		random = rand.Reader //If there is no external trusted random source,please use rand.Reader to instead of it.
+	}
+	params := c.Params()
+	b := make([]byte, params.BitSize/8+8)
+	_, err := io.ReadFull(random, b)
+	if err != nil {
+		return nil, err
+	}
+
+	k := new(big.Int).SetBytes(b)
+	n := new(big.Int).Sub(params.N, two)
+	k.Mod(k, n)
+	k.Add(k, one)
+	priv := new(PrivateKey)
+	priv.PublicKey.Curve = c
+	priv.D = k
+	priv.PublicKey.X, priv.PublicKey.Y = c.ScalarBaseMult(k.Bytes())
+
+	return priv, nil
+}
+
+type zr struct {
+	io.Reader
+}
+
+func (z *zr) Read(dst []byte) (n int, err error) {
+	for i := range dst {
+		dst[i] = 0
+	}
+	return len(dst), nil
+}
+
+var zeroReader = &zr{}
+
+func getLastBit(a *big.Int) uint {
+	return a.Bit(0)
+}
+
+// crypto.Decrypter
+func (priv *PrivateKey) Decrypt(_ io.Reader, msg []byte, _ crypto.DecrypterOpts) (plaintext []byte, err error) {
+	return Decrypt(priv, msg,C1C3C2)
+}

--- a/vendor/github.com/tjfoc/gmsm/sm2/utils.go
+++ b/vendor/github.com/tjfoc/gmsm/sm2/utils.go
@@ -1,0 +1,59 @@
+package sm2
+
+import (
+	"encoding/asn1"
+	"math/big"
+)
+
+func Decompress(a []byte) *PublicKey {
+	var aa, xx, xx3 sm2P256FieldElement
+
+	P256Sm2()
+	x := new(big.Int).SetBytes(a[1:])
+	curve := sm2P256
+	sm2P256FromBig(&xx, x)
+	sm2P256Square(&xx3, &xx)       // x3 = x ^ 2
+	sm2P256Mul(&xx3, &xx3, &xx)    // x3 = x ^ 2 * x
+	sm2P256Mul(&aa, &curve.a, &xx) // a = a * x
+	sm2P256Add(&xx3, &xx3, &aa)
+	sm2P256Add(&xx3, &xx3, &curve.b)
+
+	y2 := sm2P256ToBig(&xx3)
+	y := new(big.Int).ModSqrt(y2, sm2P256.P)
+	if getLastBit(y)!= uint(a[0]) {
+		y.Sub(sm2P256.P, y)
+	}
+	return &PublicKey{
+		Curve: P256Sm2(),
+		X:     x,
+		Y:     y,
+	}
+}
+
+func Compress(a *PublicKey) []byte {
+	buf := []byte{}
+	yp := getLastBit(a.Y)
+	buf = append(buf, a.X.Bytes()...)
+	if n := len(a.X.Bytes()); n < 32 {
+		buf = append(zeroByteSlice()[:(32-n)], buf...)
+	}
+	buf = append([]byte{byte(yp)}, buf...)
+	return buf
+}
+
+
+
+func SignDigitToSignData(r, s *big.Int) ([]byte, error) {
+	return asn1.Marshal(sm2Signature{r, s})
+}
+
+func SignDataToSignDigit(sign []byte) (*big.Int, *big.Int, error) {
+	var sm2Sign sm2Signature
+
+	_, err := asn1.Unmarshal(sign, &sm2Sign)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sm2Sign.R, sm2Sign.S, nil
+}
+

--- a/vendor/github.com/tjfoc/gmsm/x509/ber.go
+++ b/vendor/github.com/tjfoc/gmsm/x509/ber.go
@@ -1,0 +1,248 @@
+package x509
+
+import (
+	"bytes"
+	"errors"
+)
+
+var encodeIndent = 0
+
+type asn1Object interface {
+	EncodeTo(writer *bytes.Buffer) error
+}
+
+type asn1Structured struct {
+	tagBytes []byte
+	content  []asn1Object
+}
+
+func (s asn1Structured) EncodeTo(out *bytes.Buffer) error {
+	//fmt.Printf("%s--> tag: % X\n", strings.Repeat("| ", encodeIndent), s.tagBytes)
+	encodeIndent++
+	inner := new(bytes.Buffer)
+	for _, obj := range s.content {
+		err := obj.EncodeTo(inner)
+		if err != nil {
+			return err
+		}
+	}
+	encodeIndent--
+	out.Write(s.tagBytes)
+	encodeLength(out, inner.Len())
+	out.Write(inner.Bytes())
+	return nil
+}
+
+type asn1Primitive struct {
+	tagBytes []byte
+	length   int
+	content  []byte
+}
+
+func (p asn1Primitive) EncodeTo(out *bytes.Buffer) error {
+	_, err := out.Write(p.tagBytes)
+	if err != nil {
+		return err
+	}
+	if err = encodeLength(out, p.length); err != nil {
+		return err
+	}
+	//fmt.Printf("%s--> tag: % X length: %d\n", strings.Repeat("| ", encodeIndent), p.tagBytes, p.length)
+	//fmt.Printf("%s--> content length: %d\n", strings.Repeat("| ", encodeIndent), len(p.content))
+	out.Write(p.content)
+
+	return nil
+}
+
+func ber2der(ber []byte) ([]byte, error) {
+	if len(ber) == 0 {
+		return nil, errors.New("ber2der: input ber is empty")
+	}
+	//fmt.Printf("--> ber2der: Transcoding %d bytes\n", len(ber))
+	out := new(bytes.Buffer)
+
+	obj, _, err := readObject(ber, 0)
+	if err != nil {
+		return nil, err
+	}
+	obj.EncodeTo(out)
+
+	// if offset < len(ber) {
+	//	return nil, fmt.Errorf("ber2der: Content longer than expected. Got %d, expected %d", offset, len(ber))
+	//}
+
+	return out.Bytes(), nil
+}
+
+// encodes lengths that are longer than 127 into string of bytes
+func marshalLongLength(out *bytes.Buffer, i int) (err error) {
+	n := lengthLength(i)
+
+	for ; n > 0; n-- {
+		err = out.WriteByte(byte(i >> uint((n-1)*8)))
+		if err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+// computes the byte length of an encoded length value
+func lengthLength(i int) (numBytes int) {
+	numBytes = 1
+	for i > 255 {
+		numBytes++
+		i >>= 8
+	}
+	return
+}
+
+// encodes the length in DER format
+// If the length fits in 7 bits, the value is encoded directly.
+//
+// Otherwise, the number of bytes to encode the length is first determined.
+// This number is likely to be 4 or less for a 32bit length. This number is
+// added to 0x80. The length is encoded in big endian encoding follow after
+//
+// Examples:
+//  length | byte 1 | bytes n
+//  0      | 0x00   | -
+//  120    | 0x78   | -
+//  200    | 0x81   | 0xC8
+//  500    | 0x82   | 0x01 0xF4
+//
+func encodeLength(out *bytes.Buffer, length int) (err error) {
+	if length >= 128 {
+		l := lengthLength(length)
+		err = out.WriteByte(0x80 | byte(l))
+		if err != nil {
+			return
+		}
+		err = marshalLongLength(out, length)
+		if err != nil {
+			return
+		}
+	} else {
+		err = out.WriteByte(byte(length))
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func readObject(ber []byte, offset int) (asn1Object, int, error) {
+	//fmt.Printf("\n====> Starting readObject at offset: %d\n\n", offset)
+	tagStart := offset
+	b := ber[offset]
+	offset++
+	tag := b & 0x1F // last 5 bits
+	if tag == 0x1F {
+		tag = 0
+		for ber[offset] >= 0x80 {
+			tag = tag*128 + ber[offset] - 0x80
+			offset++
+		}
+		tag = tag*128 + ber[offset] - 0x80
+		offset++
+	}
+	tagEnd := offset
+
+	kind := b & 0x20
+	/*
+		if kind == 0 {
+			fmt.Print("--> Primitive\n")
+		} else {
+			fmt.Print("--> Constructed\n")
+		}
+	*/
+	// read length
+	var length int
+	l := ber[offset]
+	offset++
+	indefinite := false
+	if l > 0x80 {
+		numberOfBytes := (int)(l & 0x7F)
+		if numberOfBytes > 4 { // int is only guaranteed to be 32bit
+			return nil, 0, errors.New("ber2der: BER tag length too long")
+		}
+		if numberOfBytes == 4 && (int)(ber[offset]) > 0x7F {
+			return nil, 0, errors.New("ber2der: BER tag length is negative")
+		}
+		if 0x0 == (int)(ber[offset]) {
+			return nil, 0, errors.New("ber2der: BER tag length has leading zero")
+		}
+		//fmt.Printf("--> (compute length) indicator byte: %x\n", l)
+		//fmt.Printf("--> (compute length) length bytes: % X\n", ber[offset:offset+numberOfBytes])
+		for i := 0; i < numberOfBytes; i++ {
+			length = length*256 + (int)(ber[offset])
+			offset++
+		}
+	} else if l == 0x80 {
+		indefinite = true
+	} else {
+		length = (int)(l)
+	}
+
+	//fmt.Printf("--> length        : %d\n", length)
+	contentEnd := offset + length
+	if contentEnd > len(ber) {
+		return nil, 0, errors.New("ber2der: BER tag length is more than available data")
+	}
+	//fmt.Printf("--> content start : %d\n", offset)
+	//fmt.Printf("--> content end   : %d\n", contentEnd)
+	//fmt.Printf("--> content       : % X\n", ber[offset:contentEnd])
+	var obj asn1Object
+	if indefinite && kind == 0 {
+		return nil, 0, errors.New("ber2der: Indefinite form tag must have constructed encoding")
+	}
+	if kind == 0 {
+		obj = asn1Primitive{
+			tagBytes: ber[tagStart:tagEnd],
+			length:   length,
+			content:  ber[offset:contentEnd],
+		}
+	} else {
+		var subObjects []asn1Object
+		for (offset < contentEnd) || indefinite {
+			var subObj asn1Object
+			var err error
+			subObj, offset, err = readObject(ber, offset)
+			if err != nil {
+				return nil, 0, err
+			}
+			subObjects = append(subObjects, subObj)
+
+			if indefinite {
+				terminated, err := isIndefiniteTermination(ber, offset)
+				if err != nil {
+					return nil, 0, err
+				}
+
+				if terminated {
+					break
+				}
+			}
+		}
+		obj = asn1Structured{
+			tagBytes: ber[tagStart:tagEnd],
+			content:  subObjects,
+		}
+	}
+
+	// Apply indefinite form length with 0x0000 terminator.
+	if indefinite {
+		contentEnd = offset + 2
+	}
+
+	return obj, contentEnd, nil
+}
+
+func isIndefiniteTermination(ber []byte, offset int) (bool, error) {
+	if len(ber)-offset < 2 {
+		return false, errors.New("ber2der: Invalid BER format")
+	}
+
+	return bytes.Index(ber[offset:], []byte{0x0, 0x0}) == 0, nil
+}

--- a/vendor/github.com/tjfoc/gmsm/x509/cert_pool.go
+++ b/vendor/github.com/tjfoc/gmsm/x509/cert_pool.go
@@ -1,0 +1,229 @@
+/*
+Copyright Suzhou Tongji Fintech Research Institute 2017 All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package x509
+
+import (
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"sync"
+)
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+}
+
+// CertPool is a set of certificates.
+type CertPool struct {
+	bySubjectKeyId map[string][]int
+	byName         map[string][]int
+	certs          []*Certificate
+}
+
+// NewCertPool returns a new, empty CertPool.
+func NewCertPool() *CertPool {
+	return &CertPool{
+		bySubjectKeyId: make(map[string][]int),
+		byName:         make(map[string][]int),
+	}
+}
+
+// Possible directories with certificate files; stop after successfully
+// reading at least one file from a directory.
+var certDirectories = []string{
+	"/etc/ssl/certs",               // SLES10/SLES11, https://golang.org/issue/12139
+	"/system/etc/security/cacerts", // Android
+}
+
+var (
+	once           sync.Once
+	systemRoots    *CertPool
+	systemRootsErr error
+)
+
+func systemRootsPool() *CertPool {
+	once.Do(initSystemRoots)
+	return systemRoots
+}
+
+func initSystemRoots() {
+	systemRoots, systemRootsErr = loadSystemRoots()
+}
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}
+
+func loadSystemRoots() (*CertPool, error) {
+	roots := NewCertPool()
+	var firstErr error
+	for _, file := range certFiles {
+		data, err := ioutil.ReadFile(file)
+		if err == nil {
+			roots.AppendCertsFromPEM(data)
+			return roots, nil
+		}
+		if firstErr == nil && !os.IsNotExist(err) {
+			firstErr = err
+		}
+	}
+
+	for _, directory := range certDirectories {
+		fis, err := ioutil.ReadDir(directory)
+		if err != nil {
+			if firstErr == nil && !os.IsNotExist(err) {
+				firstErr = err
+			}
+			continue
+		}
+		rootsAdded := false
+		for _, fi := range fis {
+			data, err := ioutil.ReadFile(directory + "/" + fi.Name())
+			if err == nil && roots.AppendCertsFromPEM(data) {
+				rootsAdded = true
+			}
+		}
+		if rootsAdded {
+			return roots, nil
+		}
+	}
+
+	return nil, firstErr
+}
+
+// SystemCertPool returns a copy of the system cert pool.
+//
+// Any mutations to the returned pool are not written to disk and do
+// not affect any other pool.
+func SystemCertPool() (*CertPool, error) {
+	if runtime.GOOS == "windows" {
+		// Issue 16736, 18609:
+		return nil, errors.New("crypto/x509: system root pool is not available on Windows")
+	}
+
+	return loadSystemRoots()
+}
+
+// findVerifiedParents attempts to find certificates in s which have signed the
+// given certificate. If any candidates were rejected then errCert will be set
+// to one of them, arbitrarily, and err will contain the reason that it was
+// rejected.
+func (s *CertPool) findVerifiedParents(cert *Certificate) (parents []int, errCert *Certificate, err error) {
+	if s == nil {
+		return
+	}
+	var candidates []int
+
+	if len(cert.AuthorityKeyId) > 0 {
+		candidates = s.bySubjectKeyId[string(cert.AuthorityKeyId)]
+	}
+	if len(candidates) == 0 {
+		candidates = s.byName[string(cert.RawIssuer)]
+	}
+
+	for _, c := range candidates {
+		if err = cert.CheckSignatureFrom(s.certs[c]); err == nil {
+			parents = append(parents, c)
+		} else {
+			errCert = s.certs[c]
+		}
+	}
+
+	return
+}
+
+func (s *CertPool) contains(cert *Certificate) bool {
+	if s == nil {
+		return false
+	}
+
+	candidates := s.byName[string(cert.RawSubject)]
+	for _, c := range candidates {
+		if s.certs[c].Equal(cert) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AddCert adds a certificate to a pool.
+func (s *CertPool) AddCert(cert *Certificate) {
+	if cert == nil {
+		panic("adding nil Certificate to CertPool")
+	}
+
+	// Check that the certificate isn't being added twice.
+	if s.contains(cert) {
+		return
+	}
+
+	n := len(s.certs)
+	s.certs = append(s.certs, cert)
+
+	if len(cert.SubjectKeyId) > 0 {
+		keyId := string(cert.SubjectKeyId)
+		s.bySubjectKeyId[keyId] = append(s.bySubjectKeyId[keyId], n)
+	}
+	name := string(cert.RawSubject)
+	s.byName[name] = append(s.byName[name], n)
+}
+
+// AppendCertsFromPEM attempts to parse a series of PEM encoded certificates.
+// It appends any certificates found to s and reports whether any certificates
+// were successfully parsed.
+//
+// On many Linux systems, /etc/ssl/cert.pem will contain the system wide set
+// of root CAs in a format suitable for this function.
+func (s *CertPool) AppendCertsFromPEM(pemCerts []byte) (ok bool) {
+	for len(pemCerts) > 0 {
+		var block *pem.Block
+		block, pemCerts = pem.Decode(pemCerts)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			continue
+		}
+
+		cert, err := ParseCertificate(block.Bytes)
+		if err != nil {
+			continue
+		}
+
+		s.AddCert(cert)
+		ok = true
+	}
+
+	return
+}
+
+// Subjects returns a list of the DER-encoded subjects of
+// all of the certificates in the pool.
+func (s *CertPool) Subjects() [][]byte {
+	res := make([][]byte, len(s.certs))
+	for i, c := range s.certs {
+		res[i] = c.RawSubject
+	}
+	return res
+}

--- a/vendor/github.com/tjfoc/gmsm/x509/pkcs1.go
+++ b/vendor/github.com/tjfoc/gmsm/x509/pkcs1.go
@@ -1,0 +1,132 @@
+/*
+Copyright Suzhou Tongji Fintech Research Institute 2017 All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package x509
+
+import (
+	"crypto/rsa"
+	"encoding/asn1"
+	"errors"
+	"math/big"
+)
+
+// pkcs1PrivateKey is a structure which mirrors the PKCS#1 ASN.1 for an RSA private key.
+type pkcs1PrivateKey struct {
+	Version int
+	N       *big.Int
+	E       int
+	D       *big.Int
+	P       *big.Int
+	Q       *big.Int
+	// We ignore these values, if present, because rsa will calculate them.
+	Dp   *big.Int `asn1:"optional"`
+	Dq   *big.Int `asn1:"optional"`
+	Qinv *big.Int `asn1:"optional"`
+
+	AdditionalPrimes []pkcs1AdditionalRSAPrime `asn1:"optional,omitempty"`
+}
+
+type pkcs1AdditionalRSAPrime struct {
+	Prime *big.Int
+
+	// We ignore these values because rsa will calculate them.
+	Exp   *big.Int
+	Coeff *big.Int
+}
+
+// ParsePKCS1PrivateKey returns an RSA private key from its ASN.1 PKCS#1 DER encoded form.
+func ParsePKCS1PrivateKey(der []byte) (*rsa.PrivateKey, error) {
+	var priv pkcs1PrivateKey
+	rest, err := asn1.Unmarshal(der, &priv)
+	if len(rest) > 0 {
+		return nil, asn1.SyntaxError{Msg: "trailing data"}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if priv.Version > 1 {
+		return nil, errors.New("x509: unsupported private key version")
+	}
+
+	if priv.N.Sign() <= 0 || priv.D.Sign() <= 0 || priv.P.Sign() <= 0 || priv.Q.Sign() <= 0 {
+		return nil, errors.New("x509: private key contains zero or negative value")
+	}
+
+	key := new(rsa.PrivateKey)
+	key.PublicKey = rsa.PublicKey{
+		E: priv.E,
+		N: priv.N,
+	}
+
+	key.D = priv.D
+	key.Primes = make([]*big.Int, 2+len(priv.AdditionalPrimes))
+	key.Primes[0] = priv.P
+	key.Primes[1] = priv.Q
+	for i, a := range priv.AdditionalPrimes {
+		if a.Prime.Sign() <= 0 {
+			return nil, errors.New("x509: private key contains zero or negative prime")
+		}
+		key.Primes[i+2] = a.Prime
+		// We ignore the other two values because rsa will calculate
+		// them as needed.
+	}
+
+	err = key.Validate()
+	if err != nil {
+		return nil, err
+	}
+	key.Precompute()
+
+	return key, nil
+}
+
+// MarshalPKCS1PrivateKey converts a private key to ASN.1 DER encoded form.
+func MarshalPKCS1PrivateKey(key *rsa.PrivateKey) []byte {
+	key.Precompute()
+
+	version := 0
+	if len(key.Primes) > 2 {
+		version = 1
+	}
+
+	priv := pkcs1PrivateKey{
+		Version: version,
+		N:       key.N,
+		E:       key.PublicKey.E,
+		D:       key.D,
+		P:       key.Primes[0],
+		Q:       key.Primes[1],
+		Dp:      key.Precomputed.Dp,
+		Dq:      key.Precomputed.Dq,
+		Qinv:    key.Precomputed.Qinv,
+	}
+
+	priv.AdditionalPrimes = make([]pkcs1AdditionalRSAPrime, len(key.Precomputed.CRTValues))
+	for i, values := range key.Precomputed.CRTValues {
+		priv.AdditionalPrimes[i].Prime = key.Primes[2+i]
+		priv.AdditionalPrimes[i].Exp = values.Exp
+		priv.AdditionalPrimes[i].Coeff = values.Coeff
+	}
+
+	b, _ := asn1.Marshal(priv)
+	return b
+}
+
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKey struct {
+	N *big.Int
+	E int
+}

--- a/vendor/github.com/tjfoc/gmsm/x509/pkcs7.go
+++ b/vendor/github.com/tjfoc/gmsm/x509/pkcs7.go
@@ -1,0 +1,971 @@
+package x509
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	_ "crypto/sha1" // for crypto.SHA1
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+	"sort"
+	"time"
+)
+
+// PKCS7 Represents a PKCS7 structure
+type PKCS7 struct {
+	Content      []byte
+	Certificates []*Certificate
+	CRLs         []pkix.CertificateList
+	Signers      []signerInfo
+	raw          interface{}
+}
+
+type contentInfo struct {
+	ContentType asn1.ObjectIdentifier
+	Content     asn1.RawValue `asn1:"explicit,optional,tag:0"`
+}
+
+// ErrUnsupportedContentType is returned when a PKCS7 content is not supported.
+// Currently only Data (1.2.156.10197.6.1.4.2.1), Signed Data (1.2.156.10197.6.1.4.2.2),
+// and Enveloped Data are supported (1.2.156.10197.6.1.4.2.3)
+var ErrUnsupportedContentType = errors.New("pkcs7: cannot parse data: unimplemented content type")
+
+type unsignedData []byte
+
+var (
+	oidData                   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 1}
+	oidSignedData             = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 2}
+	oidSMSignedData           = asn1.ObjectIdentifier{1, 2, 156, 10197, 6, 1, 4, 2, 2}
+	oidEnvelopedData          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 3}
+	oidSignedAndEnvelopedData = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 4}
+	oidDigestedData           = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 5}
+	oidEncryptedData          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 6}
+	oidAttributeContentType   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 3}
+	oidAttributeMessageDigest = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 4}
+	oidAttributeSigningTime   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 5}
+	oidSM3withSM2             = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 501}
+	oidDSASM2                 = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 301, 1}
+)
+
+type signedData struct {
+	Version                    int                        `asn1:"default:1"`
+	DigestAlgorithmIdentifiers []pkix.AlgorithmIdentifier `asn1:"set"`
+	ContentInfo                contentInfo
+	Certificates               rawCertificates        `asn1:"optional,tag:0"`
+	CRLs                       []pkix.CertificateList `asn1:"optional,tag:1"`
+	SignerInfos                []signerInfo           `asn1:"set"`
+}
+
+type rawCertificates struct {
+	Raw asn1.RawContent
+}
+
+type envelopedData struct {
+	Version              int
+	RecipientInfos       []recipientInfo `asn1:"set"`
+	EncryptedContentInfo encryptedContentInfo
+}
+
+type recipientInfo struct {
+	Version                int
+	IssuerAndSerialNumber  issuerAndSerial
+	KeyEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedKey           []byte
+}
+
+type encryptedContentInfo struct {
+	ContentType                asn1.ObjectIdentifier
+	ContentEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedContent           asn1.RawValue `asn1:"tag:0,optional"`
+}
+
+type attribute struct {
+	Type  asn1.ObjectIdentifier
+	Value asn1.RawValue `asn1:"set"`
+}
+
+type issuerAndSerial struct {
+	IssuerName   asn1.RawValue
+	SerialNumber *big.Int
+}
+
+// MessageDigestMismatchError is returned when the signer data digest does not
+// match the computed digest for the contained content
+type MessageDigestMismatchError struct {
+	ExpectedDigest []byte
+	ActualDigest   []byte
+}
+
+func (err *MessageDigestMismatchError) Error() string {
+	return fmt.Sprintf("pkcs7: Message digest mismatch\n\tExpected: %X\n\tActual  : %X", err.ExpectedDigest, err.ActualDigest)
+}
+
+type signerInfo struct {
+	Version                   int `asn1:"default:1"`
+	IssuerAndSerialNumber     issuerAndSerial
+	DigestAlgorithm           pkix.AlgorithmIdentifier
+	AuthenticatedAttributes   []attribute `asn1:"optional,tag:0"`
+	DigestEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedDigest           []byte
+	UnauthenticatedAttributes []attribute `asn1:"optional,tag:1"`
+}
+
+// ParsePKCS7 decodes a DER encoded PKCS7.
+func ParsePKCS7(data []byte) (p7 *PKCS7, err error) {
+	if len(data) == 0 {
+		return nil, errors.New("pkcs7: input data is empty")
+	}
+	var info contentInfo
+	der, err := ber2der(data)
+	if err != nil {
+		return nil, err
+	}
+	rest, err := asn1.Unmarshal(der, &info)
+	if len(rest) > 0 {
+		err = asn1.SyntaxError{Msg: "trailing data"}
+		return
+	}
+
+	if err != nil {
+		return
+	}
+
+	// fmt.Printf("--> Content Type: %s", info.ContentType)
+	switch {
+	case info.ContentType.Equal(oidSignedData):
+		return parseSignedData(info.Content.Bytes)
+	case info.ContentType.Equal(oidSMSignedData):
+		return parseSignedData(info.Content.Bytes)
+	case info.ContentType.Equal(oidEnvelopedData):
+		return parseEnvelopedData(info.Content.Bytes)
+	}
+	return nil, ErrUnsupportedContentType
+}
+
+func parseSignedData(data []byte) (*PKCS7, error) {
+	var sd signedData
+	asn1.Unmarshal(data, &sd)
+	certs, err := sd.Certificates.Parse()
+	if err != nil {
+		return nil, err
+	}
+	// fmt.Printf("--> Signed Data Version %d\n", sd.Version)
+
+	var compound asn1.RawValue
+	var content unsignedData
+
+	// The Content.Bytes maybe empty on PKI responses.
+	if len(sd.ContentInfo.Content.Bytes) > 0 {
+		if _, err := asn1.Unmarshal(sd.ContentInfo.Content.Bytes, &compound); err != nil {
+			return nil, err
+		}
+	}
+	// Compound octet string
+	if compound.IsCompound {
+		if _, err = asn1.Unmarshal(compound.Bytes, &content); err != nil {
+			return nil, err
+		}
+	} else {
+		// assuming this is tag 04
+		content = compound.Bytes
+	}
+	return &PKCS7{
+		Content:      content,
+		Certificates: certs,
+		CRLs:         sd.CRLs,
+		Signers:      sd.SignerInfos,
+		raw:          sd}, nil
+}
+
+func (raw rawCertificates) Parse() ([]*Certificate, error) {
+	if len(raw.Raw) == 0 {
+		return nil, nil
+	}
+
+	var val asn1.RawValue
+	if _, err := asn1.Unmarshal(raw.Raw, &val); err != nil {
+		return nil, err
+	}
+
+	return ParseCertificates(val.Bytes)
+}
+
+func parseEnvelopedData(data []byte) (*PKCS7, error) {
+	var ed envelopedData
+	if _, err := asn1.Unmarshal(data, &ed); err != nil {
+		return nil, err
+	}
+	return &PKCS7{
+		raw: ed,
+	}, nil
+}
+
+// Verify checks the signatures of a PKCS7 object
+// WARNING: Verify does not check signing time or verify certificate chains at
+// this time.
+func (p7 *PKCS7) Verify() (err error) {
+	if len(p7.Signers) == 0 {
+		return errors.New("pkcs7: Message has no signers")
+	}
+	for _, signer := range p7.Signers {
+		if err := verifySignature(p7, signer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifySignature(p7 *PKCS7, signer signerInfo) error {
+	signedData := p7.Content
+	hash, err := getHashForOID(signer.DigestAlgorithm.Algorithm)
+	if err != nil {
+		return err
+	}
+	// fmt.Println("===== hash algo=====:", hash)
+	if len(signer.AuthenticatedAttributes) > 0 {
+		var digest []byte
+		err := unmarshalAttribute(signer.AuthenticatedAttributes, oidAttributeMessageDigest, &digest)
+		if err != nil {
+			return err
+		}
+		h := hash.New()
+		h.Write(p7.Content)
+		computed := h.Sum(nil)
+		if !hmac.Equal(digest, computed) {
+			return &MessageDigestMismatchError{
+				ExpectedDigest: digest,
+				ActualDigest:   computed,
+			}
+		}
+		// TODO(shengzhi): Optionally verify certificate chain
+		// TODO(shengzhi): Optionally verify signingTime against certificate NotAfter/NotBefore
+		signedData, err = marshalAttributes(signer.AuthenticatedAttributes)
+		if err != nil {
+			return err
+		}
+	}
+	cert := getCertFromCertsByIssuerAndSerial(p7.Certificates, signer.IssuerAndSerialNumber)
+	if cert == nil {
+		return errors.New("pkcs7: No certificate for signer")
+	}
+
+	algo := getSignatureAlgorithmByHash(hash, signer.DigestEncryptionAlgorithm.Algorithm)
+	if algo == UnknownSignatureAlgorithm {
+		return ErrPKCS7UnsupportedAlgorithm
+	}
+	return cert.CheckSignature(algo, signedData, signer.EncryptedDigest)
+}
+
+func getSignatureAlgorithmByHash(hash Hash, oid asn1.ObjectIdentifier) SignatureAlgorithm {
+	switch hash {
+	case SM3:
+		switch {
+		case oid.Equal(oidSM3withSM2):
+			return SM2WithSM3
+		}
+	case SHA256:
+		switch {
+		case oid.Equal(oidDSASM2):
+			return SM2WithSHA256
+		}
+	}
+	return UnknownSignatureAlgorithm
+}
+
+func marshalAttributes(attrs []attribute) ([]byte, error) {
+	encodedAttributes, err := asn1.Marshal(struct {
+		A []attribute `asn1:"set"`
+	}{A: attrs})
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the leading sequence octets
+	var raw asn1.RawValue
+	_, err = asn1.Unmarshal(encodedAttributes, &raw)
+	if err != nil {
+		return nil, err
+	}
+	return raw.Bytes, nil
+}
+
+var (
+	oidDigestAlgorithmSHA1    = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
+	oidEncryptionAlgorithmRSA = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+)
+
+func getCertFromCertsByIssuerAndSerial(certs []*Certificate, ias issuerAndSerial) *Certificate {
+	for _, cert := range certs {
+		if isCertMatchForIssuerAndSerial(cert, ias) {
+			return cert
+		}
+	}
+	return nil
+}
+
+func getHashForOID(oid asn1.ObjectIdentifier) (Hash, error) {
+	switch {
+	case oid.Equal(oidDigestAlgorithmSHA1):
+		return SHA1, nil
+	case oid.Equal(oidSHA256):
+		return SHA256, nil
+	case oid.Equal(oidSM3):
+	case oid.Equal(oidHashSM3):
+		return SM3, nil
+	}
+	return Hash(0), ErrPKCS7UnsupportedAlgorithm
+}
+
+// GetOnlySigner returns an x509.Certificate for the first signer of the signed
+// data payload. If there are more or less than one signer, nil is returned
+func (p7 *PKCS7) GetOnlySigner() *Certificate {
+	if len(p7.Signers) != 1 {
+		return nil
+	}
+	signer := p7.Signers[0]
+	return getCertFromCertsByIssuerAndSerial(p7.Certificates, signer.IssuerAndSerialNumber)
+}
+
+// ErrPKCS7UnsupportedAlgorithm tells you when our quick dev assumptions have failed
+var ErrPKCS7UnsupportedAlgorithm = errors.New("pkcs7: cannot decrypt data: only RSA, DES, DES-EDE3, AES-256-CBC and AES-128-GCM supported")
+
+// ErrNotEncryptedContent is returned when attempting to Decrypt data that is not encrypted data
+var ErrNotEncryptedContent = errors.New("pkcs7: content data is a decryptable data type")
+
+// Decrypt decrypts encrypted content info for recipient cert and private key
+func (p7 *PKCS7) Decrypt(cert *Certificate, pk crypto.PrivateKey) ([]byte, error) {
+	data, ok := p7.raw.(envelopedData)
+	if !ok {
+		return nil, ErrNotEncryptedContent
+	}
+	recipient := selectRecipientForCertificate(data.RecipientInfos, cert)
+	if recipient.EncryptedKey == nil {
+		return nil, errors.New("pkcs7: no enveloped recipient for provided certificate")
+	}
+	if priv := pk.(*rsa.PrivateKey); priv != nil {
+		var contentKey []byte
+		contentKey, err := rsa.DecryptPKCS1v15(rand.Reader, priv, recipient.EncryptedKey)
+		if err != nil {
+			return nil, err
+		}
+		return data.EncryptedContentInfo.decrypt(contentKey)
+	}
+	fmt.Printf("Unsupported Private Key: %v\n", pk)
+	// TODO: SM decript
+	return nil, ErrPKCS7UnsupportedAlgorithm
+}
+
+var oidEncryptionAlgorithmDESCBC = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 7}
+var oidEncryptionAlgorithmDESEDE3CBC = asn1.ObjectIdentifier{1, 2, 840, 113549, 3, 7}
+var oidEncryptionAlgorithmAES256CBC = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 42}
+var oidEncryptionAlgorithmAES128GCM = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 6}
+var oidEncryptionAlgorithmAES128CBC = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 2}
+
+func (eci encryptedContentInfo) decrypt(key []byte) ([]byte, error) {
+	alg := eci.ContentEncryptionAlgorithm.Algorithm
+	if !alg.Equal(oidEncryptionAlgorithmDESCBC) &&
+		!alg.Equal(oidEncryptionAlgorithmDESEDE3CBC) &&
+		!alg.Equal(oidEncryptionAlgorithmAES256CBC) &&
+		!alg.Equal(oidEncryptionAlgorithmAES128CBC) &&
+		!alg.Equal(oidEncryptionAlgorithmAES128GCM) {
+		fmt.Printf("Unsupported Content Encryption Algorithm: %s\n", alg)
+		return nil, ErrPKCS7UnsupportedAlgorithm
+	}
+
+	// EncryptedContent can either be constructed of multple OCTET STRINGs
+	// or _be_ a tagged OCTET STRING
+	var cyphertext []byte
+	if eci.EncryptedContent.IsCompound {
+		// Complex case to concat all of the children OCTET STRINGs
+		var buf bytes.Buffer
+		cypherbytes := eci.EncryptedContent.Bytes
+		for {
+			var part []byte
+			cypherbytes, _ = asn1.Unmarshal(cypherbytes, &part)
+			buf.Write(part)
+			if cypherbytes == nil {
+				break
+			}
+		}
+		cyphertext = buf.Bytes()
+	} else {
+		// Simple case, the bytes _are_ the cyphertext
+		cyphertext = eci.EncryptedContent.Bytes
+	}
+
+	var block cipher.Block
+	var err error
+
+	switch {
+	case alg.Equal(oidEncryptionAlgorithmDESCBC):
+		block, err = des.NewCipher(key)
+	case alg.Equal(oidEncryptionAlgorithmDESEDE3CBC):
+		block, err = des.NewTripleDESCipher(key)
+	case alg.Equal(oidEncryptionAlgorithmAES256CBC):
+		fallthrough
+	case alg.Equal(oidEncryptionAlgorithmAES128GCM), alg.Equal(oidEncryptionAlgorithmAES128CBC):
+		block, err = aes.NewCipher(key)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if alg.Equal(oidEncryptionAlgorithmAES128GCM) {
+		params := aesGCMParameters{}
+		paramBytes := eci.ContentEncryptionAlgorithm.Parameters.Bytes
+
+		_, err := asn1.Unmarshal(paramBytes, &params)
+		if err != nil {
+			return nil, err
+		}
+
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(params.Nonce) != gcm.NonceSize() {
+			return nil, errors.New("pkcs7: encryption algorithm parameters are incorrect")
+		}
+		if params.ICVLen != gcm.Overhead() {
+			return nil, errors.New("pkcs7: encryption algorithm parameters are incorrect")
+		}
+
+		plaintext, err := gcm.Open(nil, params.Nonce, cyphertext, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		return plaintext, nil
+	}
+
+	iv := eci.ContentEncryptionAlgorithm.Parameters.Bytes
+	if len(iv) != block.BlockSize() {
+		return nil, errors.New("pkcs7: encryption algorithm parameters are malformed")
+	}
+	mode := cipher.NewCBCDecrypter(block, iv)
+	plaintext := make([]byte, len(cyphertext))
+	mode.CryptBlocks(plaintext, cyphertext)
+	if plaintext, err = unpad(plaintext, mode.BlockSize()); err != nil {
+		return nil, err
+	}
+	return plaintext, nil
+}
+
+func selectRecipientForCertificate(recipients []recipientInfo, cert *Certificate) recipientInfo {
+	for _, recp := range recipients {
+		if isCertMatchForIssuerAndSerial(cert, recp.IssuerAndSerialNumber) {
+			return recp
+		}
+	}
+	return recipientInfo{}
+}
+
+func isCertMatchForIssuerAndSerial(cert *Certificate, ias issuerAndSerial) bool {
+	return cert.SerialNumber.Cmp(ias.SerialNumber) == 0 && bytes.Compare(cert.RawIssuer, ias.IssuerName.FullBytes) == 0
+}
+
+func pad(data []byte, blocklen int) ([]byte, error) {
+	if blocklen < 1 {
+		return nil, fmt.Errorf("invalid blocklen %d", blocklen)
+	}
+	padlen := blocklen - (len(data) % blocklen)
+	if padlen == 0 {
+		padlen = blocklen
+	}
+	pad := bytes.Repeat([]byte{byte(padlen)}, padlen)
+	return append(data, pad...), nil
+}
+
+func unpad(data []byte, blocklen int) ([]byte, error) {
+	if blocklen < 1 {
+		return nil, fmt.Errorf("invalid blocklen %d", blocklen)
+	}
+	if len(data)%blocklen != 0 || len(data) == 0 {
+		return nil, fmt.Errorf("invalid data len %d", len(data))
+	}
+
+	// the last byte is the length of padding
+	padlen := int(data[len(data)-1])
+
+	// check padding integrity, all bytes should be the same
+	pad := data[len(data)-padlen:]
+	for _, padbyte := range pad {
+		if padbyte != byte(padlen) {
+			return nil, errors.New("invalid padding")
+		}
+	}
+
+	return data[:len(data)-padlen], nil
+}
+
+func unmarshalAttribute(attrs []attribute, attributeType asn1.ObjectIdentifier, out interface{}) error {
+	for _, attr := range attrs {
+		if attr.Type.Equal(attributeType) {
+			_, err := asn1.Unmarshal(attr.Value.Bytes, out)
+			return err
+		}
+	}
+	return errors.New("pkcs7: attribute type not in attributes")
+}
+
+// UnmarshalSignedAttribute decodes a single attribute from the signer info
+func (p7 *PKCS7) UnmarshalSignedAttribute(attributeType asn1.ObjectIdentifier, out interface{}) error {
+	sd, ok := p7.raw.(signedData)
+	if !ok {
+		return errors.New("pkcs7: payload is not signedData content")
+	}
+	if len(sd.SignerInfos) < 1 {
+		return errors.New("pkcs7: payload has no signers")
+	}
+	attributes := sd.SignerInfos[0].AuthenticatedAttributes
+	return unmarshalAttribute(attributes, attributeType, out)
+}
+
+// SignedData is an opaque data structure for creating signed data payloads
+type SignedData struct {
+	sd            signedData
+	certs         []*Certificate
+	messageDigest []byte
+}
+
+// Attribute represents a key value pair attribute. Value must be marshalable byte
+// `encoding/asn1`
+type Attribute struct {
+	Type  asn1.ObjectIdentifier
+	Value interface{}
+}
+
+// SignerInfoConfig are optional values to include when adding a signer
+type SignerInfoConfig struct {
+	ExtraSignedAttributes []Attribute
+}
+
+// NewSignedData initializes a SignedData with content
+func NewSignedData(data []byte) (*SignedData, error) {
+	content, err := asn1.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	ci := contentInfo{
+		ContentType: oidData,
+		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
+	}
+	digAlg := pkix.AlgorithmIdentifier{
+		Algorithm: oidDigestAlgorithmSHA1,
+	}
+	h := crypto.SHA1.New()
+	h.Write(data)
+	md := h.Sum(nil)
+	sd := signedData{
+		ContentInfo:                ci,
+		Version:                    1,
+		DigestAlgorithmIdentifiers: []pkix.AlgorithmIdentifier{digAlg},
+	}
+	return &SignedData{sd: sd, messageDigest: md}, nil
+}
+
+type attributes struct {
+	types  []asn1.ObjectIdentifier
+	values []interface{}
+}
+
+// Add adds the attribute, maintaining insertion order
+func (attrs *attributes) Add(attrType asn1.ObjectIdentifier, value interface{}) {
+	attrs.types = append(attrs.types, attrType)
+	attrs.values = append(attrs.values, value)
+}
+
+type sortableAttribute struct {
+	SortKey   []byte
+	Attribute attribute
+}
+
+type attributeSet []sortableAttribute
+
+func (sa attributeSet) Len() int {
+	return len(sa)
+}
+
+func (sa attributeSet) Less(i, j int) bool {
+	return bytes.Compare(sa[i].SortKey, sa[j].SortKey) < 0
+}
+
+func (sa attributeSet) Swap(i, j int) {
+	sa[i], sa[j] = sa[j], sa[i]
+}
+
+func (sa attributeSet) Attributes() []attribute {
+	attrs := make([]attribute, len(sa))
+	for i, attr := range sa {
+		attrs[i] = attr.Attribute
+	}
+	return attrs
+}
+
+func (attrs *attributes) ForMarshaling() ([]attribute, error) {
+	sortables := make(attributeSet, len(attrs.types))
+	for i := range sortables {
+		attrType := attrs.types[i]
+		attrValue := attrs.values[i]
+		asn1Value, err := asn1.Marshal(attrValue)
+		if err != nil {
+			return nil, err
+		}
+		attr := attribute{
+			Type:  attrType,
+			Value: asn1.RawValue{Tag: 17, IsCompound: true, Bytes: asn1Value}, // 17 == SET tag
+		}
+		encoded, err := asn1.Marshal(attr)
+		if err != nil {
+			return nil, err
+		}
+		sortables[i] = sortableAttribute{
+			SortKey:   encoded,
+			Attribute: attr,
+		}
+	}
+	sort.Sort(sortables)
+	return sortables.Attributes(), nil
+}
+
+// AddSigner signs attributes about the content and adds certificate to payload
+func (sd *SignedData) AddSigner(cert *Certificate, pkey crypto.PrivateKey, config SignerInfoConfig) error {
+	attrs := &attributes{}
+	attrs.Add(oidAttributeContentType, sd.sd.ContentInfo.ContentType)
+	attrs.Add(oidAttributeMessageDigest, sd.messageDigest)
+	attrs.Add(oidAttributeSigningTime, time.Now())
+	for _, attr := range config.ExtraSignedAttributes {
+		attrs.Add(attr.Type, attr.Value)
+	}
+	finalAttrs, err := attrs.ForMarshaling()
+	if err != nil {
+		return err
+	}
+	signature, err := signAttributes(finalAttrs, pkey, crypto.SHA1)
+	if err != nil {
+		return err
+	}
+
+	ias, err := cert2issuerAndSerial(cert)
+	if err != nil {
+		return err
+	}
+
+	signer := signerInfo{
+		AuthenticatedAttributes:   finalAttrs,
+		DigestAlgorithm:           pkix.AlgorithmIdentifier{Algorithm: oidDigestAlgorithmSHA1},
+		DigestEncryptionAlgorithm: pkix.AlgorithmIdentifier{Algorithm: oidSignatureSHA1WithRSA},
+		IssuerAndSerialNumber:     ias,
+		EncryptedDigest:           signature,
+		Version:                   1,
+	}
+	// create signature of signed attributes
+	sd.certs = append(sd.certs, cert)
+	sd.sd.SignerInfos = append(sd.sd.SignerInfos, signer)
+	return nil
+}
+
+// AddCertificate adds the certificate to the payload. Useful for parent certificates
+func (sd *SignedData) AddCertificate(cert *Certificate) {
+	sd.certs = append(sd.certs, cert)
+}
+
+// Detach removes content from the signed data struct to make it a detached signature.
+// This must be called right before Finish()
+func (sd *SignedData) Detach() {
+	sd.sd.ContentInfo = contentInfo{ContentType: oidData}
+}
+
+// Finish marshals the content and its signers
+func (sd *SignedData) Finish() ([]byte, error) {
+	sd.sd.Certificates = marshalCertificates(sd.certs)
+	inner, err := asn1.Marshal(sd.sd)
+	if err != nil {
+		return nil, err
+	}
+	outer := contentInfo{
+		ContentType: oidSignedData,
+		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: inner, IsCompound: true},
+	}
+	return asn1.Marshal(outer)
+}
+
+func cert2issuerAndSerial(cert *Certificate) (issuerAndSerial, error) {
+	var ias issuerAndSerial
+	// The issuer RDNSequence has to match exactly the sequence in the certificate
+	// We cannot use cert.Issuer.ToRDNSequence() here since it mangles the sequence
+	ias.IssuerName = asn1.RawValue{FullBytes: cert.RawIssuer}
+	ias.SerialNumber = cert.SerialNumber
+
+	return ias, nil
+}
+
+// signs the DER encoded form of the attributes with the private key
+func signAttributes(attrs []attribute, pkey crypto.PrivateKey, hash crypto.Hash) ([]byte, error) {
+	attrBytes, err := marshalAttributes(attrs)
+	if err != nil {
+		return nil, err
+	}
+	h := hash.New()
+	h.Write(attrBytes)
+	hashed := h.Sum(nil)
+	switch priv := pkey.(type) {
+	case *rsa.PrivateKey:
+		return rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA1, hashed)
+	}
+	return nil, ErrPKCS7UnsupportedAlgorithm
+}
+
+// concats and wraps the certificates in the RawValue structure
+func marshalCertificates(certs []*Certificate) rawCertificates {
+	var buf bytes.Buffer
+	for _, cert := range certs {
+		buf.Write(cert.Raw)
+	}
+	rawCerts, _ := marshalCertificateBytes(buf.Bytes())
+	return rawCerts
+}
+
+// Even though, the tag & length are stripped out during marshalling the
+// RawContent, we have to encode it into the RawContent. If its missing,
+// then `asn1.Marshal()` will strip out the certificate wrapper instead.
+func marshalCertificateBytes(certs []byte) (rawCertificates, error) {
+	var val = asn1.RawValue{Bytes: certs, Class: 2, Tag: 0, IsCompound: true}
+	b, err := asn1.Marshal(val)
+	if err != nil {
+		return rawCertificates{}, err
+	}
+	return rawCertificates{Raw: b}, nil
+}
+
+// DegenerateCertificate creates a signed data structure containing only the
+// provided certificate or certificate chain.
+func DegenerateCertificate(cert []byte) ([]byte, error) {
+	rawCert, err := marshalCertificateBytes(cert)
+	if err != nil {
+		return nil, err
+	}
+	emptyContent := contentInfo{ContentType: oidData}
+	sd := signedData{
+		Version:      1,
+		ContentInfo:  emptyContent,
+		Certificates: rawCert,
+		CRLs:         []pkix.CertificateList{},
+	}
+	content, err := asn1.Marshal(sd)
+	if err != nil {
+		return nil, err
+	}
+	signedContent := contentInfo{
+		ContentType: oidSignedData,
+		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
+	}
+	return asn1.Marshal(signedContent)
+}
+
+const (
+	EncryptionAlgorithmDESCBC = iota
+	EncryptionAlgorithmAES128GCM
+)
+
+// ContentEncryptionAlgorithm determines the algorithm used to encrypt the
+// plaintext message. Change the value of this variable to change which
+// algorithm is used in the Encrypt() function.
+var ContentEncryptionAlgorithm = EncryptionAlgorithmDESCBC
+
+// ErrUnsupportedEncryptionAlgorithm is returned when attempting to encrypt
+// content with an unsupported algorithm.
+var ErrUnsupportedEncryptionAlgorithm = errors.New("pkcs7: cannot encrypt content: only DES-CBC and AES-128-GCM supported")
+
+const nonceSize = 12
+
+type aesGCMParameters struct {
+	Nonce  []byte `asn1:"tag:4"`
+	ICVLen int
+}
+
+func encryptAES128GCM(content []byte) ([]byte, *encryptedContentInfo, error) {
+	// Create AES key and nonce
+	key := make([]byte, 16)
+	nonce := make([]byte, nonceSize)
+
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, err = rand.Read(nonce)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encrypt content
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, content, nil)
+
+	// Prepare ASN.1 Encrypted Content Info
+	paramSeq := aesGCMParameters{
+		Nonce:  nonce,
+		ICVLen: gcm.Overhead(),
+	}
+
+	paramBytes, err := asn1.Marshal(paramSeq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	eci := encryptedContentInfo{
+		ContentType: oidData,
+		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
+			Algorithm: oidEncryptionAlgorithmAES128GCM,
+			Parameters: asn1.RawValue{
+				Tag:   asn1.TagSequence,
+				Bytes: paramBytes,
+			},
+		},
+		EncryptedContent: marshalEncryptedContent(ciphertext),
+	}
+
+	return key, &eci, nil
+}
+
+func encryptDESCBC(content []byte) ([]byte, *encryptedContentInfo, error) {
+	// Create DES key & CBC IV
+	key := make([]byte, 8)
+	iv := make([]byte, des.BlockSize)
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, err = rand.Read(iv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encrypt padded content
+	block, err := des.NewCipher(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	mode := cipher.NewCBCEncrypter(block, iv)
+	plaintext, err := pad(content, mode.BlockSize())
+	cyphertext := make([]byte, len(plaintext))
+	mode.CryptBlocks(cyphertext, plaintext)
+
+	// Prepare ASN.1 Encrypted Content Info
+	eci := encryptedContentInfo{
+		ContentType: oidData,
+		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
+			Algorithm:  oidEncryptionAlgorithmDESCBC,
+			Parameters: asn1.RawValue{Tag: 4, Bytes: iv},
+		},
+		EncryptedContent: marshalEncryptedContent(cyphertext),
+	}
+
+	return key, &eci, nil
+}
+
+// Encrypt creates and returns an envelope data PKCS7 structure with encrypted
+// recipient keys for each recipient public key.
+//
+// The algorithm used to perform encryption is determined by the current value
+// of the global ContentEncryptionAlgorithm package variable. By default, the
+// value is EncryptionAlgorithmDESCBC. To use a different algorithm, change the
+// value before calling Encrypt(). For example:
+//
+//     ContentEncryptionAlgorithm = EncryptionAlgorithmAES128GCM
+//
+// TODO(fullsailor): Add support for encrypting content with other algorithms
+func PKCS7Encrypt(content []byte, recipients []*Certificate) ([]byte, error) {
+	var eci *encryptedContentInfo
+	var key []byte
+	var err error
+
+	// Apply chosen symmetric encryption method
+	switch ContentEncryptionAlgorithm {
+	case EncryptionAlgorithmDESCBC:
+		key, eci, err = encryptDESCBC(content)
+
+	case EncryptionAlgorithmAES128GCM:
+		key, eci, err = encryptAES128GCM(content)
+
+	default:
+		return nil, ErrUnsupportedEncryptionAlgorithm
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare each recipient's encrypted cipher key
+	recipientInfos := make([]recipientInfo, len(recipients))
+	for i, recipient := range recipients {
+		encrypted, err := encryptKey(key, recipient)
+		if err != nil {
+			return nil, err
+		}
+		ias, err := cert2issuerAndSerial(recipient)
+		if err != nil {
+			return nil, err
+		}
+		info := recipientInfo{
+			Version:               0,
+			IssuerAndSerialNumber: ias,
+			KeyEncryptionAlgorithm: pkix.AlgorithmIdentifier{
+				Algorithm: oidEncryptionAlgorithmRSA,
+			},
+			EncryptedKey: encrypted,
+		}
+		recipientInfos[i] = info
+	}
+
+	// Prepare envelope content
+	envelope := envelopedData{
+		EncryptedContentInfo: *eci,
+		Version:              0,
+		RecipientInfos:       recipientInfos,
+	}
+	innerContent, err := asn1.Marshal(envelope)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare outer payload structure
+	wrapper := contentInfo{
+		ContentType: oidEnvelopedData,
+		Content:     asn1.RawValue{Class: 2, Tag: 0, IsCompound: true, Bytes: innerContent},
+	}
+
+	return asn1.Marshal(wrapper)
+}
+
+func marshalEncryptedContent(content []byte) asn1.RawValue {
+	asn1Content, _ := asn1.Marshal(content)
+	return asn1.RawValue{Tag: 0, Class: 2, Bytes: asn1Content, IsCompound: true}
+}
+
+func encryptKey(key []byte, recipient *Certificate) ([]byte, error) {
+	if pub := recipient.PublicKey.(*rsa.PublicKey); pub != nil {
+		return rsa.EncryptPKCS1v15(rand.Reader, pub, key)
+	}
+	return nil, ErrPKCS7UnsupportedAlgorithm
+}

--- a/vendor/github.com/tjfoc/gmsm/x509/pkcs8.go
+++ b/vendor/github.com/tjfoc/gmsm/x509/pkcs8.go
@@ -1,0 +1,371 @@
+/*
+Copyright Suzhou Tongji Fintech Research Institute 2017 All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package x509
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"hash"
+	"math/big"
+	"reflect"
+
+	"github.com/tjfoc/gmsm/sm2"
+)
+
+/*
+ * reference to RFC5959 and RFC2898
+ */
+
+var (
+	oidPBES1  = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 3}  // pbeWithMD5AndDES-CBC(PBES1)
+	oidPBES2  = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 13} // id-PBES2(PBES2)
+	oidPBKDF2 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 12} // id-PBKDF2
+
+	oidKEYMD5    = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 5}
+	oidKEYSHA1   = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 7}
+	oidKEYSHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 9}
+	oidKEYSHA512 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 11}
+
+	oidAES128CBC = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 2}
+	oidAES256CBC = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 42}
+
+	oidSM2 = asn1.ObjectIdentifier{1, 2, 840, 10045, 2, 1}
+)
+
+// reference to https://www.rfc-editor.org/rfc/rfc5958.txt
+type PrivateKeyInfo struct {
+	Version             int // v1 or v2
+	PrivateKeyAlgorithm []asn1.ObjectIdentifier
+	PrivateKey          []byte
+}
+
+// reference to https://www.rfc-editor.org/rfc/rfc5958.txt
+type EncryptedPrivateKeyInfo struct {
+	EncryptionAlgorithm Pbes2Algorithms
+	EncryptedData       []byte
+}
+
+// reference to https://www.ietf.org/rfc/rfc2898.txt
+type Pbes2Algorithms struct {
+	IdPBES2     asn1.ObjectIdentifier
+	Pbes2Params Pbes2Params
+}
+
+// reference to https://www.ietf.org/rfc/rfc2898.txt
+type Pbes2Params struct {
+	KeyDerivationFunc Pbes2KDfs // PBES2-KDFs
+	EncryptionScheme  Pbes2Encs // PBES2-Encs
+}
+
+// reference to https://www.ietf.org/rfc/rfc2898.txt
+type Pbes2KDfs struct {
+	IdPBKDF2    asn1.ObjectIdentifier
+	Pkdf2Params Pkdf2Params
+}
+
+type Pbes2Encs struct {
+	EncryAlgo asn1.ObjectIdentifier
+	IV        []byte
+}
+
+// reference to https://www.ietf.org/rfc/rfc2898.txt
+type Pkdf2Params struct {
+	Salt           []byte
+	IterationCount int
+	Prf            pkix.AlgorithmIdentifier
+}
+
+type sm2PrivateKey struct {
+	Version       int
+	PrivateKey    []byte
+	NamedCurveOID asn1.ObjectIdentifier `asn1:"optional,explicit,tag:0"`
+	PublicKey     asn1.BitString        `asn1:"optional,explicit,tag:1"`
+}
+
+type pkcs8 struct {
+	Version    int
+	Algo       pkix.AlgorithmIdentifier
+	PrivateKey []byte
+}
+
+// copy from crypto/pbkdf2.go
+func pbkdf(password, salt []byte, iter, keyLen int, h func() hash.Hash) []byte {
+	prf := hmac.New(h, password)
+	hashLen := prf.Size()
+	numBlocks := (keyLen + hashLen - 1) / hashLen
+
+	var buf [4]byte
+	dk := make([]byte, 0, numBlocks*hashLen)
+	U := make([]byte, hashLen)
+	for block := 1; block <= numBlocks; block++ {
+		// N.B.: || means concatenation, ^ means XOR
+		// for each block T_i = U_1 ^ U_2 ^ ... ^ U_iter
+		// U_1 = PRF(password, salt || uint(i))
+		prf.Reset()
+		prf.Write(salt)
+		buf[0] = byte(block >> 24)
+		buf[1] = byte(block >> 16)
+		buf[2] = byte(block >> 8)
+		buf[3] = byte(block)
+		prf.Write(buf[:4])
+		dk = prf.Sum(dk)
+		T := dk[len(dk)-hashLen:]
+		copy(U, T)
+
+		// U_n = PRF(password, U_(n-1))
+		for n := 2; n <= iter; n++ {
+			prf.Reset()
+			prf.Write(U)
+			U = U[:0]
+			U = prf.Sum(U)
+			for x := range U {
+				T[x] ^= U[x]
+			}
+		}
+	}
+	return dk[:keyLen]
+}
+
+func ParseSm2PublicKey(der []byte) (*sm2.PublicKey, error) {
+	var pubkey pkixPublicKey
+
+	if _, err := asn1.Unmarshal(der, &pubkey); err != nil {
+		return nil, err
+	}
+	if !reflect.DeepEqual(pubkey.Algo.Algorithm, oidSM2) {
+		return nil, errors.New("x509: not sm2 elliptic curve")
+	}
+	curve := sm2.P256Sm2()
+	x, y := elliptic.Unmarshal(curve, pubkey.BitString.Bytes)
+	pub := sm2.PublicKey{
+		Curve: curve,
+		X:     x,
+		Y:     y,
+	}
+	return &pub, nil
+}
+
+func MarshalSm2PublicKey(key *sm2.PublicKey) ([]byte, error) {
+	var r pkixPublicKey
+	var algo pkix.AlgorithmIdentifier
+
+	if key.Curve.Params() != sm2.P256Sm2().Params() {
+		return nil, errors.New("x509: unsupported elliptic curve")
+	}
+	algo.Algorithm = oidSM2
+	algo.Parameters.Class = 0
+	algo.Parameters.Tag = 6
+	algo.Parameters.IsCompound = false
+	algo.Parameters.FullBytes = []byte{6, 8, 42, 129, 28, 207, 85, 1, 130, 45} // asn1.Marshal(asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 301})
+	r.Algo = algo
+	r.BitString = asn1.BitString{Bytes: elliptic.Marshal(key.Curve, key.X, key.Y)}
+	return asn1.Marshal(r)
+}
+
+func ParseSm2PrivateKey(der []byte) (*sm2.PrivateKey, error) {
+	var privKey sm2PrivateKey
+
+	if _, err := asn1.Unmarshal(der, &privKey); err != nil {
+		return nil, errors.New("x509: failed to parse SM2 private key: " + err.Error())
+	}
+	curve := sm2.P256Sm2()
+	k := new(big.Int).SetBytes(privKey.PrivateKey)
+	curveOrder := curve.Params().N
+	if k.Cmp(curveOrder) >= 0 {
+		return nil, errors.New("x509: invalid elliptic curve private key value")
+	}
+	priv := new(sm2.PrivateKey)
+	priv.Curve = curve
+	priv.D = k
+	privateKey := make([]byte, (curveOrder.BitLen()+7)/8)
+	for len(privKey.PrivateKey) > len(privateKey) {
+		if privKey.PrivateKey[0] != 0 {
+			return nil, errors.New("x509: invalid private key length")
+		}
+		privKey.PrivateKey = privKey.PrivateKey[1:]
+	}
+	copy(privateKey[len(privateKey)-len(privKey.PrivateKey):], privKey.PrivateKey)
+	priv.X, priv.Y = curve.ScalarBaseMult(privateKey)
+	return priv, nil
+}
+
+func ParsePKCS8UnecryptedPrivateKey(der []byte) (*sm2.PrivateKey, error) {
+	var privKey pkcs8
+
+	if _, err := asn1.Unmarshal(der, &privKey); err != nil {
+		return nil, err
+	}
+	if !reflect.DeepEqual(privKey.Algo.Algorithm, oidSM2) {
+		return nil, errors.New("x509: not sm2 elliptic curve")
+	}
+	return ParseSm2PrivateKey(privKey.PrivateKey)
+}
+
+func ParsePKCS8EcryptedPrivateKey(der, pwd []byte) (*sm2.PrivateKey, error) {
+	var keyInfo EncryptedPrivateKeyInfo
+
+	_, err := asn1.Unmarshal(der, &keyInfo)
+	if err != nil {
+		return nil, errors.New("x509: unknown format")
+	}
+	if !reflect.DeepEqual(keyInfo.EncryptionAlgorithm.IdPBES2, oidPBES2) {
+		return nil, errors.New("x509: only support PBES2")
+	}
+	encryptionScheme := keyInfo.EncryptionAlgorithm.Pbes2Params.EncryptionScheme
+	keyDerivationFunc := keyInfo.EncryptionAlgorithm.Pbes2Params.KeyDerivationFunc
+	if !reflect.DeepEqual(keyDerivationFunc.IdPBKDF2, oidPBKDF2) {
+		return nil, errors.New("x509: only support PBKDF2")
+	}
+	pkdf2Params := keyDerivationFunc.Pkdf2Params
+	if !reflect.DeepEqual(encryptionScheme.EncryAlgo, oidAES128CBC) &&
+		!reflect.DeepEqual(encryptionScheme.EncryAlgo, oidAES256CBC) {
+		return nil, errors.New("x509: unknow encryption algorithm")
+	}
+	iv := encryptionScheme.IV
+	salt := pkdf2Params.Salt
+	iter := pkdf2Params.IterationCount
+	encryptedKey := keyInfo.EncryptedData
+	var key []byte
+	switch {
+	case pkdf2Params.Prf.Algorithm.Equal(oidKEYMD5):
+		key = pbkdf(pwd, salt, iter, 32, md5.New)
+		break
+	case pkdf2Params.Prf.Algorithm.Equal(oidKEYSHA1):
+		key = pbkdf(pwd, salt, iter, 32, sha1.New)
+		break
+	case pkdf2Params.Prf.Algorithm.Equal(oidKEYSHA256):
+		key = pbkdf(pwd, salt, iter, 32, sha256.New)
+		break
+	case pkdf2Params.Prf.Algorithm.Equal(oidKEYSHA512):
+		key = pbkdf(pwd, salt, iter, 32, sha512.New)
+		break
+	default:
+		return nil, errors.New("x509: unknown hash algorithm")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	mode := cipher.NewCBCDecrypter(block, iv)
+	mode.CryptBlocks(encryptedKey, encryptedKey)
+	rKey, err := ParsePKCS8UnecryptedPrivateKey(encryptedKey)
+	if err != nil {
+		return nil, errors.New("pkcs8: incorrect password")
+	}
+	return rKey, nil
+}
+
+func ParsePKCS8PrivateKey(der, pwd []byte) (*sm2.PrivateKey, error) {
+	if pwd == nil {
+
+		return ParsePKCS8UnecryptedPrivateKey(der)
+	}
+	return ParsePKCS8EcryptedPrivateKey(der, pwd)
+}
+
+func MarshalSm2UnecryptedPrivateKey(key *sm2.PrivateKey) ([]byte, error) {
+	var r pkcs8
+	var priv sm2PrivateKey
+	var algo pkix.AlgorithmIdentifier
+
+	algo.Algorithm = oidSM2
+	algo.Parameters.Class = 0
+	algo.Parameters.Tag = 6
+	algo.Parameters.IsCompound = false
+	algo.Parameters.FullBytes = []byte{6, 8, 42, 129, 28, 207, 85, 1, 130, 45} // asn1.Marshal(asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 301})
+	priv.Version = 1
+	priv.NamedCurveOID = oidNamedCurveP256SM2
+	priv.PublicKey = asn1.BitString{Bytes: elliptic.Marshal(key.Curve, key.X, key.Y)}
+	priv.PrivateKey = key.D.Bytes()
+	r.Version = 0
+	r.Algo = algo
+	r.PrivateKey, _ = asn1.Marshal(priv)
+	return asn1.Marshal(r)
+}
+
+func MarshalSm2EcryptedPrivateKey(PrivKey *sm2.PrivateKey, pwd []byte) ([]byte, error) {
+	der, err := MarshalSm2UnecryptedPrivateKey(PrivKey)
+	if err != nil {
+		return nil, err
+	}
+	iter := 2048
+	salt := make([]byte, 8)
+	iv := make([]byte, 16)
+	rand.Reader.Read(salt)
+	rand.Reader.Read(iv)
+	key := pbkdf(pwd, salt, iter, 32, sha1.New) // 默认是SHA1
+	padding := aes.BlockSize - len(der)%aes.BlockSize
+	if padding > 0 {
+		n := len(der)
+		der = append(der, make([]byte, padding)...)
+		for i := 0; i < padding; i++ {
+			der[n+i] = byte(padding)
+		}
+	}
+	encryptedKey := make([]byte, len(der))
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	mode := cipher.NewCBCEncrypter(block, iv)
+	mode.CryptBlocks(encryptedKey, der)
+	var algorithmIdentifier pkix.AlgorithmIdentifier
+	algorithmIdentifier.Algorithm = oidKEYSHA1
+	algorithmIdentifier.Parameters.Tag = 5
+	algorithmIdentifier.Parameters.IsCompound = false
+	algorithmIdentifier.Parameters.FullBytes = []byte{5, 0}
+	keyDerivationFunc := Pbes2KDfs{
+		oidPBKDF2,
+		Pkdf2Params{
+			salt,
+			iter,
+			algorithmIdentifier,
+		},
+	}
+	encryptionScheme := Pbes2Encs{
+		oidAES256CBC,
+		iv,
+	}
+	pbes2Algorithms := Pbes2Algorithms{
+		oidPBES2,
+		Pbes2Params{
+			keyDerivationFunc,
+			encryptionScheme,
+		},
+	}
+	encryptedPkey := EncryptedPrivateKeyInfo{
+		pbes2Algorithms,
+		encryptedKey,
+	}
+	return asn1.Marshal(encryptedPkey)
+}
+
+func MarshalSm2PrivateKey(key *sm2.PrivateKey, pwd []byte) ([]byte, error) {
+	if pwd == nil {
+		return MarshalSm2UnecryptedPrivateKey(key)
+	}
+	return MarshalSm2EcryptedPrivateKey(key, pwd)
+}

--- a/vendor/github.com/tjfoc/gmsm/x509/utils.go
+++ b/vendor/github.com/tjfoc/gmsm/x509/utils.go
@@ -1,0 +1,295 @@
+package x509
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"math/big"
+
+	"github.com/tjfoc/gmsm/sm2"
+)
+
+func ReadPrivateKeyFromPem(privateKeyPem []byte, pwd []byte) (*sm2.PrivateKey, error) {
+	var block *pem.Block
+	block, _ = pem.Decode(privateKeyPem)
+	if block == nil {
+		return nil, errors.New("failed to decode private key")
+	}
+	priv, err := ParsePKCS8PrivateKey(block.Bytes, pwd)
+	return priv, err
+}
+
+func WritePrivateKeyToPem(key *sm2.PrivateKey, pwd []byte) ([]byte, error) {
+	var block *pem.Block
+	der, err := MarshalSm2PrivateKey(key, pwd) //Convert private key to DER format
+	if err != nil {
+		return nil, err
+	}
+	if pwd != nil {
+		block = &pem.Block{
+			Type:  "ENCRYPTED PRIVATE KEY",
+			Bytes: der,
+		}
+	} else {
+		block = &pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: der,
+		}
+	}
+	certPem := pem.EncodeToMemory(block)
+	return certPem, nil
+}
+
+func ReadPublicKeyFromPem(publicKeyPem []byte) (*sm2.PublicKey, error) {
+	block, _ := pem.Decode(publicKeyPem)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return nil, errors.New("failed to decode public key")
+	}
+	return ParseSm2PublicKey(block.Bytes)
+}
+
+func WritePublicKeyToPem(key *sm2.PublicKey) ([]byte, error) {
+	der, err := MarshalSm2PublicKey(key) //Convert publick key to DER format
+	if err != nil {
+		return nil, err
+	}
+	block := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	}
+	certPem := pem.EncodeToMemory(block)
+	return certPem, nil
+}
+
+//DHex是sm2私钥的真正关键数值
+func ReadPrivateKeyFromHex(Dhex string) (*sm2.PrivateKey,error) {
+	c := sm2.P256Sm2()
+	d,err:=hex.DecodeString(Dhex)
+	if err!=nil{
+		return nil,err
+	}
+	k:= new(big.Int).SetBytes(d)
+	params := c.Params()
+	one := new(big.Int).SetInt64(1)
+	n := new(big.Int).Sub(params.N, one)
+	if k.Cmp(n)>=0{
+      return nil,errors.New("privateKey's D is overflow.")
+	}
+	priv := new(sm2.PrivateKey)
+	priv.PublicKey.Curve = c
+	priv.D = k
+	priv.PublicKey.X, priv.PublicKey.Y = c.ScalarBaseMult(k.Bytes())
+	return priv,nil
+}
+
+
+
+func WritePrivateKeyToHex(key *sm2.PrivateKey) string {
+	return key.D.Text(16)
+}
+
+func ReadPublicKeyFromHex(Qhex string) (*sm2.PublicKey, error) {
+	q,err:=hex.DecodeString(Qhex)
+	if err!=nil{
+		return nil,err
+	}
+	if len(q)==65&&q[0]==byte(0x04){
+		q=q[1:]
+	}
+	if len(q)!=64{
+		return nil,errors.New("publicKey is not uncompressed.")
+	}
+	pub := new(sm2.PublicKey)
+	pub.Curve = sm2.P256Sm2()
+	pub.X = new(big.Int).SetBytes(q[:32])
+	pub.Y = new(big.Int).SetBytes(q[32:])
+	return pub, nil
+}
+
+
+func WritePublicKeyToHex(key *sm2.PublicKey) string {
+	x := key.X.Bytes()
+	y := key.Y.Bytes()
+	if n := len(x); n < 32 {
+		x = append(zeroByteSlice()[:32-n], x...)
+	}
+	if n := len(y); n < 32 {
+		y = append(zeroByteSlice()[:32-n], y...)
+	}
+	c := []byte{}
+	c = append(c, x...)
+	c = append(c, y...)
+	c = append([]byte{0x04}, c...)
+	return hex.EncodeToString(c)
+}
+
+
+func ReadCertificateRequestFromPem(certPem []byte) (*CertificateRequest, error) {
+	block, _ := pem.Decode(certPem)
+	if block == nil {
+		return nil, errors.New("failed to decode certificate request")
+	}
+	return ParseCertificateRequest(block.Bytes)
+}
+
+func CreateCertificateRequestToPem(template *CertificateRequest, signer crypto.Signer) ([]byte, error) {
+	der, err := CreateCertificateRequest(rand.Reader, template, signer)
+	if err != nil {
+		return nil, err
+	}
+	block := &pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: der,
+	}
+	certPem := pem.EncodeToMemory(block)
+	return certPem, nil
+}
+
+func ReadCertificateFromPem(certPem []byte) (*Certificate, error) {
+	block, _ := pem.Decode(certPem)
+	if block == nil {
+		return nil, errors.New("failed to decode certificate request")
+	}
+	return ParseCertificate(block.Bytes)
+}
+
+// CreateCertificate creates a new certificate based on a template. The
+// following members of template are used: SerialNumber, Subject, NotBefore,
+// NotAfter, KeyUsage, ExtKeyUsage, UnknownExtKeyUsage, BasicConstraintsValid,
+// IsCA, MaxPathLen, SubjectKeyId, DNSNames, PermittedDNSDomainsCritical,
+// PermittedDNSDomains, SignatureAlgorithm.
+//
+// The certificate is signed by parent. If parent is equal to template then the
+// certificate is self-signed. The parameter pub is the public key of the
+// signee and priv is the private key of the signer.
+//
+// The returned slice is the certificate in DER encoding.
+//
+// All keys types that are implemented via crypto.Signer are supported (This
+// includes *rsa.PublicKey and *ecdsa.PublicKey.)
+func CreateCertificate(template, parent *Certificate, publicKey *sm2.PublicKey, signer crypto.Signer) ([]byte, error) {
+	if template.SerialNumber == nil {
+		return nil, errors.New("x509: no SerialNumber given")
+	}
+
+	hashFunc, signatureAlgorithm, err := signingParamsForPublicKey(signer.Public(), template.SignatureAlgorithm)
+	if err != nil {
+		return nil, err
+	}
+
+	publicKeyBytes, publicKeyAlgorithm, err := marshalPublicKey(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	asn1Issuer, err := subjectBytes(parent)
+	if err != nil {
+		return nil, err
+	}
+
+	asn1Subject, err := subjectBytes(template)
+	if err != nil {
+		return nil, err
+	}
+
+	if !bytes.Equal(asn1Issuer, asn1Subject) && len(parent.SubjectKeyId) > 0 {
+		template.AuthorityKeyId = parent.SubjectKeyId
+	}
+
+	extensions, err := buildExtensions(template)
+	if err != nil {
+		return nil, err
+	}
+	encodedPublicKey := asn1.BitString{BitLength: len(publicKeyBytes) * 8, Bytes: publicKeyBytes}
+	c := tbsCertificate{
+		Version:            2,
+		SerialNumber:       template.SerialNumber,
+		SignatureAlgorithm: signatureAlgorithm,
+		Issuer:             asn1.RawValue{FullBytes: asn1Issuer},
+		Validity:           validity{template.NotBefore.UTC(), template.NotAfter.UTC()},
+		Subject:            asn1.RawValue{FullBytes: asn1Subject},
+		PublicKey:          publicKeyInfo{nil, publicKeyAlgorithm, encodedPublicKey},
+		Extensions:         extensions,
+	}
+
+	tbsCertContents, err := asn1.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+
+	c.Raw = tbsCertContents
+
+	digest := tbsCertContents
+	switch template.SignatureAlgorithm {
+	case SM2WithSM3, SM2WithSHA1, SM2WithSHA256:
+		break
+	default:
+		h := hashFunc.New()
+		h.Write(tbsCertContents)
+		digest = h.Sum(nil)
+	}
+
+	var signerOpts crypto.SignerOpts
+	signerOpts = hashFunc
+	if template.SignatureAlgorithm != 0 && template.SignatureAlgorithm.isRSAPSS() {
+		signerOpts = &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
+			Hash:       crypto.Hash(hashFunc),
+		}
+	}
+
+	var signature []byte
+	signature, err = signer.Sign(rand.Reader, digest, signerOpts)
+	if err != nil {
+		return nil, err
+	}
+	return asn1.Marshal(certificate{
+		nil,
+		c,
+		signatureAlgorithm,
+		asn1.BitString{Bytes: signature, BitLength: len(signature) * 8},
+	})
+}
+
+// CreateCertificateToPem creates a new certificate based on a template and
+// encodes it to PEM format. It uses CreateCertificate to create certificate
+// and returns its PEM format.
+func CreateCertificateToPem(template, parent *Certificate, pubKey *sm2.PublicKey, signer crypto.Signer) ([]byte, error) {
+	der, err := CreateCertificate(template, parent, pubKey, signer)
+	if err != nil {
+		return nil, err
+	}
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: der,
+	}
+	certPem := pem.EncodeToMemory(block)
+	return certPem, nil
+}
+
+func ParseSm2CertifateToX509(asn1data []byte) (*x509.Certificate, error) {
+	sm2Cert, err := ParseCertificate(asn1data)
+	if err != nil {
+		return nil, err
+	}
+	return sm2Cert.ToX509Certificate(), nil
+}
+// 32byte
+func zeroByteSlice() []byte {
+	return []byte{
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+	}
+}

--- a/vendor/github.com/tjfoc/gmsm/x509/verify.go
+++ b/vendor/github.com/tjfoc/gmsm/x509/verify.go
@@ -1,0 +1,568 @@
+/*
+Copyright Suzhou Tongji Fintech Research Institute 2017 All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package x509
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"runtime"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+type InvalidReason int
+
+const (
+	// NotAuthorizedToSign results when a certificate is signed by another
+	// which isn't marked as a CA certificate.
+	NotAuthorizedToSign InvalidReason = iota
+	// Expired results when a certificate has expired, based on the time
+	// given in the VerifyOptions.
+	Expired
+	// CANotAuthorizedForThisName results when an intermediate or root
+	// certificate has a name constraint which doesn't include the name
+	// being checked.
+	CANotAuthorizedForThisName
+	// TooManyIntermediates results when a path length constraint is
+	// violated.
+	TooManyIntermediates
+	// IncompatibleUsage results when the certificate's key usage indicates
+	// that it may only be used for a different purpose.
+	IncompatibleUsage
+	// NameMismatch results when the subject name of a parent certificate
+	// does not match the issuer name in the child.
+	NameMismatch
+)
+
+// CertificateInvalidError results when an odd error occurs. Users of this
+// library probably want to handle all these errors uniformly.
+type CertificateInvalidError struct {
+	Cert   *Certificate
+	Reason InvalidReason
+}
+
+func (e CertificateInvalidError) Error() string {
+	switch e.Reason {
+	case NotAuthorizedToSign:
+		return "x509: certificate is not authorized to sign other certificates"
+	case Expired:
+		return "x509: certificate has expired or is not yet valid"
+	case CANotAuthorizedForThisName:
+		return "x509: a root or intermediate certificate is not authorized to sign in this domain"
+	case TooManyIntermediates:
+		return "x509: too many intermediates for path length constraint"
+	case IncompatibleUsage:
+		return "x509: certificate specifies an incompatible key usage"
+	case NameMismatch:
+		return "x509: issuer name does not match subject from issuing certificate"
+	}
+	return "x509: unknown error"
+}
+
+// HostnameError results when the set of authorized names doesn't match the
+// requested name.
+type HostnameError struct {
+	Certificate *Certificate
+	Host        string
+}
+
+func (h HostnameError) Error() string {
+	c := h.Certificate
+
+	var valid string
+	if ip := net.ParseIP(h.Host); ip != nil {
+		// Trying to validate an IP
+		if len(c.IPAddresses) == 0 {
+			return "x509: cannot validate certificate for " + h.Host + " because it doesn't contain any IP SANs"
+		}
+		for _, san := range c.IPAddresses {
+			if len(valid) > 0 {
+				valid += ", "
+			}
+			valid += san.String()
+		}
+	} else {
+		if len(c.DNSNames) > 0 {
+			valid = strings.Join(c.DNSNames, ", ")
+		} else {
+			valid = c.Subject.CommonName
+		}
+	}
+
+	if len(valid) == 0 {
+		return "x509: certificate is not valid for any names, but wanted to match " + h.Host
+	}
+	return "x509: certificate is valid for " + valid + ", not " + h.Host
+}
+
+// UnknownAuthorityError results when the certificate issuer is unknown
+type UnknownAuthorityError struct {
+	Cert *Certificate
+	// hintErr contains an error that may be helpful in determining why an
+	// authority wasn't found.
+	hintErr error
+	// hintCert contains a possible authority certificate that was rejected
+	// because of the error in hintErr.
+	hintCert *Certificate
+}
+
+func (e UnknownAuthorityError) Error() string {
+	s := "x509: certificate signed by unknown authority"
+	if e.hintErr != nil {
+		certName := e.hintCert.Subject.CommonName
+		if len(certName) == 0 {
+			if len(e.hintCert.Subject.Organization) > 0 {
+				certName = e.hintCert.Subject.Organization[0]
+			} else {
+				certName = "serial:" + e.hintCert.SerialNumber.String()
+			}
+		}
+		s += fmt.Sprintf(" (possibly because of %q while trying to verify candidate authority certificate %q)", e.hintErr, certName)
+	}
+	return s
+}
+
+// SystemRootsError results when we fail to load the system root certificates.
+type SystemRootsError struct {
+	Err error
+}
+
+func (se SystemRootsError) Error() string {
+	msg := "x509: failed to load system roots and no roots provided"
+	if se.Err != nil {
+		return msg + "; " + se.Err.Error()
+	}
+	return msg
+}
+
+// errNotParsed is returned when a certificate without ASN.1 contents is
+// verified. Platform-specific verification needs the ASN.1 contents.
+var errNotParsed = errors.New("x509: missing ASN.1 contents; use ParseCertificate")
+
+// VerifyOptions contains parameters for Certificate.Verify. It's a structure
+// because other PKIX verification APIs have ended up needing many options.
+type VerifyOptions struct {
+	DNSName       string
+	Intermediates *CertPool
+	Roots         *CertPool // if nil, the system roots are used
+	CurrentTime   time.Time // if zero, the current time is used
+	// KeyUsage specifies which Extended Key Usage values are acceptable.
+	// An empty list means ExtKeyUsageServerAuth. Key usage is considered a
+	// constraint down the chain which mirrors Windows CryptoAPI behavior,
+	// but not the spec. To accept any key usage, include ExtKeyUsageAny.
+	KeyUsages []ExtKeyUsage
+}
+
+const (
+	leafCertificate = iota
+	intermediateCertificate
+	rootCertificate
+)
+
+func matchNameConstraint(domain, constraint string) bool {
+	// The meaning of zero length constraints is not specified, but this
+	// code follows NSS and accepts them as valid for everything.
+	if len(constraint) == 0 {
+		return true
+	}
+
+	if len(domain) < len(constraint) {
+		return false
+	}
+
+	prefixLen := len(domain) - len(constraint)
+	if !strings.EqualFold(domain[prefixLen:], constraint) {
+		return false
+	}
+
+	if prefixLen == 0 {
+		return true
+	}
+
+	isSubdomain := domain[prefixLen-1] == '.'
+	constraintHasLeadingDot := constraint[0] == '.'
+	return isSubdomain != constraintHasLeadingDot
+}
+
+// isValid performs validity checks on the c.
+func (c *Certificate) isValid(certType int, currentChain []*Certificate, opts *VerifyOptions) error {
+	if len(currentChain) > 0 {
+		child := currentChain[len(currentChain)-1]
+		if !bytes.Equal(child.RawIssuer, c.RawSubject) {
+			return CertificateInvalidError{c, NameMismatch}
+		}
+	}
+	now := opts.CurrentTime
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if now.Before(c.NotBefore) || now.After(c.NotAfter) {
+		return CertificateInvalidError{c, Expired}
+	}
+	if len(c.PermittedDNSDomains) > 0 {
+		ok := false
+		for _, constraint := range c.PermittedDNSDomains {
+			ok = matchNameConstraint(opts.DNSName, constraint)
+			if ok {
+				break
+			}
+		}
+
+		if !ok {
+			return CertificateInvalidError{c, CANotAuthorizedForThisName}
+		}
+	}
+
+	// KeyUsage status flags are ignored. From Engineering Security, Peter
+	// Gutmann: A European government CA marked its signing certificates as
+	// being valid for encryption only, but no-one noticed. Another
+	// European CA marked its signature keys as not being valid for
+	// signatures. A different CA marked its own trusted root certificate
+	// as being invalid for certificate signing. Another national CA
+	// distributed a certificate to be used to encrypt data for the
+	// country’s tax authority that was marked as only being usable for
+	// digital signatures but not for encryption. Yet another CA reversed
+	// the order of the bit flags in the keyUsage due to confusion over
+	// encoding endianness, essentially setting a random keyUsage in
+	// certificates that it issued. Another CA created a self-invalidating
+	// certificate by adding a certificate policy statement stipulating
+	// that the certificate had to be used strictly as specified in the
+	// keyUsage, and a keyUsage containing a flag indicating that the RSA
+	// encryption key could only be used for Diffie-Hellman key agreement.
+
+	if certType == intermediateCertificate && (!c.BasicConstraintsValid || !c.IsCA) {
+		return CertificateInvalidError{c, NotAuthorizedToSign}
+	}
+
+	if c.BasicConstraintsValid && c.MaxPathLen >= 0 {
+		numIntermediates := len(currentChain) - 1
+		if numIntermediates > c.MaxPathLen {
+			return CertificateInvalidError{c, TooManyIntermediates}
+		}
+	}
+
+	return nil
+}
+
+// Verify attempts to verify c by building one or more chains from c to a
+// certificate in opts.Roots, using certificates in opts.Intermediates if
+// needed. If successful, it returns one or more chains where the first
+// element of the chain is c and the last element is from opts.Roots.
+//
+// If opts.Roots is nil and system roots are unavailable the returned error
+// will be of type SystemRootsError.
+//
+// WARNING: this doesn't do any revocation checking.
+func (c *Certificate) Verify(opts VerifyOptions) (chains [][]*Certificate, err error) {
+	// Platform-specific verification needs the ASN.1 contents so
+	// this makes the behavior consistent across platforms.
+	if len(c.Raw) == 0 {
+		return nil, errNotParsed
+	}
+	if opts.Intermediates != nil {
+		for _, intermediate := range opts.Intermediates.certs {
+			if len(intermediate.Raw) == 0 {
+				return nil, errNotParsed
+			}
+		}
+	}
+
+	// Use Windows's own verification and chain building.
+	if opts.Roots == nil && runtime.GOOS == "windows" {
+		return c.systemVerify(&opts)
+	}
+
+	if len(c.UnhandledCriticalExtensions) > 0 {
+		return nil, UnhandledCriticalExtension{}
+	}
+
+	if opts.Roots == nil {
+		opts.Roots = systemRootsPool()
+		if opts.Roots == nil {
+			return nil, SystemRootsError{systemRootsErr}
+		}
+	}
+
+	err = c.isValid(leafCertificate, nil, &opts)
+	if err != nil {
+		return
+	}
+
+	if len(opts.DNSName) > 0 {
+		err = c.VerifyHostname(opts.DNSName)
+		if err != nil {
+			return
+		}
+	}
+
+	var candidateChains [][]*Certificate
+	if opts.Roots.contains(c) {
+		candidateChains = append(candidateChains, []*Certificate{c})
+	} else {
+		if candidateChains, err = c.buildChains(make(map[int][][]*Certificate), []*Certificate{c}, &opts); err != nil {
+			return nil, err
+		}
+	}
+
+	keyUsages := opts.KeyUsages
+	if len(keyUsages) == 0 {
+		keyUsages = []ExtKeyUsage{ExtKeyUsageServerAuth}
+	}
+
+	// If any key usage is acceptable then we're done.
+	for _, usage := range keyUsages {
+		if usage == ExtKeyUsageAny {
+			chains = candidateChains
+			return
+		}
+	}
+
+	for _, candidate := range candidateChains {
+		if checkChainForKeyUsage(candidate, keyUsages) {
+			chains = append(chains, candidate)
+		}
+	}
+
+	if len(chains) == 0 {
+		err = CertificateInvalidError{c, IncompatibleUsage}
+	}
+
+	return
+}
+
+func appendToFreshChain(chain []*Certificate, cert *Certificate) []*Certificate {
+	n := make([]*Certificate, len(chain)+1)
+	copy(n, chain)
+	n[len(chain)] = cert
+	return n
+}
+
+func (c *Certificate) buildChains(cache map[int][][]*Certificate, currentChain []*Certificate, opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	possibleRoots, failedRoot, rootErr := opts.Roots.findVerifiedParents(c)
+nextRoot:
+	for _, rootNum := range possibleRoots {
+		root := opts.Roots.certs[rootNum]
+
+		for _, cert := range currentChain {
+			if cert.Equal(root) {
+				continue nextRoot
+			}
+		}
+
+		err = root.isValid(rootCertificate, currentChain, opts)
+		if err != nil {
+			continue
+		}
+		chains = append(chains, appendToFreshChain(currentChain, root))
+	}
+
+	possibleIntermediates, failedIntermediate, intermediateErr := opts.Intermediates.findVerifiedParents(c)
+nextIntermediate:
+	for _, intermediateNum := range possibleIntermediates {
+		intermediate := opts.Intermediates.certs[intermediateNum]
+		for _, cert := range currentChain {
+			if cert.Equal(intermediate) {
+				continue nextIntermediate
+			}
+		}
+		err = intermediate.isValid(intermediateCertificate, currentChain, opts)
+		if err != nil {
+			continue
+		}
+		var childChains [][]*Certificate
+		childChains, ok := cache[intermediateNum]
+		if !ok {
+			childChains, err = intermediate.buildChains(cache, appendToFreshChain(currentChain, intermediate), opts)
+			cache[intermediateNum] = childChains
+		}
+		chains = append(chains, childChains...)
+	}
+
+	if len(chains) > 0 {
+		err = nil
+	}
+
+	if len(chains) == 0 && err == nil {
+		hintErr := rootErr
+		hintCert := failedRoot
+		if hintErr == nil {
+			hintErr = intermediateErr
+			hintCert = failedIntermediate
+		}
+		err = UnknownAuthorityError{c, hintErr, hintCert}
+	}
+
+	return
+}
+
+func matchHostnames(pattern, host string) bool {
+	host = strings.TrimSuffix(host, ".")
+	pattern = strings.TrimSuffix(pattern, ".")
+
+	if len(pattern) == 0 || len(host) == 0 {
+		return false
+	}
+
+	patternParts := strings.Split(pattern, ".")
+	hostParts := strings.Split(host, ".")
+
+	if len(patternParts) != len(hostParts) {
+		return false
+	}
+
+	for i, patternPart := range patternParts {
+		if i == 0 && patternPart == "*" {
+			continue
+		}
+		if patternPart != hostParts[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// toLowerCaseASCII returns a lower-case version of in. See RFC 6125 6.4.1. We use
+// an explicitly ASCII function to avoid any sharp corners resulting from
+// performing Unicode operations on DNS labels.
+func toLowerCaseASCII(in string) string {
+	// If the string is already lower-case then there's nothing to do.
+	isAlreadyLowerCase := true
+	for _, c := range in {
+		if c == utf8.RuneError {
+			// If we get a UTF-8 error then there might be
+			// upper-case ASCII bytes in the invalid sequence.
+			isAlreadyLowerCase = false
+			break
+		}
+		if 'A' <= c && c <= 'Z' {
+			isAlreadyLowerCase = false
+			break
+		}
+	}
+
+	if isAlreadyLowerCase {
+		return in
+	}
+
+	out := []byte(in)
+	for i, c := range out {
+		if 'A' <= c && c <= 'Z' {
+			out[i] += 'a' - 'A'
+		}
+	}
+	return string(out)
+}
+
+// VerifyHostname returns nil if c is a valid certificate for the named host.
+// Otherwise it returns an error describing the mismatch.
+func (c *Certificate) VerifyHostname(h string) error {
+	// IP addresses may be written in [ ].
+	candidateIP := h
+	if len(h) >= 3 && h[0] == '[' && h[len(h)-1] == ']' {
+		candidateIP = h[1 : len(h)-1]
+	}
+	if ip := net.ParseIP(candidateIP); ip != nil {
+		// We only match IP addresses against IP SANs.
+		// https://tools.ietf.org/html/rfc6125#appendix-B.2
+		for _, candidate := range c.IPAddresses {
+			if ip.Equal(candidate) {
+				return nil
+			}
+		}
+		return HostnameError{c, candidateIP}
+	}
+
+	lowered := toLowerCaseASCII(h)
+
+	if len(c.DNSNames) > 0 {
+		for _, match := range c.DNSNames {
+			if matchHostnames(toLowerCaseASCII(match), lowered) {
+				return nil
+			}
+		}
+		// If Subject Alt Name is given, we ignore the common name.
+	} else if matchHostnames(toLowerCaseASCII(c.Subject.CommonName), lowered) {
+		return nil
+	}
+
+	return HostnameError{c, h}
+}
+
+func checkChainForKeyUsage(chain []*Certificate, keyUsages []ExtKeyUsage) bool {
+	usages := make([]ExtKeyUsage, len(keyUsages))
+	copy(usages, keyUsages)
+
+	if len(chain) == 0 {
+		return false
+	}
+
+	usagesRemaining := len(usages)
+
+	// We walk down the list and cross out any usages that aren't supported
+	// by each certificate. If we cross out all the usages, then the chain
+	// is unacceptable.
+
+NextCert:
+	for i := len(chain) - 1; i >= 0; i-- {
+		cert := chain[i]
+		if len(cert.ExtKeyUsage) == 0 && len(cert.UnknownExtKeyUsage) == 0 {
+			// The certificate doesn't have any extended key usage specified.
+			continue
+		}
+
+		for _, usage := range cert.ExtKeyUsage {
+			if usage == ExtKeyUsageAny {
+				// The certificate is explicitly good for any usage.
+				continue NextCert
+			}
+		}
+
+		const invalidUsage ExtKeyUsage = -1
+
+	NextRequestedUsage:
+		for i, requestedUsage := range usages {
+			if requestedUsage == invalidUsage {
+				continue
+			}
+
+			for _, usage := range cert.ExtKeyUsage {
+				if requestedUsage == usage {
+					continue NextRequestedUsage
+				} else if requestedUsage == ExtKeyUsageServerAuth &&
+					(usage == ExtKeyUsageNetscapeServerGatedCrypto ||
+						usage == ExtKeyUsageMicrosoftServerGatedCrypto) {
+					// In order to support COMODO
+					// certificate chains, we have to
+					// accept Netscape or Microsoft SGC
+					// usages as equal to ServerAuth.
+					continue NextRequestedUsage
+				}
+			}
+
+			usages[i] = invalidUsage
+			usagesRemaining--
+			if usagesRemaining == 0 {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/tjfoc/gmsm/x509/x509.go
+++ b/vendor/github.com/tjfoc/gmsm/x509/x509.go
@@ -1,0 +1,2464 @@
+/*
+Copyright Suzhou Tongji Fintech Research Institute 2017 All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// crypto/x509 add sm2 support
+package x509
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/md5"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"math/big"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/tjfoc/gmsm/sm2"
+
+	"github.com/tjfoc/gmsm/sm3"
+	"golang.org/x/crypto/ripemd160"
+	"golang.org/x/crypto/sha3"
+)
+
+// pkixPublicKey reflects a PKIX public key structure. See SubjectPublicKeyInfo
+// in RFC 3280.
+type pkixPublicKey struct {
+	Algo      pkix.AlgorithmIdentifier
+	BitString asn1.BitString
+}
+
+// ParsePKIXPublicKey parses a DER encoded public key. These values are
+// typically found in PEM blocks with "BEGIN PUBLIC KEY".
+//
+// Supported key types include RSA, DSA, and ECDSA. Unknown key
+// types result in an error.
+//
+// On success, pub will be of type *rsa.PublicKey, *dsa.PublicKey,
+// or *ecdsa.PublicKey.
+func ParsePKIXPublicKey(derBytes []byte) (pub interface{}, err error) {
+	var pki publicKeyInfo
+
+	if rest, err := asn1.Unmarshal(derBytes, &pki); err != nil {
+		return nil, err
+	} else if len(rest) != 0 {
+		return nil, errors.New("x509: trailing data after ASN.1 of public-key")
+	}
+	algo := getPublicKeyAlgorithmFromOID(pki.Algorithm.Algorithm)
+	if algo == UnknownPublicKeyAlgorithm {
+		return nil, errors.New("x509: unknown public key algorithm")
+	}
+	return parsePublicKey(algo, &pki)
+}
+
+func marshalPublicKey(pub interface{}) (publicKeyBytes []byte, publicKeyAlgorithm pkix.AlgorithmIdentifier, err error) {
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		publicKeyBytes, err = asn1.Marshal(rsaPublicKey{
+			N: pub.N,
+			E: pub.E,
+		})
+		if err != nil {
+			return nil, pkix.AlgorithmIdentifier{}, err
+		}
+		publicKeyAlgorithm.Algorithm = oidPublicKeyRSA
+		// This is a NULL parameters value which is required by
+		// https://tools.ietf.org/html/rfc3279#section-2.3.1.
+		publicKeyAlgorithm.Parameters = asn1.RawValue{
+			Tag: 5,
+		}
+	case *ecdsa.PublicKey:
+		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+		oid, ok := oidFromNamedCurve(pub.Curve)
+		if !ok {
+			return nil, pkix.AlgorithmIdentifier{}, errors.New("x509: unsupported elliptic curve")
+		}
+		publicKeyAlgorithm.Algorithm = oidPublicKeyECDSA
+		var paramBytes []byte
+		paramBytes, err = asn1.Marshal(oid)
+		if err != nil {
+			return
+		}
+		publicKeyAlgorithm.Parameters.FullBytes = paramBytes
+	case *sm2.PublicKey:
+		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+		oid, ok := oidFromNamedCurve(pub.Curve)
+		if !ok {
+			return nil, pkix.AlgorithmIdentifier{}, errors.New("x509: unsupported SM2 curve")
+		}
+		publicKeyAlgorithm.Algorithm = oidPublicKeyECDSA
+		var paramBytes []byte
+		paramBytes, err = asn1.Marshal(oid)
+		if err != nil {
+			return
+		}
+		publicKeyAlgorithm.Parameters.FullBytes = paramBytes
+	default:
+		return nil, pkix.AlgorithmIdentifier{}, errors.New("x509: only RSA and ECDSA(SM2) public keys supported")
+	}
+
+	return publicKeyBytes, publicKeyAlgorithm, nil
+}
+
+// MarshalPKIXPublicKey serialises a public key to DER-encoded PKIX format.
+func MarshalPKIXPublicKey(pub interface{}) ([]byte, error) {
+	var publicKeyBytes []byte
+	var publicKeyAlgorithm pkix.AlgorithmIdentifier
+	var err error
+
+	if publicKeyBytes, publicKeyAlgorithm, err = marshalPublicKey(pub); err != nil {
+		return nil, err
+	}
+
+	pkix := pkixPublicKey{
+		Algo: publicKeyAlgorithm,
+		BitString: asn1.BitString{
+			Bytes:     publicKeyBytes,
+			BitLength: 8 * len(publicKeyBytes),
+		},
+	}
+
+	ret, _ := asn1.Marshal(pkix)
+	return ret, nil
+}
+
+// These structures reflect the ASN.1 structure of X.509 certificates.:
+
+type certificate struct {
+	Raw                asn1.RawContent
+	TBSCertificate     tbsCertificate
+	SignatureAlgorithm pkix.AlgorithmIdentifier
+	SignatureValue     asn1.BitString
+}
+
+type tbsCertificate struct {
+	Raw                asn1.RawContent
+	Version            int `asn1:"optional,explicit,default:0,tag:0"`
+	SerialNumber       *big.Int
+	SignatureAlgorithm pkix.AlgorithmIdentifier
+	Issuer             asn1.RawValue
+	Validity           validity
+	Subject            asn1.RawValue
+	PublicKey          publicKeyInfo
+	UniqueId           asn1.BitString   `asn1:"optional,tag:1"`
+	SubjectUniqueId    asn1.BitString   `asn1:"optional,tag:2"`
+	Extensions         []pkix.Extension `asn1:"optional,explicit,tag:3"`
+}
+
+type dsaAlgorithmParameters struct {
+	P, Q, G *big.Int
+}
+
+type dsaSignature struct {
+	R, S *big.Int
+}
+
+type ecdsaSignature dsaSignature
+
+type validity struct {
+	NotBefore, NotAfter time.Time
+}
+
+type publicKeyInfo struct {
+	Raw       asn1.RawContent
+	Algorithm pkix.AlgorithmIdentifier
+	PublicKey asn1.BitString
+}
+
+// RFC 5280,  4.2.1.1
+type authKeyId struct {
+	Id []byte `asn1:"optional,tag:0"`
+}
+
+type SignatureAlgorithm int
+
+type Hash uint
+
+func init() {
+	RegisterHash(MD4, nil)
+	RegisterHash(MD5, md5.New)
+	RegisterHash(SHA1, sha1.New)
+	RegisterHash(SHA224, sha256.New224)
+	RegisterHash(SHA256, sha256.New)
+	RegisterHash(SHA384, sha512.New384)
+	RegisterHash(SHA512, sha512.New)
+	RegisterHash(MD5SHA1, nil)
+	RegisterHash(RIPEMD160, ripemd160.New)
+	RegisterHash(SHA3_224, sha3.New224)
+	RegisterHash(SHA3_256, sha3.New256)
+	RegisterHash(SHA3_384, sha3.New384)
+	RegisterHash(SHA3_512, sha3.New512)
+	RegisterHash(SHA512_224, sha512.New512_224)
+	RegisterHash(SHA512_256, sha512.New512_256)
+	RegisterHash(SM3, sm3.New)
+}
+
+// HashFunc simply returns the value of h so that Hash implements SignerOpts.
+func (h Hash) HashFunc() crypto.Hash {
+	return crypto.Hash(h)
+}
+
+const (
+	MD4        Hash = 1 + iota // import golang.org/x/crypto/md4
+	MD5                        // import crypto/md5
+	SHA1                       // import crypto/sha1
+	SHA224                     // import crypto/sha256
+	SHA256                     // import crypto/sha256
+	SHA384                     // import crypto/sha512
+	SHA512                     // import crypto/sha512
+	MD5SHA1                    // no implementation; MD5+SHA1 used for TLS RSA
+	RIPEMD160                  // import golang.org/x/crypto/ripemd160
+	SHA3_224                   // import golang.org/x/crypto/sha3
+	SHA3_256                   // import golang.org/x/crypto/sha3
+	SHA3_384                   // import golang.org/x/crypto/sha3
+	SHA3_512                   // import golang.org/x/crypto/sha3
+	SHA512_224                 // import crypto/sha512
+	SHA512_256                 // import crypto/sha512
+	SM3
+	maxHash
+)
+
+var digestSizes = []uint8{
+	MD4:        16,
+	MD5:        16,
+	SHA1:       20,
+	SHA224:     28,
+	SHA256:     32,
+	SHA384:     48,
+	SHA512:     64,
+	SHA512_224: 28,
+	SHA512_256: 32,
+	SHA3_224:   28,
+	SHA3_256:   32,
+	SHA3_384:   48,
+	SHA3_512:   64,
+	MD5SHA1:    36,
+	RIPEMD160:  20,
+	SM3:        32,
+}
+
+// Size returns the length, in bytes, of a digest resulting from the given hash
+// function. It doesn't require that the hash function in question be linked
+// into the program.
+func (h Hash) Size() int {
+	if h > 0 && h < maxHash {
+		return int(digestSizes[h])
+	}
+	panic("crypto: Size of unknown hash function")
+}
+
+var hashes = make([]func() hash.Hash, maxHash)
+
+// New returns a new hash.Hash calculating the given hash function. New panics
+// if the hash function is not linked into the binary.
+func (h Hash) New() hash.Hash {
+	if h > 0 && h < maxHash {
+		f := hashes[h]
+		if f != nil {
+			return f()
+		}
+	}
+	panic("crypto: requested hash function #" + strconv.Itoa(int(h)) + " is unavailable")
+}
+
+// Available reports whether the given hash function is linked into the binary.
+func (h Hash) Available() bool {
+	return h < maxHash && hashes[h] != nil
+}
+
+// RegisterHash registers a function that returns a new instance of the given
+// hash function. This is intended to be called from the init function in
+// packages that implement hash functions.
+func RegisterHash(h Hash, f func() hash.Hash) {
+	if h >= maxHash {
+		panic("crypto: RegisterHash of unknown hash function")
+	}
+	hashes[h] = f
+}
+
+const (
+	UnknownSignatureAlgorithm SignatureAlgorithm = iota
+	MD2WithRSA
+	MD5WithRSA
+	//	SM3WithRSA reserve
+	SHA1WithRSA
+	SHA256WithRSA
+	SHA384WithRSA
+	SHA512WithRSA
+	DSAWithSHA1
+	DSAWithSHA256
+	ECDSAWithSHA1
+	ECDSAWithSHA256
+	ECDSAWithSHA384
+	ECDSAWithSHA512
+	SHA256WithRSAPSS
+	SHA384WithRSAPSS
+	SHA512WithRSAPSS
+	SM2WithSM3
+	SM2WithSHA1
+	SM2WithSHA256
+)
+
+func (algo SignatureAlgorithm) isRSAPSS() bool {
+	switch algo {
+	case SHA256WithRSAPSS, SHA384WithRSAPSS, SHA512WithRSAPSS:
+		return true
+	default:
+		return false
+	}
+}
+
+var algoName = [...]string{
+	MD2WithRSA:  "MD2-RSA",
+	MD5WithRSA:  "MD5-RSA",
+	SHA1WithRSA: "SHA1-RSA",
+	//	SM3WithRSA:       "SM3-RSA", reserve
+	SHA256WithRSA:    "SHA256-RSA",
+	SHA384WithRSA:    "SHA384-RSA",
+	SHA512WithRSA:    "SHA512-RSA",
+	SHA256WithRSAPSS: "SHA256-RSAPSS",
+	SHA384WithRSAPSS: "SHA384-RSAPSS",
+	SHA512WithRSAPSS: "SHA512-RSAPSS",
+	DSAWithSHA1:      "DSA-SHA1",
+	DSAWithSHA256:    "DSA-SHA256",
+	ECDSAWithSHA1:    "ECDSA-SHA1",
+	ECDSAWithSHA256:  "ECDSA-SHA256",
+	ECDSAWithSHA384:  "ECDSA-SHA384",
+	ECDSAWithSHA512:  "ECDSA-SHA512",
+	SM2WithSM3:       "SM2-SM3",
+	SM2WithSHA1:      "SM2-SHA1",
+	SM2WithSHA256:    "SM2-SHA256",
+}
+
+func (algo SignatureAlgorithm) String() string {
+	if 0 < algo && int(algo) < len(algoName) {
+		return algoName[algo]
+	}
+	return strconv.Itoa(int(algo))
+}
+
+type PublicKeyAlgorithm int
+
+const (
+	UnknownPublicKeyAlgorithm PublicKeyAlgorithm = iota
+	RSA
+	DSA
+	ECDSA
+	SM2
+)
+
+// OIDs for signature algorithms
+//
+// pkcs-1 OBJECT IDENTIFIER ::= {
+//    iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 1 }
+//
+//
+// RFC 3279 2.2.1 RSA Signature Algorithms
+//
+// md2WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 2 }
+//
+// md5WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 4 }
+//
+// sha-1WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 5 }
+//
+// dsaWithSha1 OBJECT IDENTIFIER ::= {
+//    iso(1) member-body(2) us(840) x9-57(10040) x9cm(4) 3 }
+//
+// RFC 3279 2.2.3 ECDSA Signature Algorithm
+//
+// ecdsa-with-SHA1 OBJECT IDENTIFIER ::= {
+// 	  iso(1) member-body(2) us(840) ansi-x962(10045)
+//    signatures(4) ecdsa-with-SHA1(1)}
+//
+//
+// RFC 4055 5 PKCS #1 Version 1.5
+//
+// sha256WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 11 }
+//
+// sha384WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 12 }
+//
+// sha512WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 13 }
+//
+//
+// RFC 5758 3.1 DSA Signature Algorithms
+//
+// dsaWithSha256 OBJECT IDENTIFIER ::= {
+//    joint-iso-ccitt(2) country(16) us(840) organization(1) gov(101)
+//    csor(3) algorithms(4) id-dsa-with-sha2(3) 2}
+//
+// RFC 5758 3.2 ECDSA Signature Algorithm
+//
+// ecdsa-with-SHA256 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 2 }
+//
+// ecdsa-with-SHA384 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 3 }
+//
+// ecdsa-with-SHA512 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 4 }
+
+var (
+	oidSignatureMD2WithRSA      = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 2}
+	oidSignatureMD5WithRSA      = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 4}
+	oidSignatureSHA1WithRSA     = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 5}
+	oidSignatureSHA256WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}
+	oidSignatureSHA384WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 12}
+	oidSignatureSHA512WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 13}
+	oidSignatureRSAPSS          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 10}
+	oidSignatureDSAWithSHA1     = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 3}
+	oidSignatureDSAWithSHA256   = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 3, 2}
+	oidSignatureECDSAWithSHA1   = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 1}
+	oidSignatureECDSAWithSHA256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
+	oidSignatureECDSAWithSHA384 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 3}
+	oidSignatureECDSAWithSHA512 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 4}
+	oidSignatureSM2WithSM3      = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 501}
+	oidSignatureSM2WithSHA1     = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 502}
+	oidSignatureSM2WithSHA256   = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 503}
+	//	oidSignatureSM3WithRSA      = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 504}
+
+	oidSM3     = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 401, 1}
+	oidSHA256  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
+	oidSHA384  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
+	oidSHA512  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
+	oidHashSM3 = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 401}
+
+	oidMGF1 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 8}
+
+	// oidISOSignatureSHA1WithRSA means the same as oidSignatureSHA1WithRSA
+	// but it's specified by ISO. Microsoft's makecert.exe has been known
+	// to produce certificates with this OID.
+	oidISOSignatureSHA1WithRSA = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 29}
+)
+
+var signatureAlgorithmDetails = []struct {
+	algo       SignatureAlgorithm
+	oid        asn1.ObjectIdentifier
+	pubKeyAlgo PublicKeyAlgorithm
+	hash       Hash
+}{
+	{MD2WithRSA, oidSignatureMD2WithRSA, RSA, Hash(0) /* no value for MD2 */},
+	{MD5WithRSA, oidSignatureMD5WithRSA, RSA, MD5},
+	{SHA1WithRSA, oidSignatureSHA1WithRSA, RSA, SHA1},
+	{SHA1WithRSA, oidISOSignatureSHA1WithRSA, RSA, SHA1},
+	{SHA256WithRSA, oidSignatureSHA256WithRSA, RSA, SHA256},
+	{SHA384WithRSA, oidSignatureSHA384WithRSA, RSA, SHA384},
+	{SHA512WithRSA, oidSignatureSHA512WithRSA, RSA, SHA512},
+	{SHA256WithRSAPSS, oidSignatureRSAPSS, RSA, SHA256},
+	{SHA384WithRSAPSS, oidSignatureRSAPSS, RSA, SHA384},
+	{SHA512WithRSAPSS, oidSignatureRSAPSS, RSA, SHA512},
+	{DSAWithSHA1, oidSignatureDSAWithSHA1, DSA, SHA1},
+	{DSAWithSHA256, oidSignatureDSAWithSHA256, DSA, SHA256},
+	{ECDSAWithSHA1, oidSignatureECDSAWithSHA1, ECDSA, SHA1},
+	{ECDSAWithSHA256, oidSignatureECDSAWithSHA256, ECDSA, SHA256},
+	{ECDSAWithSHA384, oidSignatureECDSAWithSHA384, ECDSA, SHA384},
+	{ECDSAWithSHA512, oidSignatureECDSAWithSHA512, ECDSA, SHA512},
+	{SM2WithSM3, oidSignatureSM2WithSM3, ECDSA, SM3},
+	{SM2WithSHA1, oidSignatureSM2WithSHA1, ECDSA, SHA1},
+	{SM2WithSHA256, oidSignatureSM2WithSHA256, ECDSA, SHA256},
+	//	{SM3WithRSA, oidSignatureSM3WithRSA, RSA, SM3},
+}
+
+// pssParameters reflects the parameters in an AlgorithmIdentifier that
+// specifies RSA PSS. See https://tools.ietf.org/html/rfc3447#appendix-A.2.3
+type pssParameters struct {
+	// The following three fields are not marked as
+	// optional because the default values specify SHA-1,
+	// which is no longer suitable for use in signatures.
+	Hash         pkix.AlgorithmIdentifier `asn1:"explicit,tag:0"`
+	MGF          pkix.AlgorithmIdentifier `asn1:"explicit,tag:1"`
+	SaltLength   int                      `asn1:"explicit,tag:2"`
+	TrailerField int                      `asn1:"optional,explicit,tag:3,default:1"`
+}
+
+// rsaPSSParameters returns an asn1.RawValue suitable for use as the Parameters
+// in an AlgorithmIdentifier that specifies RSA PSS.
+func rsaPSSParameters(hashFunc Hash) asn1.RawValue {
+	var hashOID asn1.ObjectIdentifier
+
+	switch hashFunc {
+	case SHA256:
+		hashOID = oidSHA256
+	case SHA384:
+		hashOID = oidSHA384
+	case SHA512:
+		hashOID = oidSHA512
+	}
+
+	params := pssParameters{
+		Hash: pkix.AlgorithmIdentifier{
+			Algorithm: hashOID,
+			Parameters: asn1.RawValue{
+				Tag: 5, /* ASN.1 NULL */
+			},
+		},
+		MGF: pkix.AlgorithmIdentifier{
+			Algorithm: oidMGF1,
+		},
+		SaltLength:   hashFunc.Size(),
+		TrailerField: 1,
+	}
+
+	mgf1Params := pkix.AlgorithmIdentifier{
+		Algorithm: hashOID,
+		Parameters: asn1.RawValue{
+			Tag: 5, /* ASN.1 NULL */
+		},
+	}
+
+	var err error
+	params.MGF.Parameters.FullBytes, err = asn1.Marshal(mgf1Params)
+	if err != nil {
+		panic(err)
+	}
+
+	serialized, err := asn1.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+
+	return asn1.RawValue{FullBytes: serialized}
+}
+
+func getSignatureAlgorithmFromAI(ai pkix.AlgorithmIdentifier) SignatureAlgorithm {
+	if !ai.Algorithm.Equal(oidSignatureRSAPSS) {
+		for _, details := range signatureAlgorithmDetails {
+			if ai.Algorithm.Equal(details.oid) {
+				return details.algo
+			}
+		}
+		return UnknownSignatureAlgorithm
+	}
+
+	// RSA PSS is special because it encodes important parameters
+	// in the Parameters.
+
+	var params pssParameters
+	if _, err := asn1.Unmarshal(ai.Parameters.FullBytes, &params); err != nil {
+		return UnknownSignatureAlgorithm
+	}
+
+	var mgf1HashFunc pkix.AlgorithmIdentifier
+	if _, err := asn1.Unmarshal(params.MGF.Parameters.FullBytes, &mgf1HashFunc); err != nil {
+		return UnknownSignatureAlgorithm
+	}
+
+	// PSS is greatly overburdened with options. This code forces
+	// them into three buckets by requiring that the MGF1 hash
+	// function always match the message hash function (as
+	// recommended in
+	// https://tools.ietf.org/html/rfc3447#section-8.1), that the
+	// salt length matches the hash length, and that the trailer
+	// field has the default value.
+	asn1NULL := []byte{0x05, 0x00}
+	if !bytes.Equal(params.Hash.Parameters.FullBytes, asn1NULL) ||
+		!params.MGF.Algorithm.Equal(oidMGF1) ||
+		!mgf1HashFunc.Algorithm.Equal(params.Hash.Algorithm) ||
+		!bytes.Equal(mgf1HashFunc.Parameters.FullBytes, asn1NULL) ||
+		params.TrailerField != 1 {
+		return UnknownSignatureAlgorithm
+	}
+
+	switch {
+	case params.Hash.Algorithm.Equal(oidSHA256) && params.SaltLength == 32:
+		return SHA256WithRSAPSS
+	case params.Hash.Algorithm.Equal(oidSHA384) && params.SaltLength == 48:
+		return SHA384WithRSAPSS
+	case params.Hash.Algorithm.Equal(oidSHA512) && params.SaltLength == 64:
+		return SHA512WithRSAPSS
+	}
+
+	return UnknownSignatureAlgorithm
+}
+
+// RFC 3279, 2.3 Public Key Algorithms
+//
+// pkcs-1 OBJECT IDENTIFIER ::== { iso(1) member-body(2) us(840)
+//    rsadsi(113549) pkcs(1) 1 }
+//
+// rsaEncryption OBJECT IDENTIFIER ::== { pkcs1-1 1 }
+//
+// id-dsa OBJECT IDENTIFIER ::== { iso(1) member-body(2) us(840)
+//    x9-57(10040) x9cm(4) 1 }
+//
+// RFC 5480, 2.1.1 Unrestricted Algorithm Identifier and Parameters
+//
+// id-ecPublicKey OBJECT IDENTIFIER ::= {
+//       iso(1) member-body(2) us(840) ansi-X9-62(10045) keyType(2) 1 }
+var (
+	oidPublicKeyRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	oidPublicKeyDSA   = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 1}
+	oidPublicKeyECDSA = asn1.ObjectIdentifier{1, 2, 840, 10045, 2, 1}
+)
+
+func getPublicKeyAlgorithmFromOID(oid asn1.ObjectIdentifier) PublicKeyAlgorithm {
+	switch {
+	case oid.Equal(oidPublicKeyRSA):
+		return RSA
+	case oid.Equal(oidPublicKeyDSA):
+		return DSA
+	case oid.Equal(oidPublicKeyECDSA):
+		return ECDSA
+	}
+	return UnknownPublicKeyAlgorithm
+}
+
+// RFC 5480, 2.1.1.1. Named Curve
+//
+// secp224r1 OBJECT IDENTIFIER ::= {
+//   iso(1) identified-organization(3) certicom(132) curve(0) 33 }
+//
+// secp256r1 OBJECT IDENTIFIER ::= {
+//   iso(1) member-body(2) us(840) ansi-X9-62(10045) curves(3)
+//   prime(1) 7 }
+//
+// secp384r1 OBJECT IDENTIFIER ::= {
+//   iso(1) identified-organization(3) certicom(132) curve(0) 34 }
+//
+// secp521r1 OBJECT IDENTIFIER ::= {
+//   iso(1) identified-organization(3) certicom(132) curve(0) 35 }
+//
+// NB: secp256r1 is equivalent to prime256v1
+var (
+	oidNamedCurveP224    = asn1.ObjectIdentifier{1, 3, 132, 0, 33}
+	oidNamedCurveP256    = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
+	oidNamedCurveP384    = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
+	oidNamedCurveP521    = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
+	oidNamedCurveP256SM2 = asn1.ObjectIdentifier{1, 2, 156, 10197, 1, 301} // I get the SM2 ID through parsing the pem file generated by gmssl
+)
+
+func namedCurveFromOID(oid asn1.ObjectIdentifier) elliptic.Curve {
+	switch {
+	case oid.Equal(oidNamedCurveP224):
+		return elliptic.P224()
+	case oid.Equal(oidNamedCurveP256):
+		return elliptic.P256()
+	case oid.Equal(oidNamedCurveP384):
+		return elliptic.P384()
+	case oid.Equal(oidNamedCurveP521):
+		return elliptic.P521()
+	case oid.Equal(oidNamedCurveP256SM2):
+		return sm2.P256Sm2()
+	}
+	return nil
+}
+
+func oidFromNamedCurve(curve elliptic.Curve) (asn1.ObjectIdentifier, bool) {
+	switch curve {
+	case elliptic.P224():
+		return oidNamedCurveP224, true
+	case elliptic.P256():
+		return oidNamedCurveP256, true
+	case elliptic.P384():
+		return oidNamedCurveP384, true
+	case elliptic.P521():
+		return oidNamedCurveP521, true
+	case sm2.P256Sm2():
+		return oidNamedCurveP256SM2, true
+	}
+	return nil, false
+}
+
+// KeyUsage represents the set of actions that are valid for a given key. It's
+// a bitmap of the KeyUsage* constants.
+type KeyUsage int
+
+const (
+	KeyUsageDigitalSignature KeyUsage = 1 << iota
+	KeyUsageContentCommitment
+	KeyUsageKeyEncipherment
+	KeyUsageDataEncipherment
+	KeyUsageKeyAgreement
+	KeyUsageCertSign
+	KeyUsageCRLSign
+	KeyUsageEncipherOnly
+	KeyUsageDecipherOnly
+)
+
+// RFC 5280, 4.2.1.12  Extended Key Usage
+//
+// anyExtendedKeyUsage OBJECT IDENTIFIER ::= { id-ce-extKeyUsage 0 }
+//
+// id-kp OBJECT IDENTIFIER ::= { id-pkix 3 }
+//
+// id-kp-serverAuth             OBJECT IDENTIFIER ::= { id-kp 1 }
+// id-kp-clientAuth             OBJECT IDENTIFIER ::= { id-kp 2 }
+// id-kp-codeSigning            OBJECT IDENTIFIER ::= { id-kp 3 }
+// id-kp-emailProtection        OBJECT IDENTIFIER ::= { id-kp 4 }
+// id-kp-timeStamping           OBJECT IDENTIFIER ::= { id-kp 8 }
+// id-kp-OCSPSigning            OBJECT IDENTIFIER ::= { id-kp 9 }
+var (
+	oidExtKeyUsageAny                        = asn1.ObjectIdentifier{2, 5, 29, 37, 0}
+	oidExtKeyUsageServerAuth                 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1}
+	oidExtKeyUsageClientAuth                 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 2}
+	oidExtKeyUsageCodeSigning                = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 3}
+	oidExtKeyUsageEmailProtection            = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 4}
+	oidExtKeyUsageIPSECEndSystem             = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 5}
+	oidExtKeyUsageIPSECTunnel                = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 6}
+	oidExtKeyUsageIPSECUser                  = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 7}
+	oidExtKeyUsageTimeStamping               = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8}
+	oidExtKeyUsageOCSPSigning                = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 9}
+	oidExtKeyUsageMicrosoftServerGatedCrypto = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 10, 3, 3}
+	oidExtKeyUsageNetscapeServerGatedCrypto  = asn1.ObjectIdentifier{2, 16, 840, 1, 113730, 4, 1}
+)
+
+// ExtKeyUsage represents an extended set of actions that are valid for a given key.
+// Each of the ExtKeyUsage* constants define a unique action.
+type ExtKeyUsage int
+
+const (
+	ExtKeyUsageAny ExtKeyUsage = iota
+	ExtKeyUsageServerAuth
+	ExtKeyUsageClientAuth
+	ExtKeyUsageCodeSigning
+	ExtKeyUsageEmailProtection
+	ExtKeyUsageIPSECEndSystem
+	ExtKeyUsageIPSECTunnel
+	ExtKeyUsageIPSECUser
+	ExtKeyUsageTimeStamping
+	ExtKeyUsageOCSPSigning
+	ExtKeyUsageMicrosoftServerGatedCrypto
+	ExtKeyUsageNetscapeServerGatedCrypto
+)
+
+// extKeyUsageOIDs contains the mapping between an ExtKeyUsage and its OID.
+var extKeyUsageOIDs = []struct {
+	extKeyUsage ExtKeyUsage
+	oid         asn1.ObjectIdentifier
+}{
+	{ExtKeyUsageAny, oidExtKeyUsageAny},
+	{ExtKeyUsageServerAuth, oidExtKeyUsageServerAuth},
+	{ExtKeyUsageClientAuth, oidExtKeyUsageClientAuth},
+	{ExtKeyUsageCodeSigning, oidExtKeyUsageCodeSigning},
+	{ExtKeyUsageEmailProtection, oidExtKeyUsageEmailProtection},
+	{ExtKeyUsageIPSECEndSystem, oidExtKeyUsageIPSECEndSystem},
+	{ExtKeyUsageIPSECTunnel, oidExtKeyUsageIPSECTunnel},
+	{ExtKeyUsageIPSECUser, oidExtKeyUsageIPSECUser},
+	{ExtKeyUsageTimeStamping, oidExtKeyUsageTimeStamping},
+	{ExtKeyUsageOCSPSigning, oidExtKeyUsageOCSPSigning},
+	{ExtKeyUsageMicrosoftServerGatedCrypto, oidExtKeyUsageMicrosoftServerGatedCrypto},
+	{ExtKeyUsageNetscapeServerGatedCrypto, oidExtKeyUsageNetscapeServerGatedCrypto},
+}
+
+func extKeyUsageFromOID(oid asn1.ObjectIdentifier) (eku ExtKeyUsage, ok bool) {
+	for _, pair := range extKeyUsageOIDs {
+		if oid.Equal(pair.oid) {
+			return pair.extKeyUsage, true
+		}
+	}
+	return
+}
+
+func oidFromExtKeyUsage(eku ExtKeyUsage) (oid asn1.ObjectIdentifier, ok bool) {
+	for _, pair := range extKeyUsageOIDs {
+		if eku == pair.extKeyUsage {
+			return pair.oid, true
+		}
+	}
+	return
+}
+
+// A Certificate represents an X.509 certificate.
+type Certificate struct {
+	Raw                     []byte // Complete ASN.1 DER content (certificate, signature algorithm and signature).
+	RawTBSCertificate       []byte // Certificate part of raw ASN.1 DER content.
+	RawSubjectPublicKeyInfo []byte // DER encoded SubjectPublicKeyInfo.
+	RawSubject              []byte // DER encoded Subject
+	RawIssuer               []byte // DER encoded Issuer
+
+	Signature          []byte
+	SignatureAlgorithm SignatureAlgorithm
+
+	PublicKeyAlgorithm PublicKeyAlgorithm
+	PublicKey          interface{}
+
+	Version             int
+	SerialNumber        *big.Int
+	Issuer              pkix.Name
+	Subject             pkix.Name
+	NotBefore, NotAfter time.Time // Validity bounds.
+	KeyUsage            KeyUsage
+
+	// Extensions contains raw X.509 extensions. When parsing certificates,
+	// this can be used to extract non-critical extensions that are not
+	// parsed by this package. When marshaling certificates, the Extensions
+	// field is ignored, see ExtraExtensions.
+	Extensions []pkix.Extension
+
+	// ExtraExtensions contains extensions to be copied, raw, into any
+	// marshaled certificates. Values override any extensions that would
+	// otherwise be produced based on the other fields. The ExtraExtensions
+	// field is not populated when parsing certificates, see Extensions.
+	ExtraExtensions []pkix.Extension
+
+	// UnhandledCriticalExtensions contains a list of extension IDs that
+	// were not (fully) processed when parsing. Verify will fail if this
+	// slice is non-empty, unless verification is delegated to an OS
+	// library which understands all the critical extensions.
+	//
+	// Users can access these extensions using Extensions and can remove
+	// elements from this slice if they believe that they have been
+	// handled.
+	UnhandledCriticalExtensions []asn1.ObjectIdentifier
+
+	ExtKeyUsage        []ExtKeyUsage           // Sequence of extended key usages.
+	UnknownExtKeyUsage []asn1.ObjectIdentifier // Encountered extended key usages unknown to this package.
+
+	BasicConstraintsValid bool // if true then the next two fields are valid.
+	IsCA                  bool
+	MaxPathLen            int
+	// MaxPathLenZero indicates that BasicConstraintsValid==true and
+	// MaxPathLen==0 should be interpreted as an actual maximum path length
+	// of zero. Otherwise, that combination is interpreted as MaxPathLen
+	// not being set.
+	MaxPathLenZero bool
+
+	SubjectKeyId   []byte
+	AuthorityKeyId []byte
+
+	// RFC 5280, 4.2.2.1 (Authority Information Access)
+	OCSPServer            []string
+	IssuingCertificateURL []string
+
+	// Subject Alternate Name values
+	DNSNames       []string
+	EmailAddresses []string
+	IPAddresses    []net.IP
+
+	// Name constraints
+	PermittedDNSDomainsCritical bool // if true then the name constraints are marked critical.
+	PermittedDNSDomains         []string
+
+	// CRL Distribution Points
+	CRLDistributionPoints []string
+
+	PolicyIdentifiers []asn1.ObjectIdentifier
+}
+
+// ErrUnsupportedAlgorithm results from attempting to perform an operation that
+// involves algorithms that are not currently implemented.
+var ErrUnsupportedAlgorithm = errors.New("x509: cannot verify signature: algorithm unimplemented")
+
+// An InsecureAlgorithmError
+type InsecureAlgorithmError SignatureAlgorithm
+
+func (e InsecureAlgorithmError) Error() string {
+	return fmt.Sprintf("x509: cannot verify signature: insecure algorithm %v", SignatureAlgorithm(e))
+}
+
+// ConstraintViolationError results when a requested usage is not permitted by
+// a certificate. For example: checking a signature when the public key isn't a
+// certificate signing key.
+type ConstraintViolationError struct{}
+
+func (ConstraintViolationError) Error() string {
+	return "x509: invalid signature: parent certificate cannot sign this kind of certificate"
+}
+
+func (c *Certificate) Equal(other *Certificate) bool {
+	return bytes.Equal(c.Raw, other.Raw)
+}
+
+// Entrust have a broken root certificate (CN=Entrust.net Certification
+// Authority (2048)) which isn't marked as a CA certificate and is thus invalid
+// according to PKIX.
+// We recognise this certificate by its SubjectPublicKeyInfo and exempt it
+// from the Basic Constraints requirement.
+// See http://www.entrust.net/knowledge-base/technote.cfm?tn=7869
+//
+// TODO(agl): remove this hack once their reissued root is sufficiently
+// widespread.
+var entrustBrokenSPKI = []byte{
+	0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09,
+	0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
+	0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00,
+	0x30, 0x82, 0x01, 0x0a, 0x02, 0x82, 0x01, 0x01,
+	0x00, 0x97, 0xa3, 0x2d, 0x3c, 0x9e, 0xde, 0x05,
+	0xda, 0x13, 0xc2, 0x11, 0x8d, 0x9d, 0x8e, 0xe3,
+	0x7f, 0xc7, 0x4b, 0x7e, 0x5a, 0x9f, 0xb3, 0xff,
+	0x62, 0xab, 0x73, 0xc8, 0x28, 0x6b, 0xba, 0x10,
+	0x64, 0x82, 0x87, 0x13, 0xcd, 0x57, 0x18, 0xff,
+	0x28, 0xce, 0xc0, 0xe6, 0x0e, 0x06, 0x91, 0x50,
+	0x29, 0x83, 0xd1, 0xf2, 0xc3, 0x2a, 0xdb, 0xd8,
+	0xdb, 0x4e, 0x04, 0xcc, 0x00, 0xeb, 0x8b, 0xb6,
+	0x96, 0xdc, 0xbc, 0xaa, 0xfa, 0x52, 0x77, 0x04,
+	0xc1, 0xdb, 0x19, 0xe4, 0xae, 0x9c, 0xfd, 0x3c,
+	0x8b, 0x03, 0xef, 0x4d, 0xbc, 0x1a, 0x03, 0x65,
+	0xf9, 0xc1, 0xb1, 0x3f, 0x72, 0x86, 0xf2, 0x38,
+	0xaa, 0x19, 0xae, 0x10, 0x88, 0x78, 0x28, 0xda,
+	0x75, 0xc3, 0x3d, 0x02, 0x82, 0x02, 0x9c, 0xb9,
+	0xc1, 0x65, 0x77, 0x76, 0x24, 0x4c, 0x98, 0xf7,
+	0x6d, 0x31, 0x38, 0xfb, 0xdb, 0xfe, 0xdb, 0x37,
+	0x02, 0x76, 0xa1, 0x18, 0x97, 0xa6, 0xcc, 0xde,
+	0x20, 0x09, 0x49, 0x36, 0x24, 0x69, 0x42, 0xf6,
+	0xe4, 0x37, 0x62, 0xf1, 0x59, 0x6d, 0xa9, 0x3c,
+	0xed, 0x34, 0x9c, 0xa3, 0x8e, 0xdb, 0xdc, 0x3a,
+	0xd7, 0xf7, 0x0a, 0x6f, 0xef, 0x2e, 0xd8, 0xd5,
+	0x93, 0x5a, 0x7a, 0xed, 0x08, 0x49, 0x68, 0xe2,
+	0x41, 0xe3, 0x5a, 0x90, 0xc1, 0x86, 0x55, 0xfc,
+	0x51, 0x43, 0x9d, 0xe0, 0xb2, 0xc4, 0x67, 0xb4,
+	0xcb, 0x32, 0x31, 0x25, 0xf0, 0x54, 0x9f, 0x4b,
+	0xd1, 0x6f, 0xdb, 0xd4, 0xdd, 0xfc, 0xaf, 0x5e,
+	0x6c, 0x78, 0x90, 0x95, 0xde, 0xca, 0x3a, 0x48,
+	0xb9, 0x79, 0x3c, 0x9b, 0x19, 0xd6, 0x75, 0x05,
+	0xa0, 0xf9, 0x88, 0xd7, 0xc1, 0xe8, 0xa5, 0x09,
+	0xe4, 0x1a, 0x15, 0xdc, 0x87, 0x23, 0xaa, 0xb2,
+	0x75, 0x8c, 0x63, 0x25, 0x87, 0xd8, 0xf8, 0x3d,
+	0xa6, 0xc2, 0xcc, 0x66, 0xff, 0xa5, 0x66, 0x68,
+	0x55, 0x02, 0x03, 0x01, 0x00, 0x01,
+}
+
+// CheckSignatureFrom verifies that the signature on c is a valid signature
+// from parent.
+func (c *Certificate) CheckSignatureFrom(parent *Certificate) error {
+	// RFC 5280, 4.2.1.9:
+	// "If the basic constraints extension is not present in a version 3
+	// certificate, or the extension is present but the cA boolean is not
+	// asserted, then the certified public key MUST NOT be used to verify
+	// certificate signatures."
+	// (except for Entrust, see comment above entrustBrokenSPKI)
+	if (parent.Version == 3 && !parent.BasicConstraintsValid ||
+		parent.BasicConstraintsValid && !parent.IsCA) &&
+		!bytes.Equal(c.RawSubjectPublicKeyInfo, entrustBrokenSPKI) {
+		return ConstraintViolationError{}
+	}
+
+	if parent.KeyUsage != 0 && parent.KeyUsage&KeyUsageCertSign == 0 {
+		return ConstraintViolationError{}
+	}
+
+	if parent.PublicKeyAlgorithm == UnknownPublicKeyAlgorithm {
+		return ErrUnsupportedAlgorithm
+	}
+
+	// TODO(agl): don't ignore the path length constraint.
+
+	return parent.CheckSignature(c.SignatureAlgorithm, c.RawTBSCertificate, c.Signature)
+}
+
+// CheckSignature verifies that signature is a valid signature over signed from
+// c's public key.
+func (c *Certificate) CheckSignature(algo SignatureAlgorithm, signed, signature []byte) error {
+	return checkSignature(algo, signed, signature, c.PublicKey)
+}
+
+// CheckSignature verifies that signature is a valid signature over signed from
+// a crypto.PublicKey.
+func checkSignature(algo SignatureAlgorithm, signed, signature []byte, publicKey crypto.PublicKey) (err error) {
+	var hashType Hash
+	switch algo {
+	case SHA1WithRSA, DSAWithSHA1, ECDSAWithSHA1, SM2WithSHA1:
+		hashType = SHA1
+	case SHA256WithRSA, SHA256WithRSAPSS, DSAWithSHA256, ECDSAWithSHA256, SM2WithSHA256:
+		hashType = SHA256
+	case SHA384WithRSA, SHA384WithRSAPSS, ECDSAWithSHA384:
+		hashType = SHA384
+	case SHA512WithRSA, SHA512WithRSAPSS, ECDSAWithSHA512:
+		hashType = SHA512
+	case MD2WithRSA, MD5WithRSA:
+		return InsecureAlgorithmError(algo)
+	case SM2WithSM3: // SM3WithRSA reserve
+		hashType = SM3
+	default:
+		return ErrUnsupportedAlgorithm
+	}
+
+	if !hashType.Available() {
+		return ErrUnsupportedAlgorithm
+	}
+	fnHash := func() []byte {
+		h := hashType.New()
+		h.Write(signed)
+		return h.Sum(nil)
+	}
+	switch pub := publicKey.(type) {
+	case *rsa.PublicKey:
+		if algo.isRSAPSS() {
+			return rsa.VerifyPSS(pub, crypto.Hash(hashType), fnHash(), signature, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+		} else {
+			return rsa.VerifyPKCS1v15(pub, crypto.Hash(hashType), fnHash(), signature)
+		}
+	case *dsa.PublicKey:
+		dsaSig := new(dsaSignature)
+		if rest, err := asn1.Unmarshal(signature, dsaSig); err != nil {
+			return err
+		} else if len(rest) != 0 {
+			return errors.New("x509: trailing data after DSA signature")
+		}
+		if dsaSig.R.Sign() <= 0 || dsaSig.S.Sign() <= 0 {
+			return errors.New("x509: DSA signature contained zero or negative values")
+		}
+		if !dsa.Verify(pub, fnHash(), dsaSig.R, dsaSig.S) {
+			return errors.New("x509: DSA verification failure")
+		}
+		return
+	case *ecdsa.PublicKey:
+		ecdsaSig := new(ecdsaSignature)
+		if rest, err := asn1.Unmarshal(signature, ecdsaSig); err != nil {
+			return err
+		} else if len(rest) != 0 {
+			return errors.New("x509: trailing data after ECDSA signature")
+		}
+		if ecdsaSig.R.Sign() <= 0 || ecdsaSig.S.Sign() <= 0 {
+			return errors.New("x509: ECDSA signature contained zero or negative values")
+		}
+		switch pub.Curve {
+		case sm2.P256Sm2():
+			sm2pub := &sm2.PublicKey{
+				Curve: pub.Curve,
+				X:     pub.X,
+				Y:     pub.Y,
+			}
+			if !sm2.Sm2Verify(sm2pub, signed, nil, ecdsaSig.R, ecdsaSig.S) {
+				return errors.New("x509: SM2 verification failure")
+			}
+		default:
+			if !ecdsa.Verify(pub, fnHash(), ecdsaSig.R, ecdsaSig.S) {
+				return errors.New("x509: ECDSA verification failure")
+			}
+		}
+		return
+	}
+	return ErrUnsupportedAlgorithm
+}
+
+// CheckCRLSignature checks that the signature in crl is from c.
+func (c *Certificate) CheckCRLSignature(crl *pkix.CertificateList) error {
+	algo := getSignatureAlgorithmFromAI(crl.SignatureAlgorithm)
+	return c.CheckSignature(algo, crl.TBSCertList.Raw, crl.SignatureValue.RightAlign())
+}
+
+type UnhandledCriticalExtension struct{}
+
+func (h UnhandledCriticalExtension) Error() string {
+	return "x509: unhandled critical extension"
+}
+
+type basicConstraints struct {
+	IsCA       bool `asn1:"optional"`
+	MaxPathLen int  `asn1:"optional,default:-1"`
+}
+
+// RFC 5280 4.2.1.4
+type policyInformation struct {
+	Policy asn1.ObjectIdentifier
+	// policyQualifiers omitted
+}
+
+// RFC 5280, 4.2.1.10
+type nameConstraints struct {
+	Permitted []generalSubtree `asn1:"optional,tag:0"`
+	Excluded  []generalSubtree `asn1:"optional,tag:1"`
+}
+
+type generalSubtree struct {
+	Name string `asn1:"tag:2,optional,ia5"`
+}
+
+// RFC 5280, 4.2.2.1
+type authorityInfoAccess struct {
+	Method   asn1.ObjectIdentifier
+	Location asn1.RawValue
+}
+
+// RFC 5280, 4.2.1.14
+type distributionPoint struct {
+	DistributionPoint distributionPointName `asn1:"optional,tag:0"`
+	Reason            asn1.BitString        `asn1:"optional,tag:1"`
+	CRLIssuer         asn1.RawValue         `asn1:"optional,tag:2"`
+}
+
+type distributionPointName struct {
+	FullName     asn1.RawValue    `asn1:"optional,tag:0"`
+	RelativeName pkix.RDNSequence `asn1:"optional,tag:1"`
+}
+
+// asn1Null is the ASN.1 encoding of a NULL value.
+var asn1Null = []byte{5, 0}
+
+func parsePublicKey(algo PublicKeyAlgorithm, keyData *publicKeyInfo) (interface{}, error) {
+	asn1Data := keyData.PublicKey.RightAlign()
+	switch algo {
+	case RSA:
+		// RSA public keys must have a NULL in the parameters
+		// (https://tools.ietf.org/html/rfc3279#section-2.3.1).
+		if !bytes.Equal(keyData.Algorithm.Parameters.FullBytes, asn1Null) {
+			return nil, errors.New("x509: RSA key missing NULL parameters")
+		}
+
+		p := new(rsaPublicKey)
+		rest, err := asn1.Unmarshal(asn1Data, p)
+		if err != nil {
+			return nil, err
+		}
+		if len(rest) != 0 {
+			return nil, errors.New("x509: trailing data after RSA public key")
+		}
+
+		if p.N.Sign() <= 0 {
+			return nil, errors.New("x509: RSA modulus is not a positive number")
+		}
+		if p.E <= 0 {
+			return nil, errors.New("x509: RSA public exponent is not a positive number")
+		}
+
+		pub := &rsa.PublicKey{
+			E: p.E,
+			N: p.N,
+		}
+		return pub, nil
+	case DSA:
+		var p *big.Int
+		rest, err := asn1.Unmarshal(asn1Data, &p)
+		if err != nil {
+			return nil, err
+		}
+		if len(rest) != 0 {
+			return nil, errors.New("x509: trailing data after DSA public key")
+		}
+		paramsData := keyData.Algorithm.Parameters.FullBytes
+		params := new(dsaAlgorithmParameters)
+		rest, err = asn1.Unmarshal(paramsData, params)
+		if err != nil {
+			return nil, err
+		}
+		if len(rest) != 0 {
+			return nil, errors.New("x509: trailing data after DSA parameters")
+		}
+		if p.Sign() <= 0 || params.P.Sign() <= 0 || params.Q.Sign() <= 0 || params.G.Sign() <= 0 {
+			return nil, errors.New("x509: zero or negative DSA parameter")
+		}
+		pub := &dsa.PublicKey{
+			Parameters: dsa.Parameters{
+				P: params.P,
+				Q: params.Q,
+				G: params.G,
+			},
+			Y: p,
+		}
+		return pub, nil
+	case ECDSA:
+		paramsData := keyData.Algorithm.Parameters.FullBytes
+		namedCurveOID := new(asn1.ObjectIdentifier)
+		rest, err := asn1.Unmarshal(paramsData, namedCurveOID)
+		if err != nil {
+			return nil, err
+		}
+		if len(rest) != 0 {
+			return nil, errors.New("x509: trailing data after ECDSA parameters")
+		}
+		namedCurve := namedCurveFromOID(*namedCurveOID)
+		if namedCurve == nil {
+			return nil, errors.New("x509: unsupported elliptic curve")
+		}
+		x, y := elliptic.Unmarshal(namedCurve, asn1Data)
+		if x == nil {
+			return nil, errors.New("x509: failed to unmarshal elliptic curve point")
+		}
+		pub := &ecdsa.PublicKey{
+			Curve: namedCurve,
+			X:     x,
+			Y:     y,
+		}
+		return pub, nil
+	default:
+		return nil, nil
+	}
+}
+
+func parseSANExtension(value []byte) (dnsNames, emailAddresses []string, ipAddresses []net.IP, err error) {
+	// RFC 5280, 4.2.1.6
+
+	// SubjectAltName ::= GeneralNames
+	//
+	// GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+	//
+	// GeneralName ::= CHOICE {
+	//      otherName                       [0]     OtherName,
+	//      rfc822Name                      [1]     IA5String,
+	//      dNSName                         [2]     IA5String,
+	//      x400Address                     [3]     ORAddress,
+	//      directoryName                   [4]     Name,
+	//      ediPartyName                    [5]     EDIPartyName,
+	//      uniformResourceIdentifier       [6]     IA5String,
+	//      iPAddress                       [7]     OCTET STRING,
+	//      registeredID                    [8]     OBJECT IDENTIFIER }
+	var seq asn1.RawValue
+	var rest []byte
+	if rest, err = asn1.Unmarshal(value, &seq); err != nil {
+		return
+	} else if len(rest) != 0 {
+		err = errors.New("x509: trailing data after X.509 extension")
+		return
+	}
+	if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
+		err = asn1.StructuralError{Msg: "bad SAN sequence"}
+		return
+	}
+
+	rest = seq.Bytes
+	for len(rest) > 0 {
+		var v asn1.RawValue
+		rest, err = asn1.Unmarshal(rest, &v)
+		if err != nil {
+			return
+		}
+		switch v.Tag {
+		case 1:
+			emailAddresses = append(emailAddresses, string(v.Bytes))
+		case 2:
+			dnsNames = append(dnsNames, string(v.Bytes))
+		case 7:
+			switch len(v.Bytes) {
+			case net.IPv4len, net.IPv6len:
+				ipAddresses = append(ipAddresses, v.Bytes)
+			default:
+				err = errors.New("x509: certificate contained IP address of length " + strconv.Itoa(len(v.Bytes)))
+				return
+			}
+		}
+	}
+
+	return
+}
+
+func parseCertificate(in *certificate) (*Certificate, error) {
+	out := new(Certificate)
+	out.Raw = in.Raw
+	out.RawTBSCertificate = in.TBSCertificate.Raw
+	out.RawSubjectPublicKeyInfo = in.TBSCertificate.PublicKey.Raw
+	out.RawSubject = in.TBSCertificate.Subject.FullBytes
+	out.RawIssuer = in.TBSCertificate.Issuer.FullBytes
+
+	out.Signature = in.SignatureValue.RightAlign()
+	out.SignatureAlgorithm =
+		getSignatureAlgorithmFromAI(in.TBSCertificate.SignatureAlgorithm)
+
+	out.PublicKeyAlgorithm =
+		getPublicKeyAlgorithmFromOID(in.TBSCertificate.PublicKey.Algorithm.Algorithm)
+	var err error
+	out.PublicKey, err = parsePublicKey(out.PublicKeyAlgorithm, &in.TBSCertificate.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	out.Version = in.TBSCertificate.Version + 1
+	out.SerialNumber = in.TBSCertificate.SerialNumber
+
+	var issuer, subject pkix.RDNSequence
+	if rest, err := asn1.Unmarshal(in.TBSCertificate.Subject.FullBytes, &subject); err != nil {
+		return nil, err
+	} else if len(rest) != 0 {
+		return nil, errors.New("x509: trailing data after X.509 subject")
+	}
+	if rest, err := asn1.Unmarshal(in.TBSCertificate.Issuer.FullBytes, &issuer); err != nil {
+		return nil, err
+	} else if len(rest) != 0 {
+		return nil, errors.New("x509: trailing data after X.509 subject")
+	}
+
+	out.Issuer.FillFromRDNSequence(&issuer)
+	out.Subject.FillFromRDNSequence(&subject)
+
+	out.NotBefore = in.TBSCertificate.Validity.NotBefore
+	out.NotAfter = in.TBSCertificate.Validity.NotAfter
+
+	for _, e := range in.TBSCertificate.Extensions {
+		out.Extensions = append(out.Extensions, e)
+		unhandled := false
+
+		if len(e.Id) == 4 && e.Id[0] == 2 && e.Id[1] == 5 && e.Id[2] == 29 {
+			switch e.Id[3] {
+			case 15:
+				// RFC 5280, 4.2.1.3
+				var usageBits asn1.BitString
+				if rest, err := asn1.Unmarshal(e.Value, &usageBits); err != nil {
+					return nil, err
+				} else if len(rest) != 0 {
+					return nil, errors.New("x509: trailing data after X.509 KeyUsage")
+				}
+
+				var usage int
+				for i := 0; i < 9; i++ {
+					if usageBits.At(i) != 0 {
+						usage |= 1 << uint(i)
+					}
+				}
+				out.KeyUsage = KeyUsage(usage)
+
+			case 19:
+				// RFC 5280, 4.2.1.9
+				var constraints basicConstraints
+				if rest, err := asn1.Unmarshal(e.Value, &constraints); err != nil {
+					return nil, err
+				} else if len(rest) != 0 {
+					return nil, errors.New("x509: trailing data after X.509 BasicConstraints")
+				}
+
+				out.BasicConstraintsValid = true
+				out.IsCA = constraints.IsCA
+				out.MaxPathLen = constraints.MaxPathLen
+				out.MaxPathLenZero = out.MaxPathLen == 0
+
+			case 17:
+				out.DNSNames, out.EmailAddresses, out.IPAddresses, err = parseSANExtension(e.Value)
+				if err != nil {
+					return nil, err
+				}
+
+				if len(out.DNSNames) == 0 && len(out.EmailAddresses) == 0 && len(out.IPAddresses) == 0 {
+					// If we didn't parse anything then we do the critical check, below.
+					unhandled = true
+				}
+
+			case 30:
+				// RFC 5280, 4.2.1.10
+
+				// NameConstraints ::= SEQUENCE {
+				//      permittedSubtrees       [0]     GeneralSubtrees OPTIONAL,
+				//      excludedSubtrees        [1]     GeneralSubtrees OPTIONAL }
+				//
+				// GeneralSubtrees ::= SEQUENCE SIZE (1..MAX) OF GeneralSubtree
+				//
+				// GeneralSubtree ::= SEQUENCE {
+				//      base                    GeneralName,
+				//      minimum         [0]     BaseDistance DEFAULT 0,
+				//      maximum         [1]     BaseDistance OPTIONAL }
+				//
+				// BaseDistance ::= INTEGER (0..MAX)
+
+				var constraints nameConstraints
+				if rest, err := asn1.Unmarshal(e.Value, &constraints); err != nil {
+					return nil, err
+				} else if len(rest) != 0 {
+					return nil, errors.New("x509: trailing data after X.509 NameConstraints")
+				}
+
+				if len(constraints.Excluded) > 0 && e.Critical {
+					return out, UnhandledCriticalExtension{}
+				}
+
+				for _, subtree := range constraints.Permitted {
+					if len(subtree.Name) == 0 {
+						if e.Critical {
+							return out, UnhandledCriticalExtension{}
+						}
+						continue
+					}
+					out.PermittedDNSDomains = append(out.PermittedDNSDomains, subtree.Name)
+				}
+
+			case 31:
+				// RFC 5280, 4.2.1.13
+
+				// CRLDistributionPoints ::= SEQUENCE SIZE (1..MAX) OF DistributionPoint
+				//
+				// DistributionPoint ::= SEQUENCE {
+				//     distributionPoint       [0]     DistributionPointName OPTIONAL,
+				//     reasons                 [1]     ReasonFlags OPTIONAL,
+				//     cRLIssuer               [2]     GeneralNames OPTIONAL }
+				//
+				// DistributionPointName ::= CHOICE {
+				//     fullName                [0]     GeneralNames,
+				//     nameRelativeToCRLIssuer [1]     RelativeDistinguishedName }
+
+				var cdp []distributionPoint
+				if rest, err := asn1.Unmarshal(e.Value, &cdp); err != nil {
+					return nil, err
+				} else if len(rest) != 0 {
+					return nil, errors.New("x509: trailing data after X.509 CRL distribution point")
+				}
+
+				for _, dp := range cdp {
+					// Per RFC 5280, 4.2.1.13, one of distributionPoint or cRLIssuer may be empty.
+					if len(dp.DistributionPoint.FullName.Bytes) == 0 {
+						continue
+					}
+
+					var n asn1.RawValue
+					if _, err := asn1.Unmarshal(dp.DistributionPoint.FullName.Bytes, &n); err != nil {
+						return nil, err
+					}
+					// Trailing data after the fullName is
+					// allowed because other elements of
+					// the SEQUENCE can appear.
+
+					if n.Tag == 6 {
+						out.CRLDistributionPoints = append(out.CRLDistributionPoints, string(n.Bytes))
+					}
+				}
+
+			case 35:
+				// RFC 5280, 4.2.1.1
+				var a authKeyId
+				if rest, err := asn1.Unmarshal(e.Value, &a); err != nil {
+					return nil, err
+				} else if len(rest) != 0 {
+					return nil, errors.New("x509: trailing data after X.509 authority key-id")
+				}
+				out.AuthorityKeyId = a.Id
+
+			case 37:
+				// RFC 5280, 4.2.1.12.  Extended Key Usage
+
+				// id-ce-extKeyUsage OBJECT IDENTIFIER ::= { id-ce 37 }
+				//
+				// ExtKeyUsageSyntax ::= SEQUENCE SIZE (1..MAX) OF KeyPurposeId
+				//
+				// KeyPurposeId ::= OBJECT IDENTIFIER
+
+				var keyUsage []asn1.ObjectIdentifier
+				if rest, err := asn1.Unmarshal(e.Value, &keyUsage); err != nil {
+					return nil, err
+				} else if len(rest) != 0 {
+					return nil, errors.New("x509: trailing data after X.509 ExtendedKeyUsage")
+				}
+
+				for _, u := range keyUsage {
+					if extKeyUsage, ok := extKeyUsageFromOID(u); ok {
+						out.ExtKeyUsage = append(out.ExtKeyUsage, extKeyUsage)
+					} else {
+						out.UnknownExtKeyUsage = append(out.UnknownExtKeyUsage, u)
+					}
+				}
+
+			case 14:
+				// RFC 5280, 4.2.1.2
+				var keyid []byte
+				if rest, err := asn1.Unmarshal(e.Value, &keyid); err != nil {
+					return nil, err
+				} else if len(rest) != 0 {
+					return nil, errors.New("x509: trailing data after X.509 key-id")
+				}
+				out.SubjectKeyId = keyid
+
+			case 32:
+				// RFC 5280 4.2.1.4: Certificate Policies
+				var policies []policyInformation
+				if rest, err := asn1.Unmarshal(e.Value, &policies); err != nil {
+					return nil, err
+				} else if len(rest) != 0 {
+					return nil, errors.New("x509: trailing data after X.509 certificate policies")
+				}
+				out.PolicyIdentifiers = make([]asn1.ObjectIdentifier, len(policies))
+				for i, policy := range policies {
+					out.PolicyIdentifiers[i] = policy.Policy
+				}
+
+			default:
+				// Unknown extensions are recorded if critical.
+				unhandled = true
+			}
+		} else if e.Id.Equal(oidExtensionAuthorityInfoAccess) {
+			// RFC 5280 4.2.2.1: Authority Information Access
+			var aia []authorityInfoAccess
+			if rest, err := asn1.Unmarshal(e.Value, &aia); err != nil {
+				return nil, err
+			} else if len(rest) != 0 {
+				return nil, errors.New("x509: trailing data after X.509 authority information")
+			}
+
+			for _, v := range aia {
+				// GeneralName: uniformResourceIdentifier [6] IA5String
+				if v.Location.Tag != 6 {
+					continue
+				}
+				if v.Method.Equal(oidAuthorityInfoAccessOcsp) {
+					out.OCSPServer = append(out.OCSPServer, string(v.Location.Bytes))
+				} else if v.Method.Equal(oidAuthorityInfoAccessIssuers) {
+					out.IssuingCertificateURL = append(out.IssuingCertificateURL, string(v.Location.Bytes))
+				}
+			}
+		} else {
+			// Unknown extensions are recorded if critical.
+			unhandled = true
+		}
+
+		if e.Critical && unhandled {
+			out.UnhandledCriticalExtensions = append(out.UnhandledCriticalExtensions, e.Id)
+		}
+	}
+
+	return out, nil
+}
+
+// ParseCertificate parses a single certificate from the given ASN.1 DER data.
+func ParseCertificate(asn1Data []byte) (*Certificate, error) {
+	var cert certificate
+	rest, err := asn1.Unmarshal(asn1Data, &cert)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) > 0 {
+		return nil, asn1.SyntaxError{Msg: "trailing data"}
+	}
+
+	return parseCertificate(&cert)
+}
+
+// ParseCertificates parses one or more certificates from the given ASN.1 DER
+// data. The certificates must be concatenated with no intermediate padding.
+func ParseCertificates(asn1Data []byte) ([]*Certificate, error) {
+	var v []*certificate
+
+	for len(asn1Data) > 0 {
+		cert := new(certificate)
+		var err error
+		asn1Data, err = asn1.Unmarshal(asn1Data, cert)
+		if err != nil {
+			return nil, err
+		}
+		v = append(v, cert)
+	}
+
+	ret := make([]*Certificate, len(v))
+	for i, ci := range v {
+		cert, err := parseCertificate(ci)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = cert
+	}
+
+	return ret, nil
+}
+
+func reverseBitsInAByte(in byte) byte {
+	b1 := in>>4 | in<<4
+	b2 := b1>>2&0x33 | b1<<2&0xcc
+	b3 := b2>>1&0x55 | b2<<1&0xaa
+	return b3
+}
+
+// asn1BitLength returns the bit-length of bitString by considering the
+// most-significant bit in a byte to be the "first" bit. This convention
+// matches ASN.1, but differs from almost everything else.
+func asn1BitLength(bitString []byte) int {
+	bitLen := len(bitString) * 8
+
+	for i := range bitString {
+		b := bitString[len(bitString)-i-1]
+
+		for bit := uint(0); bit < 8; bit++ {
+			if (b>>bit)&1 == 1 {
+				return bitLen
+			}
+			bitLen--
+		}
+	}
+
+	return 0
+}
+
+var (
+	oidExtensionSubjectKeyId          = []int{2, 5, 29, 14}
+	oidExtensionKeyUsage              = []int{2, 5, 29, 15}
+	oidExtensionExtendedKeyUsage      = []int{2, 5, 29, 37}
+	oidExtensionAuthorityKeyId        = []int{2, 5, 29, 35}
+	oidExtensionBasicConstraints      = []int{2, 5, 29, 19}
+	oidExtensionSubjectAltName        = []int{2, 5, 29, 17}
+	oidExtensionCertificatePolicies   = []int{2, 5, 29, 32}
+	oidExtensionNameConstraints       = []int{2, 5, 29, 30}
+	oidExtensionCRLDistributionPoints = []int{2, 5, 29, 31}
+	oidExtensionAuthorityInfoAccess   = []int{1, 3, 6, 1, 5, 5, 7, 1, 1}
+)
+
+var (
+	oidAuthorityInfoAccessOcsp    = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 48, 1}
+	oidAuthorityInfoAccessIssuers = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 48, 2}
+)
+
+// oidNotInExtensions returns whether an extension with the given oid exists in
+// extensions.
+func oidInExtensions(oid asn1.ObjectIdentifier, extensions []pkix.Extension) bool {
+	for _, e := range extensions {
+		if e.Id.Equal(oid) {
+			return true
+		}
+	}
+	return false
+}
+
+// marshalSANs marshals a list of addresses into a the contents of an X.509
+// SubjectAlternativeName extension.
+func marshalSANs(dnsNames, emailAddresses []string, ipAddresses []net.IP) (derBytes []byte, err error) {
+	var rawValues []asn1.RawValue
+	for _, name := range dnsNames {
+		rawValues = append(rawValues, asn1.RawValue{Tag: 2, Class: 2, Bytes: []byte(name)})
+	}
+	for _, email := range emailAddresses {
+		rawValues = append(rawValues, asn1.RawValue{Tag: 1, Class: 2, Bytes: []byte(email)})
+	}
+	for _, rawIP := range ipAddresses {
+		// If possible, we always want to encode IPv4 addresses in 4 bytes.
+		ip := rawIP.To4()
+		if ip == nil {
+			ip = rawIP
+		}
+		rawValues = append(rawValues, asn1.RawValue{Tag: 7, Class: 2, Bytes: ip})
+	}
+	return asn1.Marshal(rawValues)
+}
+
+func buildExtensions(template *Certificate) (ret []pkix.Extension, err error) {
+	ret = make([]pkix.Extension, 10 /* maximum number of elements. */)
+	n := 0
+
+	if template.KeyUsage != 0 &&
+		!oidInExtensions(oidExtensionKeyUsage, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionKeyUsage
+		ret[n].Critical = true
+
+		var a [2]byte
+		a[0] = reverseBitsInAByte(byte(template.KeyUsage))
+		a[1] = reverseBitsInAByte(byte(template.KeyUsage >> 8))
+
+		l := 1
+		if a[1] != 0 {
+			l = 2
+		}
+
+		bitString := a[:l]
+		ret[n].Value, err = asn1.Marshal(asn1.BitString{Bytes: bitString, BitLength: asn1BitLength(bitString)})
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if (len(template.ExtKeyUsage) > 0 || len(template.UnknownExtKeyUsage) > 0) &&
+		!oidInExtensions(oidExtensionExtendedKeyUsage, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionExtendedKeyUsage
+
+		var oids []asn1.ObjectIdentifier
+		for _, u := range template.ExtKeyUsage {
+			if oid, ok := oidFromExtKeyUsage(u); ok {
+				oids = append(oids, oid)
+			} else {
+				panic("internal error")
+			}
+		}
+
+		oids = append(oids, template.UnknownExtKeyUsage...)
+
+		ret[n].Value, err = asn1.Marshal(oids)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if template.BasicConstraintsValid && !oidInExtensions(oidExtensionBasicConstraints, template.ExtraExtensions) {
+		// Leaving MaxPathLen as zero indicates that no maximum path
+		// length is desired, unless MaxPathLenZero is set. A value of
+		// -1 causes encoding/asn1 to omit the value as desired.
+		maxPathLen := template.MaxPathLen
+		if maxPathLen == 0 && !template.MaxPathLenZero {
+			maxPathLen = -1
+		}
+		ret[n].Id = oidExtensionBasicConstraints
+		ret[n].Value, err = asn1.Marshal(basicConstraints{template.IsCA, maxPathLen})
+		ret[n].Critical = true
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.SubjectKeyId) > 0 && !oidInExtensions(oidExtensionSubjectKeyId, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionSubjectKeyId
+		ret[n].Value, err = asn1.Marshal(template.SubjectKeyId)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.AuthorityKeyId) > 0 && !oidInExtensions(oidExtensionAuthorityKeyId, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionAuthorityKeyId
+		ret[n].Value, err = asn1.Marshal(authKeyId{template.AuthorityKeyId})
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if (len(template.OCSPServer) > 0 || len(template.IssuingCertificateURL) > 0) &&
+		!oidInExtensions(oidExtensionAuthorityInfoAccess, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionAuthorityInfoAccess
+		var aiaValues []authorityInfoAccess
+		for _, name := range template.OCSPServer {
+			aiaValues = append(aiaValues, authorityInfoAccess{
+				Method:   oidAuthorityInfoAccessOcsp,
+				Location: asn1.RawValue{Tag: 6, Class: 2, Bytes: []byte(name)},
+			})
+		}
+		for _, name := range template.IssuingCertificateURL {
+			aiaValues = append(aiaValues, authorityInfoAccess{
+				Method:   oidAuthorityInfoAccessIssuers,
+				Location: asn1.RawValue{Tag: 6, Class: 2, Bytes: []byte(name)},
+			})
+		}
+		ret[n].Value, err = asn1.Marshal(aiaValues)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if (len(template.DNSNames) > 0 || len(template.EmailAddresses) > 0 || len(template.IPAddresses) > 0) &&
+		!oidInExtensions(oidExtensionSubjectAltName, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionSubjectAltName
+		ret[n].Value, err = marshalSANs(template.DNSNames, template.EmailAddresses, template.IPAddresses)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.PolicyIdentifiers) > 0 &&
+		!oidInExtensions(oidExtensionCertificatePolicies, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionCertificatePolicies
+		policies := make([]policyInformation, len(template.PolicyIdentifiers))
+		for i, policy := range template.PolicyIdentifiers {
+			policies[i].Policy = policy
+		}
+		ret[n].Value, err = asn1.Marshal(policies)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.PermittedDNSDomains) > 0 &&
+		!oidInExtensions(oidExtensionNameConstraints, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionNameConstraints
+		ret[n].Critical = template.PermittedDNSDomainsCritical
+
+		var out nameConstraints
+		out.Permitted = make([]generalSubtree, len(template.PermittedDNSDomains))
+		for i, permitted := range template.PermittedDNSDomains {
+			out.Permitted[i] = generalSubtree{Name: permitted}
+		}
+		ret[n].Value, err = asn1.Marshal(out)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.CRLDistributionPoints) > 0 &&
+		!oidInExtensions(oidExtensionCRLDistributionPoints, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionCRLDistributionPoints
+
+		var crlDp []distributionPoint
+		for _, name := range template.CRLDistributionPoints {
+			rawFullName, _ := asn1.Marshal(asn1.RawValue{Tag: 6, Class: 2, Bytes: []byte(name)})
+
+			dp := distributionPoint{
+				DistributionPoint: distributionPointName{
+					FullName: asn1.RawValue{Tag: 0, Class: 2, IsCompound: true, Bytes: rawFullName},
+				},
+			}
+			crlDp = append(crlDp, dp)
+		}
+
+		ret[n].Value, err = asn1.Marshal(crlDp)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	// Adding another extension here? Remember to update the maximum number
+	// of elements in the make() at the top of the function.
+
+	return append(ret[:n], template.ExtraExtensions...), nil
+}
+
+func subjectBytes(cert *Certificate) ([]byte, error) {
+	if len(cert.RawSubject) > 0 {
+		return cert.RawSubject, nil
+	}
+
+	return asn1.Marshal(cert.Subject.ToRDNSequence())
+}
+
+// signingParamsForPublicKey returns the parameters to use for signing with
+// priv. If requestedSigAlgo is not zero then it overrides the default
+// signature algorithm.
+func signingParamsForPublicKey(pub interface{}, requestedSigAlgo SignatureAlgorithm) (hashFunc Hash, sigAlgo pkix.AlgorithmIdentifier, err error) {
+	var pubType PublicKeyAlgorithm
+
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		pubType = RSA
+		hashFunc = SHA256
+		sigAlgo.Algorithm = oidSignatureSHA256WithRSA
+		sigAlgo.Parameters = asn1.RawValue{
+			Tag: 5,
+		}
+
+	case *ecdsa.PublicKey:
+		pubType = ECDSA
+		switch pub.Curve {
+		case elliptic.P224(), elliptic.P256():
+			hashFunc = SHA256
+			sigAlgo.Algorithm = oidSignatureECDSAWithSHA256
+		case elliptic.P384():
+			hashFunc = SHA384
+			sigAlgo.Algorithm = oidSignatureECDSAWithSHA384
+		case elliptic.P521():
+			hashFunc = SHA512
+			sigAlgo.Algorithm = oidSignatureECDSAWithSHA512
+		default:
+			err = errors.New("x509: unknown elliptic curve")
+		}
+	case *sm2.PublicKey:
+		pubType = ECDSA
+		switch pub.Curve {
+		case sm2.P256Sm2():
+			hashFunc = SM3
+			sigAlgo.Algorithm = oidSignatureSM2WithSM3
+		default:
+			err = errors.New("x509: unknown SM2 curve")
+		}
+	default:
+		err = errors.New("x509: only RSA and ECDSA keys supported")
+	}
+
+	if err != nil {
+		return
+	}
+
+	if requestedSigAlgo == 0 {
+		return
+	}
+
+	found := false
+	for _, details := range signatureAlgorithmDetails {
+		if details.algo == requestedSigAlgo {
+			if details.pubKeyAlgo != pubType {
+				err = errors.New("x509: requested SignatureAlgorithm does not match private key type")
+				return
+			}
+			sigAlgo.Algorithm, hashFunc = details.oid, details.hash
+			if hashFunc == 0 {
+				err = errors.New("x509: cannot sign with hash function requested")
+				return
+			}
+			if requestedSigAlgo.isRSAPSS() {
+				sigAlgo.Parameters = rsaPSSParameters(hashFunc)
+			}
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		err = errors.New("x509: unknown SignatureAlgorithm")
+	}
+
+	return
+}
+
+// CreateCertificateToMem creates a new certificate based on a template. The
+// following members of template are used: SerialNumber, Subject, NotBefore,
+// NotAfter, KeyUsage, ExtKeyUsage, UnknownExtKeyUsage, BasicConstraintsValid,
+// IsCA, MaxPathLen, SubjectKeyId, DNSNames, PermittedDNSDomainsCritical,
+// PermittedDNSDomains, SignatureAlgorithm.
+//
+// The certificate is signed by parent. If parent is equal to template then the
+// certificate is self-signed. The parameter pub is the public key of the
+// signer and priv is the private key of the signer.
+//
+// The returned slice is the certificate in PEM encoding.
+//
+// All keys types that are implemented via crypto.Signer are supported (This
+// includes *rsa.PublicKey and *ecdsa.PublicKey.)
+
+// pemCRLPrefix is the magic string that indicates that we have a PEM encoded
+// CRL.
+var pemCRLPrefix = []byte("-----BEGIN X509 CRL")
+
+// pemType is the type of a PEM encoded CRL.
+var pemType = "X509 CRL"
+
+// ParseCRL parses a CRL from the given bytes. It's often the case that PEM
+// encoded CRLs will appear where they should be DER encoded, so this function
+// will transparently handle PEM encoding as long as there isn't any leading
+// garbage.
+func ParseCRL(crlBytes []byte) (*pkix.CertificateList, error) {
+	if bytes.HasPrefix(crlBytes, pemCRLPrefix) {
+		block, _ := pem.Decode(crlBytes)
+		if block != nil && block.Type == pemType {
+			crlBytes = block.Bytes
+		}
+	}
+	return ParseDERCRL(crlBytes)
+}
+
+// ParseDERCRL parses a DER encoded CRL from the given bytes.
+func ParseDERCRL(derBytes []byte) (*pkix.CertificateList, error) {
+	certList := new(pkix.CertificateList)
+	if rest, err := asn1.Unmarshal(derBytes, certList); err != nil {
+		return nil, err
+	} else if len(rest) != 0 {
+		return nil, errors.New("x509: trailing data after CRL")
+	}
+	return certList, nil
+}
+
+// CreateCRL returns a DER encoded CRL, signed by this Certificate, that
+// contains the given list of revoked certificates.
+func (c *Certificate) CreateCRL(rand io.Reader, priv interface{}, revokedCerts []pkix.RevokedCertificate, now, expiry time.Time) (crlBytes []byte, err error) {
+	key, ok := priv.(crypto.Signer)
+	if !ok {
+		return nil, errors.New("x509: certificate private key does not implement crypto.Signer")
+	}
+
+	hashFunc, signatureAlgorithm, err := signingParamsForPublicKey(key.Public(), 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Force revocation times to UTC per RFC 5280.
+	revokedCertsUTC := make([]pkix.RevokedCertificate, len(revokedCerts))
+	for i, rc := range revokedCerts {
+		rc.RevocationTime = rc.RevocationTime.UTC()
+		revokedCertsUTC[i] = rc
+	}
+
+	tbsCertList := pkix.TBSCertificateList{
+		Version:             1,
+		Signature:           signatureAlgorithm,
+		Issuer:              c.Subject.ToRDNSequence(),
+		ThisUpdate:          now.UTC(),
+		NextUpdate:          expiry.UTC(),
+		RevokedCertificates: revokedCertsUTC,
+	}
+
+	// Authority Key Id
+	if len(c.SubjectKeyId) > 0 {
+		var aki pkix.Extension
+		aki.Id = oidExtensionAuthorityKeyId
+		aki.Value, err = asn1.Marshal(authKeyId{Id: c.SubjectKeyId})
+		if err != nil {
+			return
+		}
+		tbsCertList.Extensions = append(tbsCertList.Extensions, aki)
+	}
+
+	tbsCertListContents, err := asn1.Marshal(tbsCertList)
+	if err != nil {
+		return
+	}
+
+	digest := tbsCertListContents
+	switch hashFunc {
+	case SM3:
+		break
+	default:
+		h := hashFunc.New()
+		h.Write(tbsCertListContents)
+		digest = h.Sum(nil)
+	}
+
+	var signature []byte
+	signature, err = key.Sign(rand, digest, hashFunc)
+	if err != nil {
+		return
+	}
+
+	return asn1.Marshal(pkix.CertificateList{
+		TBSCertList:        tbsCertList,
+		SignatureAlgorithm: signatureAlgorithm,
+		SignatureValue:     asn1.BitString{Bytes: signature, BitLength: len(signature) * 8},
+	})
+}
+
+// CertificateRequest represents a PKCS #10, certificate signature request.
+type CertificateRequest struct {
+	Raw                      []byte // Complete ASN.1 DER content (CSR, signature algorithm and signature).
+	RawTBSCertificateRequest []byte // Certificate request info part of raw ASN.1 DER content.
+	RawSubjectPublicKeyInfo  []byte // DER encoded SubjectPublicKeyInfo.
+	RawSubject               []byte // DER encoded Subject.
+
+	Version            int
+	Signature          []byte
+	SignatureAlgorithm SignatureAlgorithm
+
+	PublicKeyAlgorithm PublicKeyAlgorithm
+	PublicKey          interface{}
+
+	Subject pkix.Name
+
+	// Attributes is the dried husk of a bug and shouldn't be used.
+	Attributes []pkix.AttributeTypeAndValueSET
+
+	// Extensions contains raw X.509 extensions. When parsing CSRs, this
+	// can be used to extract extensions that are not parsed by this
+	// package.
+	Extensions []pkix.Extension
+
+	// ExtraExtensions contains extensions to be copied, raw, into any
+	// marshaled CSR. Values override any extensions that would otherwise
+	// be produced based on the other fields but are overridden by any
+	// extensions specified in Attributes.
+	//
+	// The ExtraExtensions field is not populated when parsing CSRs, see
+	// Extensions.
+	ExtraExtensions []pkix.Extension
+
+	// Subject Alternate Name values.
+	DNSNames       []string
+	EmailAddresses []string
+	IPAddresses    []net.IP
+}
+
+// These structures reflect the ASN.1 structure of X.509 certificate
+// signature requests (see RFC 2986):
+
+type tbsCertificateRequest struct {
+	Raw           asn1.RawContent
+	Version       int
+	Subject       asn1.RawValue
+	PublicKey     publicKeyInfo
+	RawAttributes []asn1.RawValue `asn1:"tag:0"`
+}
+
+type certificateRequest struct {
+	Raw                asn1.RawContent
+	TBSCSR             tbsCertificateRequest
+	SignatureAlgorithm pkix.AlgorithmIdentifier
+	SignatureValue     asn1.BitString
+}
+
+// oidExtensionRequest is a PKCS#9 OBJECT IDENTIFIER that indicates requested
+// extensions in a CSR.
+var oidExtensionRequest = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 14}
+
+// newRawAttributes converts AttributeTypeAndValueSETs from a template
+// CertificateRequest's Attributes into tbsCertificateRequest RawAttributes.
+func newRawAttributes(attributes []pkix.AttributeTypeAndValueSET) ([]asn1.RawValue, error) {
+	var rawAttributes []asn1.RawValue
+	b, err := asn1.Marshal(attributes)
+	if err != nil {
+		return nil, err
+	}
+	rest, err := asn1.Unmarshal(b, &rawAttributes)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) != 0 {
+		return nil, errors.New("x509: failed to unmarshal raw CSR Attributes")
+	}
+	return rawAttributes, nil
+}
+
+// parseRawAttributes Unmarshals RawAttributes intos AttributeTypeAndValueSETs.
+func parseRawAttributes(rawAttributes []asn1.RawValue) []pkix.AttributeTypeAndValueSET {
+	var attributes []pkix.AttributeTypeAndValueSET
+	for _, rawAttr := range rawAttributes {
+		var attr pkix.AttributeTypeAndValueSET
+		rest, err := asn1.Unmarshal(rawAttr.FullBytes, &attr)
+		// Ignore attributes that don't parse into pkix.AttributeTypeAndValueSET
+		// (i.e.: challengePassword or unstructuredName).
+		if err == nil && len(rest) == 0 {
+			attributes = append(attributes, attr)
+		}
+	}
+	return attributes
+}
+
+// parseCSRExtensions parses the attributes from a CSR and extracts any
+// requested extensions.
+func parseCSRExtensions(rawAttributes []asn1.RawValue) ([]pkix.Extension, error) {
+	// pkcs10Attribute reflects the Attribute structure from section 4.1 of
+	// https://tools.ietf.org/html/rfc2986.
+	type pkcs10Attribute struct {
+		Id     asn1.ObjectIdentifier
+		Values []asn1.RawValue `asn1:"set"`
+	}
+
+	var ret []pkix.Extension
+	for _, rawAttr := range rawAttributes {
+		var attr pkcs10Attribute
+		if rest, err := asn1.Unmarshal(rawAttr.FullBytes, &attr); err != nil || len(rest) != 0 || len(attr.Values) == 0 {
+			// Ignore attributes that don't parse.
+			continue
+		}
+
+		if !attr.Id.Equal(oidExtensionRequest) {
+			continue
+		}
+
+		var extensions []pkix.Extension
+		if _, err := asn1.Unmarshal(attr.Values[0].FullBytes, &extensions); err != nil {
+			return nil, err
+		}
+		ret = append(ret, extensions...)
+	}
+
+	return ret, nil
+}
+
+// CreateCertificateRequest creates a new certificate request based on a template.
+// The following members of template are used: Subject, Attributes,
+// SignatureAlgorithm, Extensions, DNSNames, EmailAddresses, and IPAddresses.
+// The private key is the private key of the signer.
+//
+// The returned slice is the certificate request in DER encoding.
+//
+// All keys types that are implemented via crypto.Signer are supported (This
+// includes *rsa.PublicKey and *ecdsa.PublicKey.)
+func CreateCertificateRequest(rand io.Reader, template *CertificateRequest, signer crypto.Signer) (csr []byte, err error) {
+	var hashFunc Hash
+	var sigAlgo pkix.AlgorithmIdentifier
+	hashFunc, sigAlgo, err = signingParamsForPublicKey(signer.Public(), template.SignatureAlgorithm)
+	if err != nil {
+		return nil, err
+	}
+
+	var publicKeyBytes []byte
+	var publicKeyAlgorithm pkix.AlgorithmIdentifier
+	publicKeyBytes, publicKeyAlgorithm, err = marshalPublicKey(signer.Public())
+	if err != nil {
+		return nil, err
+	}
+
+	var extensions []pkix.Extension
+
+	if (len(template.DNSNames) > 0 || len(template.EmailAddresses) > 0 || len(template.IPAddresses) > 0) &&
+		!oidInExtensions(oidExtensionSubjectAltName, template.ExtraExtensions) {
+		sanBytes, err := marshalSANs(template.DNSNames, template.EmailAddresses, template.IPAddresses)
+		if err != nil {
+			return nil, err
+		}
+
+		extensions = append(extensions, pkix.Extension{
+			Id:    oidExtensionSubjectAltName,
+			Value: sanBytes,
+		})
+	}
+
+	extensions = append(extensions, template.ExtraExtensions...)
+
+	var attributes []pkix.AttributeTypeAndValueSET
+	attributes = append(attributes, template.Attributes...)
+
+	if len(extensions) > 0 {
+		// specifiedExtensions contains all the extensions that we
+		// found specified via template.Attributes.
+		specifiedExtensions := make(map[string]bool)
+
+		for _, atvSet := range template.Attributes {
+			if !atvSet.Type.Equal(oidExtensionRequest) {
+				continue
+			}
+
+			for _, atvs := range atvSet.Value {
+				for _, atv := range atvs {
+					specifiedExtensions[atv.Type.String()] = true
+				}
+			}
+		}
+
+		atvs := make([]pkix.AttributeTypeAndValue, 0, len(extensions))
+		for _, e := range extensions {
+			if specifiedExtensions[e.Id.String()] {
+				// Attributes already contained a value for
+				// this extension and it takes priority.
+				continue
+			}
+
+			atvs = append(atvs, pkix.AttributeTypeAndValue{
+				// There is no place for the critical flag in a CSR.
+				Type:  e.Id,
+				Value: e.Value,
+			})
+		}
+
+		// Append the extensions to an existing attribute if possible.
+		appended := false
+		for _, atvSet := range attributes {
+			if !atvSet.Type.Equal(oidExtensionRequest) || len(atvSet.Value) == 0 {
+				continue
+			}
+
+			atvSet.Value[0] = append(atvSet.Value[0], atvs...)
+			appended = true
+			break
+		}
+
+		// Otherwise, add a new attribute for the extensions.
+		if !appended {
+			attributes = append(attributes, pkix.AttributeTypeAndValueSET{
+				Type: oidExtensionRequest,
+				Value: [][]pkix.AttributeTypeAndValue{
+					atvs,
+				},
+			})
+		}
+	}
+
+	asn1Subject := template.RawSubject
+	if len(asn1Subject) == 0 {
+		asn1Subject, err = asn1.Marshal(template.Subject.ToRDNSequence())
+		if err != nil {
+			return
+		}
+	}
+
+	rawAttributes, err := newRawAttributes(attributes)
+	if err != nil {
+		return
+	}
+
+	tbsCSR := tbsCertificateRequest{
+		Version: 0, // PKCS #10, RFC 2986
+		Subject: asn1.RawValue{FullBytes: asn1Subject},
+		PublicKey: publicKeyInfo{
+			Algorithm: publicKeyAlgorithm,
+			PublicKey: asn1.BitString{
+				Bytes:     publicKeyBytes,
+				BitLength: len(publicKeyBytes) * 8,
+			},
+		},
+		RawAttributes: rawAttributes,
+	}
+
+	tbsCSRContents, err := asn1.Marshal(tbsCSR)
+	if err != nil {
+		return
+	}
+	tbsCSR.Raw = tbsCSRContents
+
+	digest := tbsCSRContents
+	switch template.SignatureAlgorithm {
+	case SM2WithSM3, SM2WithSHA1, SM2WithSHA256, UnknownSignatureAlgorithm:
+		break
+	default:
+		h := hashFunc.New()
+		h.Write(tbsCSRContents)
+		digest = h.Sum(nil)
+	}
+
+	var signature []byte
+	signature, err = signer.Sign(rand, digest, hashFunc)
+	if err != nil {
+		return
+	}
+
+	return asn1.Marshal(certificateRequest{
+		TBSCSR:             tbsCSR,
+		SignatureAlgorithm: sigAlgo,
+		SignatureValue: asn1.BitString{
+			Bytes:     signature,
+			BitLength: len(signature) * 8,
+		},
+	})
+}
+
+// ParseCertificateRequest parses a single certificate request from the
+// given ASN.1 DER data.
+func ParseCertificateRequest(asn1Data []byte) (*CertificateRequest, error) {
+	var csr certificateRequest
+
+	rest, err := asn1.Unmarshal(asn1Data, &csr)
+	if err != nil {
+		return nil, err
+	} else if len(rest) != 0 {
+		return nil, asn1.SyntaxError{Msg: "trailing data"}
+	}
+
+	return parseCertificateRequest(&csr)
+}
+
+func parseCertificateRequest(in *certificateRequest) (*CertificateRequest, error) {
+	out := &CertificateRequest{
+		Raw:                      in.Raw,
+		RawTBSCertificateRequest: in.TBSCSR.Raw,
+		RawSubjectPublicKeyInfo:  in.TBSCSR.PublicKey.Raw,
+		RawSubject:               in.TBSCSR.Subject.FullBytes,
+
+		Signature:          in.SignatureValue.RightAlign(),
+		SignatureAlgorithm: getSignatureAlgorithmFromAI(in.SignatureAlgorithm),
+
+		PublicKeyAlgorithm: getPublicKeyAlgorithmFromOID(in.TBSCSR.PublicKey.Algorithm.Algorithm),
+
+		Version:    in.TBSCSR.Version,
+		Attributes: parseRawAttributes(in.TBSCSR.RawAttributes),
+	}
+
+	var err error
+	out.PublicKey, err = parsePublicKey(out.PublicKeyAlgorithm, &in.TBSCSR.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var subject pkix.RDNSequence
+	if rest, err := asn1.Unmarshal(in.TBSCSR.Subject.FullBytes, &subject); err != nil {
+		return nil, err
+	} else if len(rest) != 0 {
+		return nil, errors.New("x509: trailing data after X.509 Subject")
+	}
+
+	out.Subject.FillFromRDNSequence(&subject)
+
+	if out.Extensions, err = parseCSRExtensions(in.TBSCSR.RawAttributes); err != nil {
+		return nil, err
+	}
+
+	for _, extension := range out.Extensions {
+		if extension.Id.Equal(oidExtensionSubjectAltName) {
+			out.DNSNames, out.EmailAddresses, out.IPAddresses, err = parseSANExtension(extension.Value)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// CheckSignature reports whether the signature on c is valid.
+func (c *CertificateRequest) CheckSignature() error {
+	return checkSignature(c.SignatureAlgorithm, c.RawTBSCertificateRequest, c.Signature, c.PublicKey)
+}
+
+func (c *Certificate) ToX509Certificate() *x509.Certificate {
+	x509cert := &x509.Certificate{
+		Raw:                     c.Raw,
+		RawTBSCertificate:       c.RawTBSCertificate,
+		RawSubjectPublicKeyInfo: c.RawSubjectPublicKeyInfo,
+		RawSubject:              c.RawSubject,
+		RawIssuer:               c.RawIssuer,
+
+		Signature:          c.Signature,
+		SignatureAlgorithm: x509.SignatureAlgorithm(c.SignatureAlgorithm),
+
+		PublicKeyAlgorithm: x509.PublicKeyAlgorithm(c.PublicKeyAlgorithm),
+		PublicKey:          c.PublicKey,
+
+		Version:      c.Version,
+		SerialNumber: c.SerialNumber,
+		Issuer:       c.Issuer,
+		Subject:      c.Subject,
+		NotBefore:    c.NotBefore,
+		NotAfter:     c.NotAfter,
+		KeyUsage:     x509.KeyUsage(c.KeyUsage),
+
+		Extensions: c.Extensions,
+
+		ExtraExtensions: c.ExtraExtensions,
+
+		UnhandledCriticalExtensions: c.UnhandledCriticalExtensions,
+
+		//ExtKeyUsage:	[]x509.ExtKeyUsage(c.ExtKeyUsage) ,
+		UnknownExtKeyUsage: c.UnknownExtKeyUsage,
+
+		BasicConstraintsValid: c.BasicConstraintsValid,
+		IsCA:                  c.IsCA,
+		MaxPathLen:            c.MaxPathLen,
+		// MaxPathLenZero indicates that BasicConstraintsValid==true and
+		// MaxPathLen==0 should be interpreted as an actual maximum path length
+		// of zero. Otherwise, that combination is interpreted as MaxPathLen
+		// not being set.
+		MaxPathLenZero: c.MaxPathLenZero,
+
+		SubjectKeyId:   c.SubjectKeyId,
+		AuthorityKeyId: c.AuthorityKeyId,
+
+		// RFC 5280, 4.2.2.1 (Authority Information Access)
+		OCSPServer:            c.OCSPServer,
+		IssuingCertificateURL: c.IssuingCertificateURL,
+
+		// Subject Alternate Name values
+		DNSNames:       c.DNSNames,
+		EmailAddresses: c.EmailAddresses,
+		IPAddresses:    c.IPAddresses,
+
+		// Name constraints
+		PermittedDNSDomainsCritical: c.PermittedDNSDomainsCritical,
+		PermittedDNSDomains:         c.PermittedDNSDomains,
+
+		// CRL Distribution Points
+		CRLDistributionPoints: c.CRLDistributionPoints,
+
+		PolicyIdentifiers: c.PolicyIdentifiers,
+	}
+
+	for _, val := range c.ExtKeyUsage {
+		x509cert.ExtKeyUsage = append(x509cert.ExtKeyUsage, x509.ExtKeyUsage(val))
+	}
+
+	return x509cert
+}
+
+func (c *Certificate) FromX509Certificate(x509Cert *x509.Certificate) {
+	c.Raw = x509Cert.Raw
+	c.RawTBSCertificate = x509Cert.RawTBSCertificate
+	c.RawSubjectPublicKeyInfo = x509Cert.RawSubjectPublicKeyInfo
+	c.RawSubject = x509Cert.RawSubject
+	c.RawIssuer = x509Cert.RawIssuer
+	c.Signature = x509Cert.Signature
+	c.SignatureAlgorithm = SM2WithSM3
+	c.PublicKeyAlgorithm = PublicKeyAlgorithm(x509Cert.PublicKeyAlgorithm)
+	c.PublicKey = x509Cert.PublicKey
+	c.Version = x509Cert.Version
+	c.SerialNumber = x509Cert.SerialNumber
+	c.Issuer = x509Cert.Issuer
+	c.Subject = x509Cert.Subject
+	c.NotBefore = x509Cert.NotBefore
+	c.NotAfter = x509Cert.NotAfter
+	c.KeyUsage = KeyUsage(x509Cert.KeyUsage)
+	c.Extensions = x509Cert.Extensions
+	c.ExtraExtensions = x509Cert.ExtraExtensions
+	c.UnhandledCriticalExtensions = x509Cert.UnhandledCriticalExtensions
+	c.UnknownExtKeyUsage = x509Cert.UnknownExtKeyUsage
+	c.BasicConstraintsValid = x509Cert.BasicConstraintsValid
+	c.IsCA = x509Cert.IsCA
+	c.MaxPathLen = x509Cert.MaxPathLen
+	c.MaxPathLenZero = x509Cert.MaxPathLenZero
+	c.SubjectKeyId = x509Cert.SubjectKeyId
+	c.AuthorityKeyId = x509Cert.AuthorityKeyId
+	c.OCSPServer = x509Cert.OCSPServer
+	c.IssuingCertificateURL = x509Cert.IssuingCertificateURL
+	c.DNSNames = x509Cert.DNSNames
+	c.EmailAddresses = x509Cert.EmailAddresses
+	c.IPAddresses = x509Cert.IPAddresses
+	c.PermittedDNSDomainsCritical = x509Cert.PermittedDNSDomainsCritical
+	c.PermittedDNSDomains = x509Cert.PermittedDNSDomains
+	c.CRLDistributionPoints = x509Cert.CRLDistributionPoints
+	c.PolicyIdentifiers = x509Cert.PolicyIdentifiers
+
+	for _, val := range x509Cert.ExtKeyUsage {
+		c.ExtKeyUsage = append(c.ExtKeyUsage, ExtKeyUsage(val))
+	}
+}

--- a/vendor/golang.org/x/crypto/ripemd160/ripemd160.go
+++ b/vendor/golang.org/x/crypto/ripemd160/ripemd160.go
@@ -1,0 +1,124 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package ripemd160 implements the RIPEMD-160 hash algorithm.
+//
+// Deprecated: RIPEMD-160 is a legacy hash and should not be used for new
+// applications. Also, this package does not and will not provide an optimized
+// implementation. Instead, use a modern hash like SHA-256 (from crypto/sha256).
+package ripemd160 // import "golang.org/x/crypto/ripemd160"
+
+// RIPEMD-160 is designed by Hans Dobbertin, Antoon Bosselaers, and Bart
+// Preneel with specifications available at:
+// http://homes.esat.kuleuven.be/~cosicart/pdf/AB-9601/AB-9601.pdf.
+
+import (
+	"crypto"
+	"hash"
+)
+
+func init() {
+	crypto.RegisterHash(crypto.RIPEMD160, New)
+}
+
+// The size of the checksum in bytes.
+const Size = 20
+
+// The block size of the hash algorithm in bytes.
+const BlockSize = 64
+
+const (
+	_s0 = 0x67452301
+	_s1 = 0xefcdab89
+	_s2 = 0x98badcfe
+	_s3 = 0x10325476
+	_s4 = 0xc3d2e1f0
+)
+
+// digest represents the partial evaluation of a checksum.
+type digest struct {
+	s  [5]uint32       // running context
+	x  [BlockSize]byte // temporary buffer
+	nx int             // index into x
+	tc uint64          // total count of bytes processed
+}
+
+func (d *digest) Reset() {
+	d.s[0], d.s[1], d.s[2], d.s[3], d.s[4] = _s0, _s1, _s2, _s3, _s4
+	d.nx = 0
+	d.tc = 0
+}
+
+// New returns a new hash.Hash computing the checksum.
+func New() hash.Hash {
+	result := new(digest)
+	result.Reset()
+	return result
+}
+
+func (d *digest) Size() int { return Size }
+
+func (d *digest) BlockSize() int { return BlockSize }
+
+func (d *digest) Write(p []byte) (nn int, err error) {
+	nn = len(p)
+	d.tc += uint64(nn)
+	if d.nx > 0 {
+		n := len(p)
+		if n > BlockSize-d.nx {
+			n = BlockSize - d.nx
+		}
+		for i := 0; i < n; i++ {
+			d.x[d.nx+i] = p[i]
+		}
+		d.nx += n
+		if d.nx == BlockSize {
+			_Block(d, d.x[0:])
+			d.nx = 0
+		}
+		p = p[n:]
+	}
+	n := _Block(d, p)
+	p = p[n:]
+	if len(p) > 0 {
+		d.nx = copy(d.x[:], p)
+	}
+	return
+}
+
+func (d0 *digest) Sum(in []byte) []byte {
+	// Make a copy of d0 so that caller can keep writing and summing.
+	d := *d0
+
+	// Padding.  Add a 1 bit and 0 bits until 56 bytes mod 64.
+	tc := d.tc
+	var tmp [64]byte
+	tmp[0] = 0x80
+	if tc%64 < 56 {
+		d.Write(tmp[0 : 56-tc%64])
+	} else {
+		d.Write(tmp[0 : 64+56-tc%64])
+	}
+
+	// Length in bits.
+	tc <<= 3
+	for i := uint(0); i < 8; i++ {
+		tmp[i] = byte(tc >> (8 * i))
+	}
+	d.Write(tmp[0:8])
+
+	if d.nx != 0 {
+		panic("d.nx != 0")
+	}
+
+	var digest [Size]byte
+	for i, s := range d.s {
+		digest[i*4] = byte(s)
+		digest[i*4+1] = byte(s >> 8)
+		digest[i*4+2] = byte(s >> 16)
+		digest[i*4+3] = byte(s >> 24)
+	}
+
+	return append(in, digest[:]...)
+}

--- a/vendor/golang.org/x/crypto/ripemd160/ripemd160block.go
+++ b/vendor/golang.org/x/crypto/ripemd160/ripemd160block.go
@@ -1,0 +1,165 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// RIPEMD-160 block step.
+// In its own file so that a faster assembly or C version
+// can be substituted easily.
+
+package ripemd160
+
+import (
+	"math/bits"
+)
+
+// work buffer indices and roll amounts for one line
+var _n = [80]uint{
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+	7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8,
+	3, 10, 14, 4, 9, 15, 8, 1, 2, 7, 0, 6, 13, 11, 5, 12,
+	1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7, 15, 14, 5, 6, 2,
+	4, 0, 5, 9, 7, 12, 2, 10, 14, 1, 3, 8, 11, 6, 15, 13,
+}
+
+var _r = [80]uint{
+	11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8,
+	7, 6, 8, 13, 11, 9, 7, 15, 7, 12, 15, 9, 11, 7, 13, 12,
+	11, 13, 6, 7, 14, 9, 13, 15, 14, 8, 13, 6, 5, 12, 7, 5,
+	11, 12, 14, 15, 14, 15, 9, 8, 9, 14, 5, 6, 8, 6, 5, 12,
+	9, 15, 5, 11, 6, 8, 13, 12, 5, 12, 13, 14, 11, 8, 5, 6,
+}
+
+// same for the other parallel one
+var n_ = [80]uint{
+	5, 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12,
+	6, 11, 3, 7, 0, 13, 5, 10, 14, 15, 8, 12, 4, 9, 1, 2,
+	15, 5, 1, 3, 7, 14, 6, 9, 11, 8, 12, 2, 10, 0, 4, 13,
+	8, 6, 4, 1, 3, 11, 15, 0, 5, 12, 2, 13, 9, 7, 10, 14,
+	12, 15, 10, 4, 1, 5, 8, 7, 6, 2, 13, 14, 0, 3, 9, 11,
+}
+
+var r_ = [80]uint{
+	8, 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6,
+	9, 13, 15, 7, 12, 8, 9, 11, 7, 7, 12, 7, 6, 15, 13, 11,
+	9, 7, 15, 11, 8, 6, 6, 14, 12, 13, 5, 14, 13, 13, 7, 5,
+	15, 5, 8, 11, 14, 14, 6, 14, 6, 9, 12, 9, 12, 5, 15, 8,
+	8, 5, 12, 9, 12, 5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11,
+}
+
+func _Block(md *digest, p []byte) int {
+	n := 0
+	var x [16]uint32
+	var alpha, beta uint32
+	for len(p) >= BlockSize {
+		a, b, c, d, e := md.s[0], md.s[1], md.s[2], md.s[3], md.s[4]
+		aa, bb, cc, dd, ee := a, b, c, d, e
+		j := 0
+		for i := 0; i < 16; i++ {
+			x[i] = uint32(p[j]) | uint32(p[j+1])<<8 | uint32(p[j+2])<<16 | uint32(p[j+3])<<24
+			j += 4
+		}
+
+		// round 1
+		i := 0
+		for i < 16 {
+			alpha = a + (b ^ c ^ d) + x[_n[i]]
+			s := int(_r[i])
+			alpha = bits.RotateLeft32(alpha, s) + e
+			beta = bits.RotateLeft32(c, 10)
+			a, b, c, d, e = e, alpha, b, beta, d
+
+			// parallel line
+			alpha = aa + (bb ^ (cc | ^dd)) + x[n_[i]] + 0x50a28be6
+			s = int(r_[i])
+			alpha = bits.RotateLeft32(alpha, s) + ee
+			beta = bits.RotateLeft32(cc, 10)
+			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
+
+			i++
+		}
+
+		// round 2
+		for i < 32 {
+			alpha = a + (b&c | ^b&d) + x[_n[i]] + 0x5a827999
+			s := int(_r[i])
+			alpha = bits.RotateLeft32(alpha, s) + e
+			beta = bits.RotateLeft32(c, 10)
+			a, b, c, d, e = e, alpha, b, beta, d
+
+			// parallel line
+			alpha = aa + (bb&dd | cc&^dd) + x[n_[i]] + 0x5c4dd124
+			s = int(r_[i])
+			alpha = bits.RotateLeft32(alpha, s) + ee
+			beta = bits.RotateLeft32(cc, 10)
+			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
+
+			i++
+		}
+
+		// round 3
+		for i < 48 {
+			alpha = a + (b | ^c ^ d) + x[_n[i]] + 0x6ed9eba1
+			s := int(_r[i])
+			alpha = bits.RotateLeft32(alpha, s) + e
+			beta = bits.RotateLeft32(c, 10)
+			a, b, c, d, e = e, alpha, b, beta, d
+
+			// parallel line
+			alpha = aa + (bb | ^cc ^ dd) + x[n_[i]] + 0x6d703ef3
+			s = int(r_[i])
+			alpha = bits.RotateLeft32(alpha, s) + ee
+			beta = bits.RotateLeft32(cc, 10)
+			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
+
+			i++
+		}
+
+		// round 4
+		for i < 64 {
+			alpha = a + (b&d | c&^d) + x[_n[i]] + 0x8f1bbcdc
+			s := int(_r[i])
+			alpha = bits.RotateLeft32(alpha, s) + e
+			beta = bits.RotateLeft32(c, 10)
+			a, b, c, d, e = e, alpha, b, beta, d
+
+			// parallel line
+			alpha = aa + (bb&cc | ^bb&dd) + x[n_[i]] + 0x7a6d76e9
+			s = int(r_[i])
+			alpha = bits.RotateLeft32(alpha, s) + ee
+			beta = bits.RotateLeft32(cc, 10)
+			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
+
+			i++
+		}
+
+		// round 5
+		for i < 80 {
+			alpha = a + (b ^ (c | ^d)) + x[_n[i]] + 0xa953fd4e
+			s := int(_r[i])
+			alpha = bits.RotateLeft32(alpha, s) + e
+			beta = bits.RotateLeft32(c, 10)
+			a, b, c, d, e = e, alpha, b, beta, d
+
+			// parallel line
+			alpha = aa + (bb ^ cc ^ dd) + x[n_[i]]
+			s = int(r_[i])
+			alpha = bits.RotateLeft32(alpha, s) + ee
+			beta = bits.RotateLeft32(cc, 10)
+			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
+
+			i++
+		}
+
+		// combine results
+		dd += c + md.s[1]
+		md.s[1] = md.s[2] + d + ee
+		md.s[2] = md.s[3] + e + aa
+		md.s[3] = md.s[4] + a + bb
+		md.s[4] = md.s[0] + b + cc
+		md.s[0] = dd
+
+		p = p[BlockSize:]
+		n += BlockSize
+	}
+	return n
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -422,8 +422,11 @@ github.com/swaggo/files
 ## explicit
 github.com/swaggo/swag
 github.com/swaggo/swag/gen
-# github.com/tjfoc/gmsm v1.3.2
+# github.com/tjfoc/gmsm v1.4.1
+## explicit
+github.com/tjfoc/gmsm/sm2
 github.com/tjfoc/gmsm/sm3
+github.com/tjfoc/gmsm/x509
 # github.com/ungerik/go-dry v0.0.0-20210209114055-a3e162a9e62e
 ## explicit
 github.com/ungerik/go-dry
@@ -461,6 +464,7 @@ golang.org/x/crypto/acme
 golang.org/x/crypto/acme/autocert
 golang.org/x/crypto/md4
 golang.org/x/crypto/pbkdf2
+golang.org/x/crypto/ripemd160
 golang.org/x/crypto/sha3
 # golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 golang.org/x/mod/internal/lazyregexp


### PR DESCRIPTION
## 关联的 issue

https://github.com/actiontech/sqle-ee/issues/3062

## 描述你的变更

- 登录默认启用 SM2 加密（required，零配置可自动生成密钥）
- `/v1|/v2/login` 支持密文字段并拒绝明文；新增 `/v1/login/encryption` 公钥接口
- 同步 CE 对等实现到 `release-2.2306.x`（与客户基线架构匹配）

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------

Made with [Cursor](https://cursor.com)